### PR TITLE
chore(view): import types from analysis-engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31220,6 +31220,7 @@
             "devDependencies": {
                 "@babel/core": "^7.18.10",
                 "@babel/runtime": "^7.18.9",
+                "@githru-vscode-ext/analysis-engine": "^0.1.0",
                 "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
                 "@types/d3": "^7.4.0",
                 "@types/jest": "^28.1.7",
@@ -33118,6 +33119,7 @@
             "requires": {
                 "@babel/core": "^7.18.10",
                 "@babel/runtime": "^7.18.9",
+                "@githru-vscode-ext/analysis-engine": "^0.1.0",
                 "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
                 "@testing-library/jest-dom": "^5.16.4",
                 "@testing-library/react": "^13.3.0",
@@ -33257,7 +33259,7 @@
         "@githru-vscode-ext/vscode": {
             "version": "file:packages/vscode",
             "requires": {
-                "@githru-vscode-ext/analysis-engine": "*",
+                "@githru-vscode-ext/analysis-engine": "^0.1.0",
                 "@types/copy-webpack-plugin": "^10.1.0",
                 "@types/glob": "^7.2.0",
                 "@types/mocha": "^9.1.1",

--- a/packages/view/package.json
+++ b/packages/view/package.json
@@ -42,6 +42,7 @@
     ]
   },
   "devDependencies": {
+    "@githru-vscode-ext/analysis-engine": "^0.1.0",
     "@babel/core": "^7.18.10",
     "@babel/runtime": "^7.18.9",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",

--- a/packages/view/src/components/Statistics/Statistics.tsx
+++ b/packages/view/src/components/Statistics/Statistics.tsx
@@ -1,5 +1,24 @@
+import type { DifferenceStatistic } from "@githru-vscode-ext/analysis-engine/src/types/CommitRaw";
+
+const mockDifferenceStatistic: DifferenceStatistic = {
+  totalInsertionCount: 300,
+  totalDeletionCount: 100,
+  fileDictionary: {
+    "./a": {
+      insertionCount: 140,
+      deletionCount: 30,
+    },
+    "./b": {
+      insertionCount: 160,
+      deletionCount: 70,
+    },
+  },
+};
+
 const Statistics = () => {
-  return <div>Statistics</div>;
+  return (
+    <div>{mockDifferenceStatistic.fileDictionary["./a"].insertionCount}</div>
+  );
 };
 
 export default Statistics;

--- a/packages/vscode/src/webview-loader.ts
+++ b/packages/vscode/src/webview-loader.ts
@@ -7,6 +7,7 @@ export default class WebviewLoader {
     private fsPath: string;
     
     constructor(private readonly fileUri: vscode.Uri, private readonly extensionPath: string, content: string) {
+        console.log(content)
         const viewColumn = vscode.ViewColumn.One;
 
         this.fsPath = fileUri.fsPath;

--- a/packages/vscode/src/webview-loader.ts
+++ b/packages/vscode/src/webview-loader.ts
@@ -7,7 +7,7 @@ export default class WebviewLoader {
     private fsPath: string;
     
     constructor(private readonly fileUri: vscode.Uri, private readonly extensionPath: string, content: string) {
-        console.log(content)
+        console.log(content);
         const viewColumn = vscode.ViewColumn.One;
 
         this.fsPath = fileUri.fsPath;


### PR DESCRIPTION
### Contents
- analysis-engine의 types를 가져와 사용할 수 있도록 예제 코드 구성
- @hanseul-lee 님, 이미 작업해두신 부분이 많아서 conflict이 발생할 여지가 높다면 이 PR은 close 처리하고 참고사항으로만 하시면 될 것 같습니다.

### Remarks
- packages/analysis-engine/src/types에서 index.ts를 가지고 있어서 모든 파일들을 묶어서 export 처리할지는 논의가 필요할 것 같습니다.
  - 해당 논의 항목이 잔존하고 있어서 types하위를 전달해 주는 방식은 변경이 생길 수 있습니다.
- node_modules로 publish하는 경우는 dist하위에 자동으로 *.d.ts파일이 생성되도록 해두었으니 coupling으로 인해서 블로커가 된다면 publish하는 것을 고려해야 할 수도 있겠습니다.