### PR TITLE
setup: set react-hooks eslint rules

### DIFF
--- a/packages/view/.eslintrc.json
+++ b/packages/view/.eslintrc.json
@@ -8,6 +8,7 @@
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:prettier/recommended",
+    "plugin:react-hooks/recommended",
     "airbnb",
     "prettier"
   ],
@@ -16,7 +17,7 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "plugins": ["@typescript-eslint", "prettier"],
+  "plugins": ["@typescript-eslint", "prettier", "react-hooks"],
   "rules": {
     "@typescript-eslint/ban-types": "off",
     "@typescript-eslint/consistent-type-imports": ["error"],


### PR DESCRIPTION
react-hooks eslint rule이 빠진 듯 하여 올립니다.

'exhaustive-deps' rule같은 경우는 매우 쓸만한 놈이기도 해서 추가하였습니다.
혹시 view팀에서 hooks rule을 쓰지 말자라고 기존에 약속한게 있다면 살포시 "안써요~" 라고 답변 남겨주세요.