### PR TITLE
enhance(view):  Detail Component Contents

### DIFF
--- a/packages/view/public/fake-assets/sampleClusterNodeList.json
+++ b/packages/view/public/fake-assets/sampleClusterNodeList.json
@@ -6,24 +6,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "4f0044a51e4400ae99b76328405d0a62c7a09902",
-          "parentIds": [
-            "b14eddca910476f3406a05bb9be73629a20bc211"
-          ],
+          "parentIds": ["b14eddca910476f3406a05bb9be73629a20bc211"],
           "author": {
-            "names": [
-              "Brian Munkholm "
-            ],
-            "emails": [
-              "bmunkholm@users.noreply.github.com"
-            ]
+            "names": ["Brian Munkholm "],
+            "emails": ["bmunkholm@users.noreply.github.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2018-10-23T07:03:46.000Z",
           "commitDate": "2018-10-23T07:03:46.000Z",
@@ -42,7 +32,7 @@
         "implicitBranchNo": 2627,
         "seq": 15518,
         "isMergeCommit": false,
-        "taskId": 2433
+        "clusterId": 2433
       },
       {
         "nodeTypeName": "COMMIT",
@@ -53,20 +43,12 @@
             "4f0044a51e4400ae99b76328405d0a62c7a09902"
           ],
           "author": {
-            "names": [
-              "Brian Munkholm "
-            ],
-            "emails": [
-              "bmunkholm@users.noreply.github.com"
-            ]
+            "names": ["Brian Munkholm "],
+            "emails": ["bmunkholm@users.noreply.github.com"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-23T09:48:00.000Z",
           "commitDate": "2018-10-23T09:48:00.000Z",
@@ -85,7 +67,7 @@
         "implicitBranchNo": 0,
         "seq": 15519,
         "isMergeCommit": true,
-        "taskId": 2433
+        "clusterId": 2433
       }
     ]
   },
@@ -96,24 +78,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "2a7a93cde9c9f74d5f05c1d0fb1da8e96da7057b",
-          "parentIds": [
-            "7d8569355a24bf79c84c2970f88a62c20261c3f5"
-          ],
+          "parentIds": ["7d8569355a24bf79c84c2970f88a62c20261c3f5"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-09-13T07:30:42.000Z",
           "commitDate": "2018-09-13T07:30:42.000Z",
@@ -144,30 +116,20 @@
         "implicitBranchNo": 2596,
         "seq": 15369,
         "isMergeCommit": false,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "730a7504d03b0a8fe8ad73e1b4b80ef4b2ab24b1",
-          "parentIds": [
-            "2a7a93cde9c9f74d5f05c1d0fb1da8e96da7057b"
-          ],
+          "parentIds": ["2a7a93cde9c9f74d5f05c1d0fb1da8e96da7057b"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-12T18:22:57.000Z",
           "commitDate": "2018-10-12T18:22:57.000Z",
@@ -194,30 +156,20 @@
         "implicitBranchNo": 2596,
         "seq": 15480,
         "isMergeCommit": false,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "0e1a41c5e675525868e96ae22fb1e3dde2ecd4dc",
-          "parentIds": [
-            "730a7504d03b0a8fe8ad73e1b4b80ef4b2ab24b1"
-          ],
+          "parentIds": ["730a7504d03b0a8fe8ad73e1b4b80ef4b2ab24b1"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-12T18:51:59.000Z",
           "commitDate": "2018-10-12T18:51:59.000Z",
@@ -240,7 +192,7 @@
         "implicitBranchNo": 2596,
         "seq": 15481,
         "isMergeCommit": false,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
@@ -251,20 +203,12 @@
             "997cde4e83e7c6fffad18878c813f556f324fa8c"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-12T18:52:19.000Z",
           "commitDate": "2018-10-12T18:52:19.000Z",
@@ -827,30 +771,20 @@
         "implicitBranchNo": 2596,
         "seq": 15482,
         "isMergeCommit": true,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "87413b86399dfb933ce415a6c5532dfdf48e52ec",
-          "parentIds": [
-            "02b1b675657a0c32e209a9c1402fe815d72a6167"
-          ],
+          "parentIds": ["02b1b675657a0c32e209a9c1402fe815d72a6167"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-12T21:16:01.000Z",
           "commitDate": "2018-10-12T21:16:01.000Z",
@@ -885,30 +819,20 @@
         "implicitBranchNo": 2596,
         "seq": 15483,
         "isMergeCommit": false,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "be99baab618b7ac36c219829591ed0471da4d859",
-          "parentIds": [
-            "87413b86399dfb933ce415a6c5532dfdf48e52ec"
-          ],
+          "parentIds": ["87413b86399dfb933ce415a6c5532dfdf48e52ec"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-12T21:21:36.000Z",
           "commitDate": "2018-10-12T21:21:36.000Z",
@@ -927,30 +851,20 @@
         "implicitBranchNo": 2596,
         "seq": 15484,
         "isMergeCommit": false,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "9d9eeaeb0ceb71ebce540f2263d37527600cdba1",
-          "parentIds": [
-            "be99baab618b7ac36c219829591ed0471da4d859"
-          ],
+          "parentIds": ["be99baab618b7ac36c219829591ed0471da4d859"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-13T08:51:55.000Z",
           "commitDate": "2018-10-13T08:51:55.000Z",
@@ -981,30 +895,20 @@
         "implicitBranchNo": 2596,
         "seq": 15485,
         "isMergeCommit": false,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "76066ab8846cfab085a0d640ce3eb189b638f4f0",
-          "parentIds": [
-            "9d9eeaeb0ceb71ebce540f2263d37527600cdba1"
-          ],
+          "parentIds": ["9d9eeaeb0ceb71ebce540f2263d37527600cdba1"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-13T09:47:30.000Z",
           "commitDate": "2018-10-13T09:47:30.000Z",
@@ -1031,30 +935,20 @@
         "implicitBranchNo": 2596,
         "seq": 15486,
         "isMergeCommit": false,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "a3c1e94cef8d0c6b13edf9792faf7ae32532d877",
-          "parentIds": [
-            "76066ab8846cfab085a0d640ce3eb189b638f4f0"
-          ],
+          "parentIds": ["76066ab8846cfab085a0d640ce3eb189b638f4f0"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-13T23:28:38.000Z",
           "commitDate": "2018-10-13T23:28:38.000Z",
@@ -1089,30 +983,20 @@
         "implicitBranchNo": 2596,
         "seq": 15487,
         "isMergeCommit": false,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "43767a9370926bb85ee7fb49eee61f7fd16ff57b",
-          "parentIds": [
-            "a3c1e94cef8d0c6b13edf9792faf7ae32532d877"
-          ],
+          "parentIds": ["a3c1e94cef8d0c6b13edf9792faf7ae32532d877"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-13T23:36:39.000Z",
           "commitDate": "2018-10-13T23:36:39.000Z",
@@ -1131,30 +1015,20 @@
         "implicitBranchNo": 2596,
         "seq": 15488,
         "isMergeCommit": false,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "99a24f4a6ac352f60f2d949addc9b52459d6a5d1",
-          "parentIds": [
-            "43767a9370926bb85ee7fb49eee61f7fd16ff57b"
-          ],
+          "parentIds": ["43767a9370926bb85ee7fb49eee61f7fd16ff57b"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-14T13:34:55.000Z",
           "commitDate": "2018-10-14T13:34:55.000Z",
@@ -1209,30 +1083,20 @@
         "implicitBranchNo": 2596,
         "seq": 15489,
         "isMergeCommit": false,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "16cf0ab13a2950e44d81e834726425ef58206a9b",
-          "parentIds": [
-            "99a24f4a6ac352f60f2d949addc9b52459d6a5d1"
-          ],
+          "parentIds": ["99a24f4a6ac352f60f2d949addc9b52459d6a5d1"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-15T07:32:09.000Z",
           "commitDate": "2018-10-15T07:32:09.000Z",
@@ -1251,30 +1115,20 @@
         "implicitBranchNo": 2596,
         "seq": 15491,
         "isMergeCommit": false,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "41b50bc06c558e0cd5119a0f1f6ddfa1b83dbde6",
-          "parentIds": [
-            "16cf0ab13a2950e44d81e834726425ef58206a9b"
-          ],
+          "parentIds": ["16cf0ab13a2950e44d81e834726425ef58206a9b"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-15T08:07:25.000Z",
           "commitDate": "2018-10-15T08:07:25.000Z",
@@ -1293,30 +1147,20 @@
         "implicitBranchNo": 2596,
         "seq": 15492,
         "isMergeCommit": false,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "381d989bd3c0e82633fa6ba42a3109f760f2623c",
-          "parentIds": [
-            "41b50bc06c558e0cd5119a0f1f6ddfa1b83dbde6"
-          ],
+          "parentIds": ["41b50bc06c558e0cd5119a0f1f6ddfa1b83dbde6"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-15T08:41:35.000Z",
           "commitDate": "2018-10-15T08:41:35.000Z",
@@ -1339,30 +1183,20 @@
         "implicitBranchNo": 2596,
         "seq": 15493,
         "isMergeCommit": false,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "0c41625a9a0b21acb45e04012f61d488a2f14c6c",
-          "parentIds": [
-            "381d989bd3c0e82633fa6ba42a3109f760f2623c"
-          ],
+          "parentIds": ["381d989bd3c0e82633fa6ba42a3109f760f2623c"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-15T18:49:14.000Z",
           "commitDate": "2018-10-15T18:49:14.000Z",
@@ -1385,30 +1219,20 @@
         "implicitBranchNo": 2596,
         "seq": 15494,
         "isMergeCommit": false,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "fe37952309545c5ad21f6a75cad960afc8375a2e",
-          "parentIds": [
-            "0c41625a9a0b21acb45e04012f61d488a2f14c6c"
-          ],
+          "parentIds": ["0c41625a9a0b21acb45e04012f61d488a2f14c6c"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-17T12:47:03.000Z",
           "commitDate": "2018-10-17T12:47:03.000Z",
@@ -1431,30 +1255,20 @@
         "implicitBranchNo": 2596,
         "seq": 15502,
         "isMergeCommit": false,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "025e3a2f6c431cef0a85eeb6d55cb91d86563241",
-          "parentIds": [
-            "fe37952309545c5ad21f6a75cad960afc8375a2e"
-          ],
+          "parentIds": ["fe37952309545c5ad21f6a75cad960afc8375a2e"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-17T15:23:40.000Z",
           "commitDate": "2018-10-17T15:23:40.000Z",
@@ -1473,30 +1287,20 @@
         "implicitBranchNo": 2596,
         "seq": 15503,
         "isMergeCommit": false,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "322e1b4cb49a5779cbc1880ab46c2473a88d7ffc",
-          "parentIds": [
-            "025e3a2f6c431cef0a85eeb6d55cb91d86563241"
-          ],
+          "parentIds": ["025e3a2f6c431cef0a85eeb6d55cb91d86563241"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-22T12:24:28.000Z",
           "commitDate": "2018-10-22T12:24:28.000Z",
@@ -1523,7 +1327,7 @@
         "implicitBranchNo": 2596,
         "seq": 15511,
         "isMergeCommit": false,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
@@ -1534,20 +1338,12 @@
             "068ac09cbeb4537a7ad6022c6deccdcc67d4b5b1"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-23T10:11:13.000Z",
           "commitDate": "2018-10-23T10:11:13.000Z",
@@ -1582,30 +1378,20 @@
         "implicitBranchNo": 2596,
         "seq": 15520,
         "isMergeCommit": true,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "5f0b95ef1091dabc7cf5c406d232c6662f71aa8c",
-          "parentIds": [
-            "5a1a4b5b13ee9f08cae8c0be8cf94db04eb5011b"
-          ],
+          "parentIds": ["5a1a4b5b13ee9f08cae8c0be8cf94db04eb5011b"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-23T11:43:44.000Z",
           "commitDate": "2018-10-23T11:43:44.000Z",
@@ -1644,30 +1430,20 @@
         "implicitBranchNo": 2629,
         "seq": 15521,
         "isMergeCommit": false,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "e4fa7d28022a62c48b4ef88fb3d5ed21d7ed36e9",
-          "parentIds": [
-            "5a1a4b5b13ee9f08cae8c0be8cf94db04eb5011b"
-          ],
+          "parentIds": ["5a1a4b5b13ee9f08cae8c0be8cf94db04eb5011b"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-23T11:43:44.000Z",
           "commitDate": "2018-10-23T14:13:31.000Z",
@@ -1710,7 +1486,7 @@
         "implicitBranchNo": 2596,
         "seq": 15525,
         "isMergeCommit": false,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
@@ -1721,20 +1497,12 @@
             "5f0b95ef1091dabc7cf5c406d232c6662f71aa8c"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-23T14:14:35.000Z",
           "commitDate": "2018-10-23T14:14:35.000Z",
@@ -1748,30 +1516,20 @@
         "implicitBranchNo": 2596,
         "seq": 15526,
         "isMergeCommit": true,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "dc1ff5bc9292bbfea816b7a77e554c2728478756",
-          "parentIds": [
-            "b2ad37011c101e08d5b356a40523c5deeaebaf43"
-          ],
+          "parentIds": ["b2ad37011c101e08d5b356a40523c5deeaebaf43"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-23T15:12:17.000Z",
           "commitDate": "2018-10-26T16:48:55.000Z",
@@ -1866,7 +1624,7 @@
         "implicitBranchNo": 2596,
         "seq": 15532,
         "isMergeCommit": false,
-        "taskId": 2434
+        "clusterId": 2434
       },
       {
         "nodeTypeName": "COMMIT",
@@ -1877,20 +1635,12 @@
             "dc1ff5bc9292bbfea816b7a77e554c2728478756"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2018-10-26T17:14:49.000Z",
           "commitDate": "2018-10-26T17:14:49.000Z",
@@ -2049,7 +1799,7 @@
         "implicitBranchNo": 0,
         "seq": 15533,
         "isMergeCommit": true,
-        "taskId": 2434
+        "clusterId": 2434
       }
     ]
   },
@@ -2060,24 +1810,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "ff84b6031222610dc2a1fca11e76182e89a95063",
-          "parentIds": [
-            "f3cab430237b4097aba21e9eb032a81d85febf2d"
-          ],
+          "parentIds": ["f3cab430237b4097aba21e9eb032a81d85febf2d"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-05T22:54:03.000Z",
           "commitDate": "2018-10-05T22:54:03.000Z",
@@ -2136,30 +1876,20 @@
         "implicitBranchNo": 2624,
         "seq": 15436,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "fbc99b276fecd9944f1b4fa9aeadf705096049bc",
-          "parentIds": [
-            "ff84b6031222610dc2a1fca11e76182e89a95063"
-          ],
+          "parentIds": ["ff84b6031222610dc2a1fca11e76182e89a95063"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-07T22:14:15.000Z",
           "commitDate": "2018-10-07T22:14:15.000Z",
@@ -2214,30 +1944,20 @@
         "implicitBranchNo": 2624,
         "seq": 15437,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "f1014d7885893d07e1d25d3a853c595a52ed3314",
-          "parentIds": [
-            "fbc99b276fecd9944f1b4fa9aeadf705096049bc"
-          ],
+          "parentIds": ["fbc99b276fecd9944f1b4fa9aeadf705096049bc"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-08T09:54:13.000Z",
           "commitDate": "2018-10-08T09:54:13.000Z",
@@ -2260,30 +1980,20 @@
         "implicitBranchNo": 2624,
         "seq": 15438,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "fa15753966915f3563556ae54978331c5702410c",
-          "parentIds": [
-            "f1014d7885893d07e1d25d3a853c595a52ed3314"
-          ],
+          "parentIds": ["f1014d7885893d07e1d25d3a853c595a52ed3314"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-08T14:14:31.000Z",
           "commitDate": "2018-10-08T14:14:31.000Z",
@@ -2314,30 +2024,20 @@
         "implicitBranchNo": 2624,
         "seq": 15439,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "d94f8d93cf1fec00b34a97a76d113a45ef9f87aa",
-          "parentIds": [
-            "fa15753966915f3563556ae54978331c5702410c"
-          ],
+          "parentIds": ["fa15753966915f3563556ae54978331c5702410c"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-09T08:29:04.000Z",
           "commitDate": "2018-10-09T08:29:04.000Z",
@@ -2368,30 +2068,20 @@
         "implicitBranchNo": 2624,
         "seq": 15440,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "37473fc0dbc4eef8911cdc884aeebdbf17f1dc87",
-          "parentIds": [
-            "d94f8d93cf1fec00b34a97a76d113a45ef9f87aa"
-          ],
+          "parentIds": ["d94f8d93cf1fec00b34a97a76d113a45ef9f87aa"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-09T11:37:09.000Z",
           "commitDate": "2018-10-09T11:37:09.000Z",
@@ -2422,30 +2112,20 @@
         "implicitBranchNo": 2624,
         "seq": 15441,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "5b7d40086458cfe04573cf4a00861fc6cdb3f5f4",
-          "parentIds": [
-            "37473fc0dbc4eef8911cdc884aeebdbf17f1dc87"
-          ],
+          "parentIds": ["37473fc0dbc4eef8911cdc884aeebdbf17f1dc87"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-09T15:22:45.000Z",
           "commitDate": "2018-10-09T15:22:45.000Z",
@@ -2492,30 +2172,20 @@
         "implicitBranchNo": 2624,
         "seq": 15442,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "3e2dddc6e4b9d20802887b65a768b6a4b271646d",
-          "parentIds": [
-            "5b7d40086458cfe04573cf4a00861fc6cdb3f5f4"
-          ],
+          "parentIds": ["5b7d40086458cfe04573cf4a00861fc6cdb3f5f4"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-09T17:47:11.000Z",
           "commitDate": "2018-10-09T17:47:11.000Z",
@@ -2534,30 +2204,20 @@
         "implicitBranchNo": 2624,
         "seq": 15443,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "3bf50ad55b9b72fe423a118ac5e149c194e958c5",
-          "parentIds": [
-            "3e2dddc6e4b9d20802887b65a768b6a4b271646d"
-          ],
+          "parentIds": ["3e2dddc6e4b9d20802887b65a768b6a4b271646d"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-09T19:30:39.000Z",
           "commitDate": "2018-10-09T19:30:39.000Z",
@@ -2580,30 +2240,20 @@
         "implicitBranchNo": 2624,
         "seq": 15444,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "d8822717821655fb59c2f43c64a96e6d7cff8908",
-          "parentIds": [
-            "3bf50ad55b9b72fe423a118ac5e149c194e958c5"
-          ],
+          "parentIds": ["3bf50ad55b9b72fe423a118ac5e149c194e958c5"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-09T19:48:19.000Z",
           "commitDate": "2018-10-09T19:48:19.000Z",
@@ -2622,30 +2272,20 @@
         "implicitBranchNo": 2624,
         "seq": 15445,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "79687ec6c1f19823acda85702326479350532ac8",
-          "parentIds": [
-            "d8822717821655fb59c2f43c64a96e6d7cff8908"
-          ],
+          "parentIds": ["d8822717821655fb59c2f43c64a96e6d7cff8908"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-09T20:20:06.000Z",
           "commitDate": "2018-10-09T20:20:06.000Z",
@@ -2696,30 +2336,20 @@
         "implicitBranchNo": 2624,
         "seq": 15446,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "f0f737972d966ac1f857428b9ce2b690762836fd",
-          "parentIds": [
-            "79687ec6c1f19823acda85702326479350532ac8"
-          ],
+          "parentIds": ["79687ec6c1f19823acda85702326479350532ac8"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-09T21:09:45.000Z",
           "commitDate": "2018-10-09T21:09:45.000Z",
@@ -2738,30 +2368,20 @@
         "implicitBranchNo": 2624,
         "seq": 15447,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "14830ada5953568a040b0bbc32fc7f095afa4ebe",
-          "parentIds": [
-            "f0f737972d966ac1f857428b9ce2b690762836fd"
-          ],
+          "parentIds": ["f0f737972d966ac1f857428b9ce2b690762836fd"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-09T21:16:36.000Z",
           "commitDate": "2018-10-09T21:16:36.000Z",
@@ -2804,30 +2424,20 @@
         "implicitBranchNo": 2624,
         "seq": 15448,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "7d65ac15b3b330980c4f5809463671ac9237d62c",
-          "parentIds": [
-            "14830ada5953568a040b0bbc32fc7f095afa4ebe"
-          ],
+          "parentIds": ["14830ada5953568a040b0bbc32fc7f095afa4ebe"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-09T21:30:41.000Z",
           "commitDate": "2018-10-09T21:30:41.000Z",
@@ -2846,30 +2456,20 @@
         "implicitBranchNo": 2624,
         "seq": 15449,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "bb5d549b9a81199f57f7520e84651230316a84c8",
-          "parentIds": [
-            "7d65ac15b3b330980c4f5809463671ac9237d62c"
-          ],
+          "parentIds": ["7d65ac15b3b330980c4f5809463671ac9237d62c"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-09T21:31:02.000Z",
           "commitDate": "2018-10-09T21:31:02.000Z",
@@ -2896,30 +2496,20 @@
         "implicitBranchNo": 2624,
         "seq": 15450,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "fc27e2b2c0d21d7fbe02b255f35fd22b06954ca0",
-          "parentIds": [
-            "bb5d549b9a81199f57f7520e84651230316a84c8"
-          ],
+          "parentIds": ["bb5d549b9a81199f57f7520e84651230316a84c8"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-09T21:51:58.000Z",
           "commitDate": "2018-10-09T21:51:58.000Z",
@@ -2942,30 +2532,20 @@
         "implicitBranchNo": 2624,
         "seq": 15451,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "d542957cc73ac45b3c48e2d4bfa83345d52b1c44",
-          "parentIds": [
-            "fc27e2b2c0d21d7fbe02b255f35fd22b06954ca0"
-          ],
+          "parentIds": ["fc27e2b2c0d21d7fbe02b255f35fd22b06954ca0"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-09T21:59:11.000Z",
           "commitDate": "2018-10-09T21:59:11.000Z",
@@ -2984,30 +2564,20 @@
         "implicitBranchNo": 2624,
         "seq": 15452,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "125e42c835549c16c9bc491a4c51d38b7760a5da",
-          "parentIds": [
-            "d542957cc73ac45b3c48e2d4bfa83345d52b1c44"
-          ],
+          "parentIds": ["d542957cc73ac45b3c48e2d4bfa83345d52b1c44"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-09T22:16:46.000Z",
           "commitDate": "2018-10-09T22:16:46.000Z",
@@ -3042,30 +2612,20 @@
         "implicitBranchNo": 2624,
         "seq": 15453,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "f09e06648a963cdba97cd858324aec587607f0b6",
-          "parentIds": [
-            "125e42c835549c16c9bc491a4c51d38b7760a5da"
-          ],
+          "parentIds": ["125e42c835549c16c9bc491a4c51d38b7760a5da"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-09T22:54:13.000Z",
           "commitDate": "2018-10-09T22:54:13.000Z",
@@ -3124,30 +2684,20 @@
         "implicitBranchNo": 2624,
         "seq": 15454,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "2540c4feaab70450edb4a7ee9c9a81447d8d2377",
-          "parentIds": [
-            "f09e06648a963cdba97cd858324aec587607f0b6"
-          ],
+          "parentIds": ["f09e06648a963cdba97cd858324aec587607f0b6"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-09T23:39:05.000Z",
           "commitDate": "2018-10-09T23:39:05.000Z",
@@ -3166,30 +2716,20 @@
         "implicitBranchNo": 2624,
         "seq": 15455,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "c4b46088d126d827a32df910aa4840ed64dc58c9",
-          "parentIds": [
-            "2540c4feaab70450edb4a7ee9c9a81447d8d2377"
-          ],
+          "parentIds": ["2540c4feaab70450edb4a7ee9c9a81447d8d2377"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-09T23:56:08.000Z",
           "commitDate": "2018-10-09T23:56:08.000Z",
@@ -3208,30 +2748,20 @@
         "implicitBranchNo": 2624,
         "seq": 15456,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "bfa125e6f94cf5ea6f400ee67fa2f0cf1adaf363",
-          "parentIds": [
-            "c4b46088d126d827a32df910aa4840ed64dc58c9"
-          ],
+          "parentIds": ["c4b46088d126d827a32df910aa4840ed64dc58c9"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-10T07:32:18.000Z",
           "commitDate": "2018-10-10T07:32:18.000Z",
@@ -3254,30 +2784,20 @@
         "implicitBranchNo": 2624,
         "seq": 15457,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "b1ec1ed9408f68fb07a28e976bedf7440a15c374",
-          "parentIds": [
-            "bfa125e6f94cf5ea6f400ee67fa2f0cf1adaf363"
-          ],
+          "parentIds": ["bfa125e6f94cf5ea6f400ee67fa2f0cf1adaf363"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-10T10:31:13.000Z",
           "commitDate": "2018-10-10T10:31:13.000Z",
@@ -3300,30 +2820,20 @@
         "implicitBranchNo": 2624,
         "seq": 15458,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "eebd228254f1d03b07f04bcefa2b4c4374d9ab6a",
-          "parentIds": [
-            "b1ec1ed9408f68fb07a28e976bedf7440a15c374"
-          ],
+          "parentIds": ["b1ec1ed9408f68fb07a28e976bedf7440a15c374"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-10T11:53:46.000Z",
           "commitDate": "2018-10-10T11:53:46.000Z",
@@ -3342,30 +2852,20 @@
         "implicitBranchNo": 2624,
         "seq": 15459,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "4548679d61c8f4995ccc774c037c13bc919e23a7",
-          "parentIds": [
-            "eebd228254f1d03b07f04bcefa2b4c4374d9ab6a"
-          ],
+          "parentIds": ["eebd228254f1d03b07f04bcefa2b4c4374d9ab6a"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-10T12:50:20.000Z",
           "commitDate": "2018-10-10T12:50:20.000Z",
@@ -3392,30 +2892,20 @@
         "implicitBranchNo": 2624,
         "seq": 15460,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "42adf5342c851d10bd8fda4c561abc11623772d0",
-          "parentIds": [
-            "4548679d61c8f4995ccc774c037c13bc919e23a7"
-          ],
+          "parentIds": ["4548679d61c8f4995ccc774c037c13bc919e23a7"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-10T12:50:32.000Z",
           "commitDate": "2018-10-10T12:50:32.000Z",
@@ -3434,30 +2924,20 @@
         "implicitBranchNo": 2624,
         "seq": 15461,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "43fa87c60994894c7c2f6a1eea88f2fd6d6ba255",
-          "parentIds": [
-            "42adf5342c851d10bd8fda4c561abc11623772d0"
-          ],
+          "parentIds": ["42adf5342c851d10bd8fda4c561abc11623772d0"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-10T12:51:09.000Z",
           "commitDate": "2018-10-10T12:51:09.000Z",
@@ -3476,30 +2956,20 @@
         "implicitBranchNo": 2624,
         "seq": 15462,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "0293d76e9ba17619af4b6eee76323411427f3a27",
-          "parentIds": [
-            "43fa87c60994894c7c2f6a1eea88f2fd6d6ba255"
-          ],
+          "parentIds": ["43fa87c60994894c7c2f6a1eea88f2fd6d6ba255"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-10T13:13:23.000Z",
           "commitDate": "2018-10-10T13:13:23.000Z",
@@ -3518,30 +2988,20 @@
         "implicitBranchNo": 2624,
         "seq": 15463,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "f811b75e66bd886d1829767eba03435735acfddc",
-          "parentIds": [
-            "0293d76e9ba17619af4b6eee76323411427f3a27"
-          ],
+          "parentIds": ["0293d76e9ba17619af4b6eee76323411427f3a27"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-10T19:36:57.000Z",
           "commitDate": "2018-10-10T19:36:57.000Z",
@@ -3560,30 +3020,20 @@
         "implicitBranchNo": 2624,
         "seq": 15464,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "8ac9af7d7c0b9d99dd4e2396da3be4633d9cca07",
-          "parentIds": [
-            "f811b75e66bd886d1829767eba03435735acfddc"
-          ],
+          "parentIds": ["f811b75e66bd886d1829767eba03435735acfddc"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-10T20:04:31.000Z",
           "commitDate": "2018-10-10T20:04:31.000Z",
@@ -3602,30 +3052,20 @@
         "implicitBranchNo": 2624,
         "seq": 15465,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "00665f7f772f424fb00605c401faf7a1a955624d",
-          "parentIds": [
-            "8ac9af7d7c0b9d99dd4e2396da3be4633d9cca07"
-          ],
+          "parentIds": ["8ac9af7d7c0b9d99dd4e2396da3be4633d9cca07"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-10T20:05:28.000Z",
           "commitDate": "2018-10-10T20:05:28.000Z",
@@ -3652,30 +3092,20 @@
         "implicitBranchNo": 2624,
         "seq": 15466,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "e8323aee6782c961b0836a7eb346e49bcb108589",
-          "parentIds": [
-            "00665f7f772f424fb00605c401faf7a1a955624d"
-          ],
+          "parentIds": ["00665f7f772f424fb00605c401faf7a1a955624d"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-10T20:07:00.000Z",
           "commitDate": "2018-10-10T20:07:00.000Z",
@@ -3694,30 +3124,20 @@
         "implicitBranchNo": 2624,
         "seq": 15467,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "86b4a2f39f897013bb425282d450362f16aed896",
-          "parentIds": [
-            "e8323aee6782c961b0836a7eb346e49bcb108589"
-          ],
+          "parentIds": ["e8323aee6782c961b0836a7eb346e49bcb108589"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-10T20:41:10.000Z",
           "commitDate": "2018-10-10T20:41:10.000Z",
@@ -3736,30 +3156,20 @@
         "implicitBranchNo": 2624,
         "seq": 15468,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "845e0606db4802514e240b958266cc820044e211",
-          "parentIds": [
-            "86b4a2f39f897013bb425282d450362f16aed896"
-          ],
+          "parentIds": ["86b4a2f39f897013bb425282d450362f16aed896"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-10T21:40:38.000Z",
           "commitDate": "2018-10-10T21:40:38.000Z",
@@ -3790,30 +3200,20 @@
         "implicitBranchNo": 2624,
         "seq": 15469,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "2aefb4f8f93f42092605db019d47b2939a13c94d",
-          "parentIds": [
-            "845e0606db4802514e240b958266cc820044e211"
-          ],
+          "parentIds": ["845e0606db4802514e240b958266cc820044e211"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-10T22:12:47.000Z",
           "commitDate": "2018-10-10T22:12:47.000Z",
@@ -3832,30 +3232,20 @@
         "implicitBranchNo": 2624,
         "seq": 15470,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "f4224ff7a233cc726587be4e00b00167205a47b0",
-          "parentIds": [
-            "2aefb4f8f93f42092605db019d47b2939a13c94d"
-          ],
+          "parentIds": ["2aefb4f8f93f42092605db019d47b2939a13c94d"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-10T22:50:45.000Z",
           "commitDate": "2018-10-10T22:50:45.000Z",
@@ -3878,30 +3268,20 @@
         "implicitBranchNo": 2624,
         "seq": 15471,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "8cb2421df92015c6e47cee788098d2e8538bbe83",
-          "parentIds": [
-            "f4224ff7a233cc726587be4e00b00167205a47b0"
-          ],
+          "parentIds": ["f4224ff7a233cc726587be4e00b00167205a47b0"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-10T22:57:54.000Z",
           "commitDate": "2018-10-10T22:57:54.000Z",
@@ -3920,30 +3300,20 @@
         "implicitBranchNo": 2624,
         "seq": 15472,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "c51ca82e725afc6b97900c0d749551f2d20c4897",
-          "parentIds": [
-            "8cb2421df92015c6e47cee788098d2e8538bbe83"
-          ],
+          "parentIds": ["8cb2421df92015c6e47cee788098d2e8538bbe83"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-11T11:46:10.000Z",
           "commitDate": "2018-10-11T11:46:10.000Z",
@@ -3994,30 +3364,20 @@
         "implicitBranchNo": 2624,
         "seq": 15473,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "0c53107327eee12108d19ac80626f89ebaf4e395",
-          "parentIds": [
-            "c51ca82e725afc6b97900c0d749551f2d20c4897"
-          ],
+          "parentIds": ["c51ca82e725afc6b97900c0d749551f2d20c4897"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-11T11:59:00.000Z",
           "commitDate": "2018-10-11T11:59:00.000Z",
@@ -4060,30 +3420,20 @@
         "implicitBranchNo": 2624,
         "seq": 15474,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "8c362806fc307887accb7568a1a3f0531c0e7c01",
-          "parentIds": [
-            "0c53107327eee12108d19ac80626f89ebaf4e395"
-          ],
+          "parentIds": ["0c53107327eee12108d19ac80626f89ebaf4e395"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-11T12:37:22.000Z",
           "commitDate": "2018-10-11T12:37:22.000Z",
@@ -4106,30 +3456,20 @@
         "implicitBranchNo": 2624,
         "seq": 15475,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "a7b151d127bd0f221d59048863ef2b67be72c704",
-          "parentIds": [
-            "8c362806fc307887accb7568a1a3f0531c0e7c01"
-          ],
+          "parentIds": ["8c362806fc307887accb7568a1a3f0531c0e7c01"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-11T12:42:30.000Z",
           "commitDate": "2018-10-11T12:42:30.000Z",
@@ -4152,30 +3492,20 @@
         "implicitBranchNo": 2624,
         "seq": 15476,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "60434a7b30cf6aea01c098b5b3b69ceb3bd1c218",
-          "parentIds": [
-            "a7b151d127bd0f221d59048863ef2b67be72c704"
-          ],
+          "parentIds": ["a7b151d127bd0f221d59048863ef2b67be72c704"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-11T12:43:51.000Z",
           "commitDate": "2018-10-11T12:43:51.000Z",
@@ -4194,30 +3524,20 @@
         "implicitBranchNo": 2624,
         "seq": 15477,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "0bc65f2b36424f593400f9d80bdbad262259cc94",
-          "parentIds": [
-            "60434a7b30cf6aea01c098b5b3b69ceb3bd1c218"
-          ],
+          "parentIds": ["60434a7b30cf6aea01c098b5b3b69ceb3bd1c218"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-11T12:58:18.000Z",
           "commitDate": "2018-10-11T12:58:18.000Z",
@@ -4236,30 +3556,20 @@
         "implicitBranchNo": 2624,
         "seq": 15478,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "e32ddece8fdefa1ef8064670352d44c3f28cfcc7",
-          "parentIds": [
-            "0bc65f2b36424f593400f9d80bdbad262259cc94"
-          ],
+          "parentIds": ["0bc65f2b36424f593400f9d80bdbad262259cc94"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-12T10:18:47.000Z",
           "commitDate": "2018-10-12T10:18:47.000Z",
@@ -4282,7 +3592,7 @@
         "implicitBranchNo": 2624,
         "seq": 15479,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
@@ -4293,20 +3603,12 @@
             "6a31854ef99061ff6e50e0fcfc7261f85a0a799f"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-19T07:38:13.000Z",
           "commitDate": "2018-10-19T07:38:13.000Z",
@@ -4333,30 +3635,20 @@
         "implicitBranchNo": 2624,
         "seq": 15506,
         "isMergeCommit": true,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "bbdc93c9493f664a7407065ea00f6fc1de2bcb06",
-          "parentIds": [
-            "3220a0e3aa5b4dbae3a845e5a0b50b193ac15594"
-          ],
+          "parentIds": ["3220a0e3aa5b4dbae3a845e5a0b50b193ac15594"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-19T07:38:50.000Z",
           "commitDate": "2018-10-19T07:38:50.000Z",
@@ -4375,30 +3667,20 @@
         "implicitBranchNo": 2624,
         "seq": 15507,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "2367a766c45e6cb3f9a36ee4bad481c413c2fedb",
-          "parentIds": [
-            "bbdc93c9493f664a7407065ea00f6fc1de2bcb06"
-          ],
+          "parentIds": ["bbdc93c9493f664a7407065ea00f6fc1de2bcb06"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-19T08:37:47.000Z",
           "commitDate": "2018-10-19T08:37:47.000Z",
@@ -4417,7 +3699,7 @@
         "implicitBranchNo": 2624,
         "seq": 15508,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
@@ -4428,20 +3710,12 @@
             "068ac09cbeb4537a7ad6022c6deccdcc67d4b5b1"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-23T12:25:59.000Z",
           "commitDate": "2018-10-23T12:25:59.000Z",
@@ -4472,30 +3746,20 @@
         "implicitBranchNo": 2624,
         "seq": 15523,
         "isMergeCommit": true,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "3585c73438d321f09351a36e9f7ccb12e10de830",
-          "parentIds": [
-            "0f07972d9f2478a1c2ff523b737ab0f866b891b8"
-          ],
+          "parentIds": ["0f07972d9f2478a1c2ff523b737ab0f866b891b8"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-23T13:29:40.000Z",
           "commitDate": "2018-10-23T13:29:40.000Z",
@@ -4526,30 +3790,20 @@
         "implicitBranchNo": 2624,
         "seq": 15524,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "fb42a1b198a70db10b9704bd9aaca108aa12f28b",
-          "parentIds": [
-            "3585c73438d321f09351a36e9f7ccb12e10de830"
-          ],
+          "parentIds": ["3585c73438d321f09351a36e9f7ccb12e10de830"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-25T13:04:38.000Z",
           "commitDate": "2018-10-25T13:04:38.000Z",
@@ -4572,30 +3826,20 @@
         "implicitBranchNo": 2624,
         "seq": 15527,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "3ad154e69b6775baaa91daf9b41cb8a00c4e2f86",
-          "parentIds": [
-            "fb42a1b198a70db10b9704bd9aaca108aa12f28b"
-          ],
+          "parentIds": ["fb42a1b198a70db10b9704bd9aaca108aa12f28b"],
           "author": {
-            "names": [
-              "Simon Ask Ulsnes "
-            ],
-            "emails": [
-              "su@realm.io"
-            ]
+            "names": ["Simon Ask Ulsnes "],
+            "emails": ["su@realm.io"]
           },
           "committer": {
-            "names": [
-              "Simon Ask Ulsnes "
-            ],
-            "emails": [
-              "su@realm.io"
-            ]
+            "names": ["Simon Ask Ulsnes "],
+            "emails": ["su@realm.io"]
           },
           "authorDate": "2018-10-25T14:08:08.000Z",
           "commitDate": "2018-10-25T14:08:08.000Z",
@@ -4614,30 +3858,20 @@
         "implicitBranchNo": 2624,
         "seq": 15528,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "74a274cc1186fb7b71f6533371576d5a9a01d9af",
-          "parentIds": [
-            "3ad154e69b6775baaa91daf9b41cb8a00c4e2f86"
-          ],
+          "parentIds": ["3ad154e69b6775baaa91daf9b41cb8a00c4e2f86"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-26T11:27:12.000Z",
           "commitDate": "2018-10-26T11:27:12.000Z",
@@ -4672,30 +3906,20 @@
         "implicitBranchNo": 2624,
         "seq": 15529,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "5892a531ad9eb98e524f1e8b4383eb54710c1634",
-          "parentIds": [
-            "74a274cc1186fb7b71f6533371576d5a9a01d9af"
-          ],
+          "parentIds": ["74a274cc1186fb7b71f6533371576d5a9a01d9af"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-26T13:19:47.000Z",
           "commitDate": "2018-10-26T13:19:47.000Z",
@@ -4730,30 +3954,20 @@
         "implicitBranchNo": 2624,
         "seq": 15530,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "22d759f35b1441cdb8c00eaf1a473e96459299cd",
-          "parentIds": [
-            "5892a531ad9eb98e524f1e8b4383eb54710c1634"
-          ],
+          "parentIds": ["5892a531ad9eb98e524f1e8b4383eb54710c1634"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-26T13:31:08.000Z",
           "commitDate": "2018-10-26T13:31:08.000Z",
@@ -4772,7 +3986,7 @@
         "implicitBranchNo": 2624,
         "seq": 15531,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
@@ -4783,20 +3997,12 @@
             "1c71cac78dfe029c6a8b3822fbf338c54693383e"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-26T17:24:14.000Z",
           "commitDate": "2018-10-26T17:24:14.000Z",
@@ -4951,30 +4157,20 @@
         "implicitBranchNo": 2624,
         "seq": 15534,
         "isMergeCommit": true,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "37e05bc553604aed16d7e5f62ee553fd4fc5f00c",
-          "parentIds": [
-            "2025cb3b575dc47107e12969bc75a159d8955c71"
-          ],
+          "parentIds": ["2025cb3b575dc47107e12969bc75a159d8955c71"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-26T20:00:05.000Z",
           "commitDate": "2018-10-26T20:00:05.000Z",
@@ -4993,30 +4189,20 @@
         "implicitBranchNo": 2624,
         "seq": 15535,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "94ccb8d5d6c9df7ffabddff20efdbc4e387420f6",
-          "parentIds": [
-            "37e05bc553604aed16d7e5f62ee553fd4fc5f00c"
-          ],
+          "parentIds": ["37e05bc553604aed16d7e5f62ee553fd4fc5f00c"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-31T13:43:32.000Z",
           "commitDate": "2018-10-31T13:43:32.000Z",
@@ -5039,30 +4225,20 @@
         "implicitBranchNo": 2624,
         "seq": 15546,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "ea5c5b774ab309290f071370f9ffb80680b1dae9",
-          "parentIds": [
-            "94ccb8d5d6c9df7ffabddff20efdbc4e387420f6"
-          ],
+          "parentIds": ["94ccb8d5d6c9df7ffabddff20efdbc4e387420f6"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-01T11:01:08.000Z",
           "commitDate": "2018-11-01T11:01:08.000Z",
@@ -5097,30 +4273,20 @@
         "implicitBranchNo": 2624,
         "seq": 15549,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "a413291f2cabdd1fd7a19511c0ba72615fe02644",
-          "parentIds": [
-            "ea5c5b774ab309290f071370f9ffb80680b1dae9"
-          ],
+          "parentIds": ["ea5c5b774ab309290f071370f9ffb80680b1dae9"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-01T12:36:19.000Z",
           "commitDate": "2018-11-01T12:36:19.000Z",
@@ -5143,30 +4309,20 @@
         "implicitBranchNo": 2624,
         "seq": 15550,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "89f590608451f1f5350127fcf01436cb8a022cba",
-          "parentIds": [
-            "a413291f2cabdd1fd7a19511c0ba72615fe02644"
-          ],
+          "parentIds": ["a413291f2cabdd1fd7a19511c0ba72615fe02644"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-01T20:34:19.000Z",
           "commitDate": "2018-11-01T20:34:19.000Z",
@@ -5205,7 +4361,7 @@
         "implicitBranchNo": 2624,
         "seq": 15555,
         "isMergeCommit": false,
-        "taskId": 2435
+        "clusterId": 2435
       },
       {
         "nodeTypeName": "COMMIT",
@@ -5216,20 +4372,12 @@
             "89f590608451f1f5350127fcf01436cb8a022cba"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2018-11-02T21:47:30.000Z",
           "commitDate": "2018-11-02T21:47:30.000Z",
@@ -5420,7 +4568,7 @@
         "implicitBranchNo": 0,
         "seq": 15560,
         "isMergeCommit": true,
-        "taskId": 2435
+        "clusterId": 2435
       }
     ]
   },
@@ -5431,24 +4579,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "ff261dd7ac693bc0375aaa9f3f17ef42bf1d51ba",
-          "parentIds": [
-            "1c71cac78dfe029c6a8b3822fbf338c54693383e"
-          ],
+          "parentIds": ["1c71cac78dfe029c6a8b3822fbf338c54693383e"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-01T15:03:25.000Z",
           "commitDate": "2018-11-01T15:03:25.000Z",
@@ -5479,30 +4617,20 @@
         "implicitBranchNo": 2630,
         "seq": 15551,
         "isMergeCommit": false,
-        "taskId": 2436
+        "clusterId": 2436
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "d4c22c9c70d719c4ec752e6b63500efe421671ae",
-          "parentIds": [
-            "ff261dd7ac693bc0375aaa9f3f17ef42bf1d51ba"
-          ],
+          "parentIds": ["ff261dd7ac693bc0375aaa9f3f17ef42bf1d51ba"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-01T19:00:13.000Z",
           "commitDate": "2018-11-01T19:00:13.000Z",
@@ -5521,30 +4649,20 @@
         "implicitBranchNo": 2630,
         "seq": 15552,
         "isMergeCommit": false,
-        "taskId": 2436
+        "clusterId": 2436
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "1b915b6eafb22c9ae03b6f5017ef276d46ddb407",
-          "parentIds": [
-            "d4c22c9c70d719c4ec752e6b63500efe421671ae"
-          ],
+          "parentIds": ["d4c22c9c70d719c4ec752e6b63500efe421671ae"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-01T19:43:23.000Z",
           "commitDate": "2018-11-01T19:43:23.000Z",
@@ -5563,30 +4681,20 @@
         "implicitBranchNo": 2630,
         "seq": 15553,
         "isMergeCommit": false,
-        "taskId": 2436
+        "clusterId": 2436
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "068ee37cff97af3b65d73ba0eeda0ffcba9e2970",
-          "parentIds": [
-            "1b915b6eafb22c9ae03b6f5017ef276d46ddb407"
-          ],
+          "parentIds": ["1b915b6eafb22c9ae03b6f5017ef276d46ddb407"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-01T20:03:27.000Z",
           "commitDate": "2018-11-01T20:03:27.000Z",
@@ -5605,30 +4713,20 @@
         "implicitBranchNo": 2630,
         "seq": 15554,
         "isMergeCommit": false,
-        "taskId": 2436
+        "clusterId": 2436
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "a3753f347b642bec563c94154d2ea82f60cf9ece",
-          "parentIds": [
-            "068ee37cff97af3b65d73ba0eeda0ffcba9e2970"
-          ],
+          "parentIds": ["068ee37cff97af3b65d73ba0eeda0ffcba9e2970"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-01T21:10:48.000Z",
           "commitDate": "2018-11-01T21:10:48.000Z",
@@ -5647,30 +4745,20 @@
         "implicitBranchNo": 2630,
         "seq": 15556,
         "isMergeCommit": false,
-        "taskId": 2436
+        "clusterId": 2436
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "bf962865d3819ee7292a57e8ffa75ed216e0b187",
-          "parentIds": [
-            "a3753f347b642bec563c94154d2ea82f60cf9ece"
-          ],
+          "parentIds": ["a3753f347b642bec563c94154d2ea82f60cf9ece"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-01T21:14:34.000Z",
           "commitDate": "2018-11-01T21:14:34.000Z",
@@ -5689,7 +4777,7 @@
         "implicitBranchNo": 2630,
         "seq": 15557,
         "isMergeCommit": false,
-        "taskId": 2436
+        "clusterId": 2436
       },
       {
         "nodeTypeName": "COMMIT",
@@ -5700,20 +4788,12 @@
             "9c4c5e6b6c528082190c02a6e159fc3eb7929743"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-02T21:54:20.000Z",
           "commitDate": "2018-11-02T21:54:20.000Z",
@@ -5900,7 +4980,7 @@
         "implicitBranchNo": 2630,
         "seq": 15561,
         "isMergeCommit": true,
-        "taskId": 2436
+        "clusterId": 2436
       },
       {
         "nodeTypeName": "COMMIT",
@@ -5911,20 +4991,12 @@
             "d61955117e8d79285e0eb823ab6bdb8d5964b192"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2018-11-03T17:23:50.000Z",
           "commitDate": "2018-11-03T17:23:50.000Z",
@@ -5967,7 +5039,7 @@
         "implicitBranchNo": 0,
         "seq": 15564,
         "isMergeCommit": true,
-        "taskId": 2436
+        "clusterId": 2436
       }
     ]
   },
@@ -5978,24 +5050,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "ffcd0b2181ec19fa174766d916c3cbeb6f923c8a",
-          "parentIds": [
-            "bf962865d3819ee7292a57e8ffa75ed216e0b187"
-          ],
+          "parentIds": ["bf962865d3819ee7292a57e8ffa75ed216e0b187"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-02T11:03:09.000Z",
           "commitDate": "2018-11-02T11:03:09.000Z",
@@ -6054,30 +5116,20 @@
         "implicitBranchNo": 2631,
         "seq": 15558,
         "isMergeCommit": false,
-        "taskId": 2437
+        "clusterId": 2437
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "ff84a3c379ae2a99935aec21ed356d0ec5ad2789",
-          "parentIds": [
-            "ffcd0b2181ec19fa174766d916c3cbeb6f923c8a"
-          ],
+          "parentIds": ["ffcd0b2181ec19fa174766d916c3cbeb6f923c8a"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-02T12:32:02.000Z",
           "commitDate": "2018-11-02T12:32:02.000Z",
@@ -6096,30 +5148,20 @@
         "implicitBranchNo": 2631,
         "seq": 15559,
         "isMergeCommit": false,
-        "taskId": 2437
+        "clusterId": 2437
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "ce4f4b990d11e71455da63d8140bbf2604ad5c1d",
-          "parentIds": [
-            "ff84a3c379ae2a99935aec21ed356d0ec5ad2789"
-          ],
+          "parentIds": ["ff84a3c379ae2a99935aec21ed356d0ec5ad2789"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-03T16:43:50.000Z",
           "commitDate": "2018-11-03T16:43:50.000Z",
@@ -6146,7 +5188,7 @@
         "implicitBranchNo": 2631,
         "seq": 15562,
         "isMergeCommit": false,
-        "taskId": 2437
+        "clusterId": 2437
       },
       {
         "nodeTypeName": "COMMIT",
@@ -6157,20 +5199,12 @@
             "d61955117e8d79285e0eb823ab6bdb8d5964b192"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-03T16:43:57.000Z",
           "commitDate": "2018-11-03T16:43:57.000Z",
@@ -6357,7 +5391,7 @@
         "implicitBranchNo": 2631,
         "seq": 15563,
         "isMergeCommit": true,
-        "taskId": 2437
+        "clusterId": 2437
       },
       {
         "nodeTypeName": "COMMIT",
@@ -6368,20 +5402,12 @@
             "03e74870750dea24fa05a2dc8401eee196252898"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-03T17:28:53.000Z",
           "commitDate": "2018-11-03T17:28:53.000Z",
@@ -6395,30 +5421,20 @@
         "implicitBranchNo": 2631,
         "seq": 15565,
         "isMergeCommit": true,
-        "taskId": 2437
+        "clusterId": 2437
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "a00fafdc6c0720edc5f0d66685bdab335f34a9f6",
-          "parentIds": [
-            "1429be195dd6a570b5aa206ae44674ce0836c893"
-          ],
+          "parentIds": ["1429be195dd6a570b5aa206ae44674ce0836c893"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-03T17:31:26.000Z",
           "commitDate": "2018-11-03T17:31:26.000Z",
@@ -6437,7 +5453,7 @@
         "implicitBranchNo": 2631,
         "seq": 15566,
         "isMergeCommit": false,
-        "taskId": 2437
+        "clusterId": 2437
       },
       {
         "nodeTypeName": "COMMIT",
@@ -6448,20 +5464,12 @@
             "a00fafdc6c0720edc5f0d66685bdab335f34a9f6"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2018-11-03T17:31:50.000Z",
           "commitDate": "2018-11-03T17:31:50.000Z",
@@ -6524,7 +5532,7 @@
         "implicitBranchNo": 0,
         "seq": 15567,
         "isMergeCommit": true,
-        "taskId": 2437
+        "clusterId": 2437
       }
     ]
   },
@@ -6535,24 +5543,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "ad37cba4f7a118d2d21ac50ceedce0f7d4f1de3c",
-          "parentIds": [
-            "293e746a202adfcb09f076a2542f4f7e7045690c"
-          ],
+          "parentIds": ["293e746a202adfcb09f076a2542f4f7e7045690c"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-07-20T09:06:38.000Z",
           "commitDate": "2018-07-20T09:06:38.000Z",
@@ -6579,30 +5577,20 @@
         "implicitBranchNo": 2585,
         "seq": 15178,
         "isMergeCommit": false,
-        "taskId": 2438
+        "clusterId": 2438
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "f971ae0d9b9b9650842d8a008810cc0f16bef5c4",
-          "parentIds": [
-            "ad37cba4f7a118d2d21ac50ceedce0f7d4f1de3c"
-          ],
+          "parentIds": ["ad37cba4f7a118d2d21ac50ceedce0f7d4f1de3c"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-07-20T10:18:18.000Z",
           "commitDate": "2018-07-20T10:18:18.000Z",
@@ -6625,7 +5613,7 @@
         "implicitBranchNo": 2585,
         "seq": 15179,
         "isMergeCommit": false,
-        "taskId": 2438
+        "clusterId": 2438
       },
       {
         "nodeTypeName": "COMMIT",
@@ -6636,20 +5624,12 @@
             "1c71cac78dfe029c6a8b3822fbf338c54693383e"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-30T08:29:08.000Z",
           "commitDate": "2018-10-30T08:29:08.000Z",
@@ -7384,30 +6364,20 @@
         "implicitBranchNo": 2585,
         "seq": 15542,
         "isMergeCommit": true,
-        "taskId": 2438
+        "clusterId": 2438
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "b96cef6dd9df2ad8f0290a3cf90125a67dfb6cb7",
-          "parentIds": [
-            "776b678418546849437d44df3f73b29faec19c23"
-          ],
+          "parentIds": ["776b678418546849437d44df3f73b29faec19c23"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-30T13:34:47.000Z",
           "commitDate": "2018-10-30T13:34:47.000Z",
@@ -7438,30 +6408,20 @@
         "implicitBranchNo": 2585,
         "seq": 15543,
         "isMergeCommit": false,
-        "taskId": 2438
+        "clusterId": 2438
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "449bffc2ee93c890813e6200f7be70802f42e0a3",
-          "parentIds": [
-            "b96cef6dd9df2ad8f0290a3cf90125a67dfb6cb7"
-          ],
+          "parentIds": ["b96cef6dd9df2ad8f0290a3cf90125a67dfb6cb7"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-30T13:38:32.000Z",
           "commitDate": "2018-10-30T13:38:32.000Z",
@@ -7484,30 +6444,20 @@
         "implicitBranchNo": 2585,
         "seq": 15544,
         "isMergeCommit": false,
-        "taskId": 2438
+        "clusterId": 2438
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "3c2b79016140eb866f5c6c6c16fd73ccd96312bd",
-          "parentIds": [
-            "449bffc2ee93c890813e6200f7be70802f42e0a3"
-          ],
+          "parentIds": ["449bffc2ee93c890813e6200f7be70802f42e0a3"],
           "author": {
-            "names": [
-              "Brian Munkholm "
-            ],
-            "emails": [
-              "bmunkholm@users.noreply.github.com"
-            ]
+            "names": ["Brian Munkholm "],
+            "emails": ["bmunkholm@users.noreply.github.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2018-10-31T10:45:41.000Z",
           "commitDate": "2018-10-31T10:45:41.000Z",
@@ -7526,30 +6476,20 @@
         "implicitBranchNo": 2585,
         "seq": 15545,
         "isMergeCommit": false,
-        "taskId": 2438
+        "clusterId": 2438
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "fbb8a1afbaba35593570e0307cf69ca38b811d16",
-          "parentIds": [
-            "3c2b79016140eb866f5c6c6c16fd73ccd96312bd"
-          ],
+          "parentIds": ["3c2b79016140eb866f5c6c6c16fd73ccd96312bd"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-31T14:16:53.000Z",
           "commitDate": "2018-10-31T14:16:53.000Z",
@@ -7572,7 +6512,7 @@
         "implicitBranchNo": 2585,
         "seq": 15548,
         "isMergeCommit": false,
-        "taskId": 2438
+        "clusterId": 2438
       },
       {
         "nodeTypeName": "COMMIT",
@@ -7583,20 +6523,12 @@
             "81ea78bfd242785e81375b0733d51886053f8618"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-03T17:33:44.000Z",
           "commitDate": "2018-11-03T17:33:44.000Z",
@@ -7839,30 +6771,20 @@
         "implicitBranchNo": 2585,
         "seq": 15568,
         "isMergeCommit": true,
-        "taskId": 2438
+        "clusterId": 2438
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "c342541658f7458fa1cd23d35c0d072fbc891902",
-          "parentIds": [
-            "25a60265e7b5607de676585b05e1e30b3aca86c6"
-          ],
+          "parentIds": ["25a60265e7b5607de676585b05e1e30b3aca86c6"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-03T19:06:50.000Z",
           "commitDate": "2018-11-03T19:06:50.000Z",
@@ -7881,7 +6803,7 @@
         "implicitBranchNo": 2585,
         "seq": 15569,
         "isMergeCommit": false,
-        "taskId": 2438
+        "clusterId": 2438
       },
       {
         "nodeTypeName": "COMMIT",
@@ -7892,20 +6814,12 @@
             "c342541658f7458fa1cd23d35c0d072fbc891902"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2018-11-03T21:03:24.000Z",
           "commitDate": "2018-11-03T21:03:24.000Z",
@@ -7944,7 +6858,7 @@
         "implicitBranchNo": 0,
         "seq": 15570,
         "isMergeCommit": true,
-        "taskId": 2438
+        "clusterId": 2438
       }
     ]
   },
@@ -7955,24 +6869,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "0452924f81f78b379100958ea832d0fb7531cb24",
-          "parentIds": [
-            "7dddb2cca12eb44c35ad0a7768c05aa40e2c8001"
-          ],
+          "parentIds": ["7dddb2cca12eb44c35ad0a7768c05aa40e2c8001"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-09-04T07:37:41.000Z",
           "commitDate": "2018-09-04T07:37:41.000Z",
@@ -7999,30 +6903,20 @@
         "implicitBranchNo": 2612,
         "seq": 15352,
         "isMergeCommit": false,
-        "taskId": 2439
+        "clusterId": 2439
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "7a2516a1f2e3af173bf7ae078880041dba7e99a4",
-          "parentIds": [
-            "0452924f81f78b379100958ea832d0fb7531cb24"
-          ],
+          "parentIds": ["0452924f81f78b379100958ea832d0fb7531cb24"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-09-04T11:12:59.000Z",
           "commitDate": "2018-09-04T11:12:59.000Z",
@@ -8049,7 +6943,7 @@
         "implicitBranchNo": 2612,
         "seq": 15356,
         "isMergeCommit": false,
-        "taskId": 2439
+        "clusterId": 2439
       },
       {
         "nodeTypeName": "COMMIT",
@@ -8060,20 +6954,12 @@
             "581c2a9fb2560c0e850549a91bb561346c66a83c"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-09-13T05:30:02.000Z",
           "commitDate": "2018-09-13T05:30:02.000Z",
@@ -8124,30 +7010,20 @@
         "implicitBranchNo": 2612,
         "seq": 15367,
         "isMergeCommit": true,
-        "taskId": 2439
+        "clusterId": 2439
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "d1a7cacb41b6a4f6195762dcc660bb9961810463",
-          "parentIds": [
-            "9bc186f35da0f4d19421a71ef91b1f34cd73470e"
-          ],
+          "parentIds": ["9bc186f35da0f4d19421a71ef91b1f34cd73470e"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-09-13T05:50:14.000Z",
           "commitDate": "2018-09-13T05:50:14.000Z",
@@ -8166,7 +7042,7 @@
         "implicitBranchNo": 2612,
         "seq": 15368,
         "isMergeCommit": false,
-        "taskId": 2439
+        "clusterId": 2439
       },
       {
         "nodeTypeName": "COMMIT",
@@ -8177,20 +7053,12 @@
             "068ac09cbeb4537a7ad6022c6deccdcc67d4b5b1"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-23T11:52:16.000Z",
           "commitDate": "2018-10-23T11:52:16.000Z",
@@ -8581,7 +7449,7 @@
         "implicitBranchNo": 2612,
         "seq": 15522,
         "isMergeCommit": true,
-        "taskId": 2439
+        "clusterId": 2439
       },
       {
         "nodeTypeName": "COMMIT",
@@ -8592,20 +7460,12 @@
             "d8f65132d0292a85eba8c88f933eb6e81793bbc8"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-03T21:16:32.000Z",
           "commitDate": "2018-11-03T21:16:32.000Z",
@@ -8964,30 +7824,20 @@
         "implicitBranchNo": 2612,
         "seq": 15571,
         "isMergeCommit": true,
-        "taskId": 2439
+        "clusterId": 2439
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "1b96ffbf9081b5ec5c46467aa8cc2c7519eb78b6",
-          "parentIds": [
-            "08fc03eacdbac16762667a58019bebbe93a4594c"
-          ],
+          "parentIds": ["08fc03eacdbac16762667a58019bebbe93a4594c"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-03T22:18:38.000Z",
           "commitDate": "2018-11-03T22:18:38.000Z",
@@ -9006,7 +7856,7 @@
         "implicitBranchNo": 2612,
         "seq": 15573,
         "isMergeCommit": false,
-        "taskId": 2439
+        "clusterId": 2439
       },
       {
         "nodeTypeName": "COMMIT",
@@ -9017,20 +7867,12 @@
             "1b96ffbf9081b5ec5c46467aa8cc2c7519eb78b6"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2018-11-03T23:01:32.000Z",
           "commitDate": "2018-11-03T23:01:32.000Z",
@@ -9073,7 +7915,7 @@
         "implicitBranchNo": 0,
         "seq": 15574,
         "isMergeCommit": true,
-        "taskId": 2439
+        "clusterId": 2439
       }
     ]
   },
@@ -9084,24 +7926,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "9cab2d0ac26fde577bc98de48313bc881fad633f",
-          "parentIds": [
-            "65adead2a6a5c1151468299a171e2ddcc3e34e37"
-          ],
+          "parentIds": ["65adead2a6a5c1151468299a171e2ddcc3e34e37"],
           "author": {
-            "names": [
-              "Brian Munkholm "
-            ],
-            "emails": [
-              "bmunkholm@users.noreply.github.com"
-            ]
+            "names": ["Brian Munkholm "],
+            "emails": ["bmunkholm@users.noreply.github.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2018-11-05T09:52:57.000Z",
           "commitDate": "2018-11-05T09:52:57.000Z",
@@ -9120,7 +7952,7 @@
         "implicitBranchNo": 2632,
         "seq": 15580,
         "isMergeCommit": false,
-        "taskId": 2440
+        "clusterId": 2440
       },
       {
         "nodeTypeName": "COMMIT",
@@ -9131,20 +7963,12 @@
             "9cab2d0ac26fde577bc98de48313bc881fad633f"
           ],
           "author": {
-            "names": [
-              "Brian Munkholm "
-            ],
-            "emails": [
-              "bmunkholm@users.noreply.github.com"
-            ]
+            "names": ["Brian Munkholm "],
+            "emails": ["bmunkholm@users.noreply.github.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2018-11-05T09:53:45.000Z",
           "commitDate": "2018-11-05T09:53:45.000Z",
@@ -9163,7 +7987,7 @@
         "implicitBranchNo": 0,
         "seq": 15581,
         "isMergeCommit": true,
-        "taskId": 2440
+        "clusterId": 2440
       }
     ]
   },
@@ -9174,24 +7998,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "4cdbefb862209dbc6f0c3a88c7c2c605c0bb3b02",
-          "parentIds": [
-            "c026078ae731eff55b71f45bcc5a12ee2fdce3de"
-          ],
+          "parentIds": ["c026078ae731eff55b71f45bcc5a12ee2fdce3de"],
           "author": {
-            "names": [
-              "G. Blake Meike "
-            ],
-            "emails": [
-              "blake.meike@realm.io"
-            ]
+            "names": ["G. Blake Meike "],
+            "emails": ["blake.meike@realm.io"]
           },
           "committer": {
-            "names": [
-              "G. Blake Meike "
-            ],
-            "emails": [
-              "blake.meike@realm.io"
-            ]
+            "names": ["G. Blake Meike "],
+            "emails": ["blake.meike@realm.io"]
           },
           "authorDate": "2017-08-16T21:47:23.000Z",
           "commitDate": "2017-08-21T23:49:40.000Z",
@@ -9222,30 +8036,20 @@
         "implicitBranchNo": 2178,
         "seq": 12681,
         "isMergeCommit": false,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "15dc1fa93e660f670f9e9147e7f3fb189ad1d672",
-          "parentIds": [
-            "4cdbefb862209dbc6f0c3a88c7c2c605c0bb3b02"
-          ],
+          "parentIds": ["4cdbefb862209dbc6f0c3a88c7c2c605c0bb3b02"],
           "author": {
-            "names": [
-              "G. Blake Meike "
-            ],
-            "emails": [
-              "blake.meike@realm.io"
-            ]
+            "names": ["G. Blake Meike "],
+            "emails": ["blake.meike@realm.io"]
           },
           "committer": {
-            "names": [
-              "G. Blake Meike "
-            ],
-            "emails": [
-              "blake.meike@realm.io"
-            ]
+            "names": ["G. Blake Meike "],
+            "emails": ["blake.meike@realm.io"]
           },
           "authorDate": "2017-08-22T00:22:53.000Z",
           "commitDate": "2017-08-22T00:22:53.000Z",
@@ -9264,30 +8068,20 @@
         "implicitBranchNo": 2178,
         "seq": 12682,
         "isMergeCommit": false,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "c6aab125771a39dbee4e63236b3791c26ab45e2d",
-          "parentIds": [
-            "15dc1fa93e660f670f9e9147e7f3fb189ad1d672"
-          ],
+          "parentIds": ["15dc1fa93e660f670f9e9147e7f3fb189ad1d672"],
           "author": {
-            "names": [
-              "G. Blake Meike "
-            ],
-            "emails": [
-              "blake.meike@realm.io"
-            ]
+            "names": ["G. Blake Meike "],
+            "emails": ["blake.meike@realm.io"]
           },
           "committer": {
-            "names": [
-              "G. Blake Meike "
-            ],
-            "emails": [
-              "blake.meike@realm.io"
-            ]
+            "names": ["G. Blake Meike "],
+            "emails": ["blake.meike@realm.io"]
           },
           "authorDate": "2017-08-22T13:43:23.000Z",
           "commitDate": "2017-08-22T13:47:09.000Z",
@@ -9306,30 +8100,20 @@
         "implicitBranchNo": 2178,
         "seq": 12703,
         "isMergeCommit": false,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "bc52bb7a5ebbb0b80574bd356b34a1687044ccfb",
-          "parentIds": [
-            "c6aab125771a39dbee4e63236b3791c26ab45e2d"
-          ],
+          "parentIds": ["c6aab125771a39dbee4e63236b3791c26ab45e2d"],
           "author": {
-            "names": [
-              "G. Blake Meike "
-            ],
-            "emails": [
-              "blake.meike@realm.io"
-            ]
+            "names": ["G. Blake Meike "],
+            "emails": ["blake.meike@realm.io"]
           },
           "committer": {
-            "names": [
-              "G. Blake Meike "
-            ],
-            "emails": [
-              "blake.meike@realm.io"
-            ]
+            "names": ["G. Blake Meike "],
+            "emails": ["blake.meike@realm.io"]
           },
           "authorDate": "2017-08-22T21:51:38.000Z",
           "commitDate": "2017-08-22T21:51:38.000Z",
@@ -9352,7 +8136,7 @@
         "implicitBranchNo": 2178,
         "seq": 12710,
         "isMergeCommit": false,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
@@ -9363,20 +8147,12 @@
             "890270027c17b51a7e94b09231004b744fd4a8fc"
           ],
           "author": {
-            "names": [
-              "G. Blake Meike "
-            ],
-            "emails": [
-              "blake.meike@realm.io"
-            ]
+            "names": ["G. Blake Meike "],
+            "emails": ["blake.meike@realm.io"]
           },
           "committer": {
-            "names": [
-              "G. Blake Meike "
-            ],
-            "emails": [
-              "blake.meike@realm.io"
-            ]
+            "names": ["G. Blake Meike "],
+            "emails": ["blake.meike@realm.io"]
           },
           "authorDate": "2017-08-24T17:20:20.000Z",
           "commitDate": "2017-08-24T17:20:20.000Z",
@@ -9663,7 +8439,7 @@
         "implicitBranchNo": 2178,
         "seq": 12746,
         "isMergeCommit": true,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
@@ -9674,20 +8450,12 @@
             "39bb67cef10b62456649fdd7cf5710bd3361c29a"
           ],
           "author": {
-            "names": [
-              "G. Blake Meike "
-            ],
-            "emails": [
-              "blake.meike@realm.io"
-            ]
+            "names": ["G. Blake Meike "],
+            "emails": ["blake.meike@realm.io"]
           },
           "committer": {
-            "names": [
-              "G. Blake Meike "
-            ],
-            "emails": [
-              "blake.meike@realm.io"
-            ]
+            "names": ["G. Blake Meike "],
+            "emails": ["blake.meike@realm.io"]
           },
           "authorDate": "2017-08-25T23:55:17.000Z",
           "commitDate": "2017-08-25T23:55:17.000Z",
@@ -9734,7 +8502,7 @@
         "implicitBranchNo": 2178,
         "seq": 12766,
         "isMergeCommit": true,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
@@ -9745,20 +8513,12 @@
             "997cde4e83e7c6fffad18878c813f556f324fa8c"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-14T20:57:05.000Z",
           "commitDate": "2018-10-14T20:57:05.000Z",
@@ -12329,7 +11089,7 @@
         "implicitBranchNo": 2178,
         "seq": 15490,
         "isMergeCommit": true,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
@@ -12340,20 +11100,12 @@
             "e32ddece8fdefa1ef8064670352d44c3f28cfcc7"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-15T20:45:37.000Z",
           "commitDate": "2018-10-15T20:45:37.000Z",
@@ -12548,30 +11300,20 @@
         "implicitBranchNo": 2178,
         "seq": 15495,
         "isMergeCommit": true,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "8ca64f4ab7efa9d5f8d99b154668bb09ffc14d98",
-          "parentIds": [
-            "c7f0485a94b342fa54175fdbdcc4d0947b9f99dd"
-          ],
+          "parentIds": ["c7f0485a94b342fa54175fdbdcc4d0947b9f99dd"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-15T23:39:07.000Z",
           "commitDate": "2018-10-15T23:39:07.000Z",
@@ -12614,30 +11356,20 @@
         "implicitBranchNo": 2178,
         "seq": 15496,
         "isMergeCommit": false,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "ce0e601300ac07fa71b5457aec1cf3825669615b",
-          "parentIds": [
-            "8ca64f4ab7efa9d5f8d99b154668bb09ffc14d98"
-          ],
+          "parentIds": ["8ca64f4ab7efa9d5f8d99b154668bb09ffc14d98"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-16T08:32:28.000Z",
           "commitDate": "2018-10-16T08:32:28.000Z",
@@ -12664,30 +11396,20 @@
         "implicitBranchNo": 2178,
         "seq": 15497,
         "isMergeCommit": false,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "d0432527d30693fa98e40d56981c2cf2be9a9519",
-          "parentIds": [
-            "ce0e601300ac07fa71b5457aec1cf3825669615b"
-          ],
+          "parentIds": ["ce0e601300ac07fa71b5457aec1cf3825669615b"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-16T08:57:29.000Z",
           "commitDate": "2018-10-16T08:57:29.000Z",
@@ -12714,30 +11436,20 @@
         "implicitBranchNo": 2178,
         "seq": 15498,
         "isMergeCommit": false,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "62cc63d96ff24fa5908fc95166b04b29bcd52fd7",
-          "parentIds": [
-            "d0432527d30693fa98e40d56981c2cf2be9a9519"
-          ],
+          "parentIds": ["d0432527d30693fa98e40d56981c2cf2be9a9519"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-16T09:21:14.000Z",
           "commitDate": "2018-10-16T09:21:14.000Z",
@@ -12764,30 +11476,20 @@
         "implicitBranchNo": 2178,
         "seq": 15499,
         "isMergeCommit": false,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "4f71d79dfede0b6137ae9be9f0af472ccbf31ee5",
-          "parentIds": [
-            "62cc63d96ff24fa5908fc95166b04b29bcd52fd7"
-          ],
+          "parentIds": ["62cc63d96ff24fa5908fc95166b04b29bcd52fd7"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-16T09:27:40.000Z",
           "commitDate": "2018-10-16T09:27:40.000Z",
@@ -12806,30 +11508,20 @@
         "implicitBranchNo": 2178,
         "seq": 15500,
         "isMergeCommit": false,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "cc4f4c6550633bb27c0c4a2036f7554ff4b64c01",
-          "parentIds": [
-            "4f71d79dfede0b6137ae9be9f0af472ccbf31ee5"
-          ],
+          "parentIds": ["4f71d79dfede0b6137ae9be9f0af472ccbf31ee5"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-16T13:39:33.000Z",
           "commitDate": "2018-10-16T13:39:33.000Z",
@@ -12860,7 +11552,7 @@
         "implicitBranchNo": 2178,
         "seq": 15501,
         "isMergeCommit": false,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
@@ -12871,20 +11563,12 @@
             "37e05bc553604aed16d7e5f62ee553fd4fc5f00c"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-29T10:08:23.000Z",
           "commitDate": "2018-10-29T10:08:23.000Z",
@@ -13075,30 +11759,20 @@
         "implicitBranchNo": 2178,
         "seq": 15536,
         "isMergeCommit": true,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "09d4eb1c3a183d9d55c3a7d69668aa88d85c2865",
-          "parentIds": [
-            "a02eb941471fbce8af72b7304b225cdf9b8b64e7"
-          ],
+          "parentIds": ["a02eb941471fbce8af72b7304b225cdf9b8b64e7"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-29T13:21:22.000Z",
           "commitDate": "2018-10-29T13:21:22.000Z",
@@ -13141,30 +11815,20 @@
         "implicitBranchNo": 2178,
         "seq": 15537,
         "isMergeCommit": false,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "5b9aa171321f2a9a4da56bc9a2ea92fe6059d760",
-          "parentIds": [
-            "09d4eb1c3a183d9d55c3a7d69668aa88d85c2865"
-          ],
+          "parentIds": ["09d4eb1c3a183d9d55c3a7d69668aa88d85c2865"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-29T20:24:55.000Z",
           "commitDate": "2018-10-29T20:24:55.000Z",
@@ -13191,30 +11855,20 @@
         "implicitBranchNo": 2178,
         "seq": 15538,
         "isMergeCommit": false,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "dda4537daa0a8a537569d4e7f3a4db0ca436ee5c",
-          "parentIds": [
-            "5b9aa171321f2a9a4da56bc9a2ea92fe6059d760"
-          ],
+          "parentIds": ["5b9aa171321f2a9a4da56bc9a2ea92fe6059d760"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-29T21:12:32.000Z",
           "commitDate": "2018-10-29T21:12:32.000Z",
@@ -13233,30 +11887,20 @@
         "implicitBranchNo": 2178,
         "seq": 15539,
         "isMergeCommit": false,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "7d95754fc30f5abaa4a038a5911d82848dcab84b",
-          "parentIds": [
-            "dda4537daa0a8a537569d4e7f3a4db0ca436ee5c"
-          ],
+          "parentIds": ["dda4537daa0a8a537569d4e7f3a4db0ca436ee5c"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-29T21:37:32.000Z",
           "commitDate": "2018-10-29T21:37:32.000Z",
@@ -13275,30 +11919,20 @@
         "implicitBranchNo": 2178,
         "seq": 15540,
         "isMergeCommit": false,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "9efcd6157c952b2f84a0ef7c6940c75bb8f7ffd8",
-          "parentIds": [
-            "7d95754fc30f5abaa4a038a5911d82848dcab84b"
-          ],
+          "parentIds": ["7d95754fc30f5abaa4a038a5911d82848dcab84b"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-29T23:20:04.000Z",
           "commitDate": "2018-10-29T23:20:04.000Z",
@@ -13317,30 +11951,20 @@
         "implicitBranchNo": 2178,
         "seq": 15541,
         "isMergeCommit": false,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "5ba41ae8dfa0d3c7b1af21e3c1d9d05dd79c59fd",
-          "parentIds": [
-            "9efcd6157c952b2f84a0ef7c6940c75bb8f7ffd8"
-          ],
+          "parentIds": ["9efcd6157c952b2f84a0ef7c6940c75bb8f7ffd8"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-10-31T14:03:38.000Z",
           "commitDate": "2018-10-31T14:03:38.000Z",
@@ -13363,7 +11987,7 @@
         "implicitBranchNo": 2178,
         "seq": 15547,
         "isMergeCommit": false,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
@@ -13374,20 +11998,12 @@
             "d8f65132d0292a85eba8c88f933eb6e81793bbc8"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-03T22:11:11.000Z",
           "commitDate": "2018-11-03T22:11:11.000Z",
@@ -13530,7 +12146,7 @@
         "implicitBranchNo": 2178,
         "seq": 15572,
         "isMergeCommit": true,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
@@ -13541,20 +12157,12 @@
             "65adead2a6a5c1151468299a171e2ddcc3e34e37"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-03T23:15:33.000Z",
           "commitDate": "2018-11-03T23:15:33.000Z",
@@ -13597,30 +12205,20 @@
         "implicitBranchNo": 2178,
         "seq": 15575,
         "isMergeCommit": true,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "aac7546ecfe0e5ee4e1c5fa94c75a420ece9b702",
-          "parentIds": [
-            "f07538c412f5084920823e4ba50f9b8585312221"
-          ],
+          "parentIds": ["f07538c412f5084920823e4ba50f9b8585312221"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-03T23:22:05.000Z",
           "commitDate": "2018-11-03T23:22:05.000Z",
@@ -13639,30 +12237,20 @@
         "implicitBranchNo": 2178,
         "seq": 15576,
         "isMergeCommit": false,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "5515f738608e383f5d103c754a2057cd2c6a87ee",
-          "parentIds": [
-            "aac7546ecfe0e5ee4e1c5fa94c75a420ece9b702"
-          ],
+          "parentIds": ["aac7546ecfe0e5ee4e1c5fa94c75a420ece9b702"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-04T17:02:00.000Z",
           "commitDate": "2018-11-04T17:02:00.000Z",
@@ -13689,30 +12277,20 @@
         "implicitBranchNo": 2178,
         "seq": 15577,
         "isMergeCommit": false,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "0cad92f957e09f796c49f13bc9b71adb50f0093a",
-          "parentIds": [
-            "5515f738608e383f5d103c754a2057cd2c6a87ee"
-          ],
+          "parentIds": ["5515f738608e383f5d103c754a2057cd2c6a87ee"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-04T17:22:30.000Z",
           "commitDate": "2018-11-04T17:22:30.000Z",
@@ -13731,30 +12309,20 @@
         "implicitBranchNo": 2178,
         "seq": 15578,
         "isMergeCommit": false,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "69a8eb6a571514a53e59207a915f2e161fe1513c",
-          "parentIds": [
-            "0cad92f957e09f796c49f13bc9b71adb50f0093a"
-          ],
+          "parentIds": ["0cad92f957e09f796c49f13bc9b71adb50f0093a"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-05T08:16:16.000Z",
           "commitDate": "2018-11-05T08:16:16.000Z",
@@ -13773,30 +12341,20 @@
         "implicitBranchNo": 2178,
         "seq": 15579,
         "isMergeCommit": false,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "ea89a1041cd97a5ddde5e628a05416283bfaf8dc",
-          "parentIds": [
-            "69a8eb6a571514a53e59207a915f2e161fe1513c"
-          ],
+          "parentIds": ["69a8eb6a571514a53e59207a915f2e161fe1513c"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-05T12:01:24.000Z",
           "commitDate": "2018-11-05T12:01:24.000Z",
@@ -13815,7 +12373,7 @@
         "implicitBranchNo": 2178,
         "seq": 15583,
         "isMergeCommit": false,
-        "taskId": 2441
+        "clusterId": 2441
       },
       {
         "nodeTypeName": "COMMIT",
@@ -13826,20 +12384,12 @@
             "ea89a1041cd97a5ddde5e628a05416283bfaf8dc"
           ],
           "author": {
-            "names": [
-              "G. Blake Meike "
-            ],
-            "emails": [
-              "blake.meike@gmail.com"
-            ]
+            "names": ["G. Blake Meike "],
+            "emails": ["blake.meike@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-05T15:19:50.000Z",
           "commitDate": "2018-11-05T15:19:50.000Z",
@@ -13906,7 +12456,7 @@
         "implicitBranchNo": 0,
         "seq": 15584,
         "isMergeCommit": true,
-        "taskId": 2441
+        "clusterId": 2441
       }
     ]
   },
@@ -13917,24 +12467,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "c1bdaee5a0dfcd3d00a95956c5ffefb016b277c9",
-          "parentIds": [
-            "9dfeb14ff6e0cea8f3f5a6418a778f22d1245be0"
-          ],
+          "parentIds": ["9dfeb14ff6e0cea8f3f5a6418a778f22d1245be0"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-05T15:32:48.000Z",
           "commitDate": "2018-11-05T15:32:48.000Z",
@@ -13953,7 +12493,7 @@
         "implicitBranchNo": 0,
         "seq": 15585,
         "isMergeCommit": false,
-        "taskId": 2442
+        "clusterId": 2442
       }
     ]
   },
@@ -13964,24 +12504,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "8eb8e966ef44b1fb54d6f96e1ac2c306ed141408",
-          "parentIds": [
-            "c1bdaee5a0dfcd3d00a95956c5ffefb016b277c9"
-          ],
+          "parentIds": ["c1bdaee5a0dfcd3d00a95956c5ffefb016b277c9"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-06T06:34:33.000Z",
           "commitDate": "2018-11-06T06:34:33.000Z",
@@ -14000,7 +12530,7 @@
         "implicitBranchNo": 0,
         "seq": 15588,
         "isMergeCommit": false,
-        "taskId": 2443
+        "clusterId": 2443
       }
     ]
   },
@@ -14016,20 +12546,12 @@
             "8eb8e966ef44b1fb54d6f96e1ac2c306ed141408"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2018-11-06T07:47:39.000Z",
           "commitDate": "2018-11-06T07:47:39.000Z",
@@ -14048,30 +12570,20 @@
         "implicitBranchNo": 2635,
         "seq": 15589,
         "isMergeCommit": true,
-        "taskId": 2444
+        "clusterId": 2444
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "197932e0ef3b6a262ee88099289d4acd04f7146e",
-          "parentIds": [
-            "c1bdaee5a0dfcd3d00a95956c5ffefb016b277c9"
-          ],
+          "parentIds": ["c1bdaee5a0dfcd3d00a95956c5ffefb016b277c9"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-06T11:04:46.000Z",
           "commitDate": "2018-11-06T11:04:46.000Z",
@@ -14098,7 +12610,7 @@
         "implicitBranchNo": 2634,
         "seq": 15591,
         "isMergeCommit": false,
-        "taskId": 2444
+        "clusterId": 2444
       },
       {
         "nodeTypeName": "COMMIT",
@@ -14109,20 +12621,12 @@
             "197932e0ef3b6a262ee88099289d4acd04f7146e"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2018-11-06T11:07:17.000Z",
           "commitDate": "2018-11-06T11:07:17.000Z",
@@ -14149,7 +12653,7 @@
         "implicitBranchNo": 2635,
         "seq": 15592,
         "isMergeCommit": true,
-        "taskId": 2444
+        "clusterId": 2444
       },
       {
         "nodeTypeName": "COMMIT",
@@ -14160,20 +12664,12 @@
             "dc14781a9d6cd263eedab724c01b584dc627c1eb"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-06T11:15:18.000Z",
           "commitDate": "2018-11-06T11:15:18.000Z",
@@ -14200,7 +12696,7 @@
         "implicitBranchNo": 0,
         "seq": 15594,
         "isMergeCommit": true,
-        "taskId": 2444
+        "clusterId": 2444
       }
     ]
   },
@@ -14211,24 +12707,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "0149bd13d393ee82720308cd2062c30dc3f5937c",
-          "parentIds": [
-            "479db183be3c9f7562de9be03232615cdc450c47"
-          ],
+          "parentIds": ["479db183be3c9f7562de9be03232615cdc450c47"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-06T12:07:25.000Z",
           "commitDate": "2018-11-06T12:07:25.000Z",
@@ -14247,30 +12733,20 @@
         "implicitBranchNo": 2637,
         "seq": 15596,
         "isMergeCommit": false,
-        "taskId": 2445
+        "clusterId": 2445
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "af96a6d6fc2480e0de5d9f65f96e75e13309d77c",
-          "parentIds": [
-            "0149bd13d393ee82720308cd2062c30dc3f5937c"
-          ],
+          "parentIds": ["0149bd13d393ee82720308cd2062c30dc3f5937c"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-06T12:07:53.000Z",
           "commitDate": "2018-11-06T12:07:53.000Z",
@@ -14289,30 +12765,20 @@
         "implicitBranchNo": 2637,
         "seq": 15597,
         "isMergeCommit": false,
-        "taskId": 2445
+        "clusterId": 2445
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "cdda26c30decf36cf196bc6dbe6785b740566be2",
-          "parentIds": [
-            "af96a6d6fc2480e0de5d9f65f96e75e13309d77c"
-          ],
+          "parentIds": ["af96a6d6fc2480e0de5d9f65f96e75e13309d77c"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-06T12:07:53.000Z",
           "commitDate": "2018-11-06T12:07:53.000Z",
@@ -14331,7 +12797,7 @@
         "implicitBranchNo": 2637,
         "seq": 15598,
         "isMergeCommit": false,
-        "taskId": 2445
+        "clusterId": 2445
       },
       {
         "nodeTypeName": "COMMIT",
@@ -14342,20 +12808,12 @@
             "cdda26c30decf36cf196bc6dbe6785b740566be2"
           ],
           "author": {
-            "names": [
-              "Realm CI "
-            ],
-            "emails": [
-              "robot@realm.io"
-            ]
+            "names": ["Realm CI "],
+            "emails": ["robot@realm.io"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2018-11-06T13:42:33.000Z",
           "commitDate": "2018-11-06T13:42:33.000Z",
@@ -14378,7 +12836,7 @@
         "implicitBranchNo": 0,
         "seq": 15599,
         "isMergeCommit": true,
-        "taskId": 2445
+        "clusterId": 2445
       }
     ]
   },
@@ -14389,24 +12847,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "6ac1cb44d230e760c3c3b6621a37f43c419465aa",
-          "parentIds": [
-            "97e0c8fef8d13f1be49409872b445873c2a44cf4"
-          ],
+          "parentIds": ["97e0c8fef8d13f1be49409872b445873c2a44cf4"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-06T16:17:02.000Z",
           "commitDate": "2018-11-06T16:17:02.000Z",
@@ -14425,7 +12873,7 @@
         "implicitBranchNo": 0,
         "seq": 15602,
         "isMergeCommit": false,
-        "taskId": 2446
+        "clusterId": 2446
       }
     ]
   },
@@ -14436,24 +12884,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "a08e788a10b845ea70b60b66bedc7c8cedca66d3",
-          "parentIds": [
-            "6ac1cb44d230e760c3c3b6621a37f43c419465aa"
-          ],
+          "parentIds": ["6ac1cb44d230e760c3c3b6621a37f43c419465aa"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-06T22:36:21.000Z",
           "commitDate": "2018-11-06T22:36:21.000Z",
@@ -14472,7 +12910,7 @@
         "implicitBranchNo": 0,
         "seq": 15604,
         "isMergeCommit": false,
-        "taskId": 2447
+        "clusterId": 2447
       }
     ]
   },
@@ -14483,24 +12921,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "98c57fee446c932e6b231d3e5736c7407005e7e5",
-          "parentIds": [
-            "a08e788a10b845ea70b60b66bedc7c8cedca66d3"
-          ],
+          "parentIds": ["a08e788a10b845ea70b60b66bedc7c8cedca66d3"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-11-09T09:48:54.000Z",
           "commitDate": "2018-11-09T09:48:54.000Z",
@@ -14519,7 +12947,7 @@
         "implicitBranchNo": 2641,
         "seq": 15606,
         "isMergeCommit": false,
-        "taskId": 2448
+        "clusterId": 2448
       },
       {
         "nodeTypeName": "COMMIT",
@@ -14530,20 +12958,12 @@
             "98c57fee446c932e6b231d3e5736c7407005e7e5"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2018-11-10T00:22:15.000Z",
           "commitDate": "2018-11-10T00:22:15.000Z",
@@ -14562,7 +12982,7 @@
         "implicitBranchNo": 0,
         "seq": 15607,
         "isMergeCommit": true,
-        "taskId": 2448
+        "clusterId": 2448
       }
     ]
   },
@@ -14573,24 +12993,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "72b87276e953d0af782760d69d439af6f9eb1fc9",
-          "parentIds": [
-            "cdda26c30decf36cf196bc6dbe6785b740566be2"
-          ],
+          "parentIds": ["cdda26c30decf36cf196bc6dbe6785b740566be2"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2018-12-19T08:51:55.000Z",
           "commitDate": "2018-12-19T08:51:55.000Z",
@@ -14617,30 +13027,20 @@
         "implicitBranchNo": 2639,
         "seq": 15611,
         "isMergeCommit": false,
-        "taskId": 2449
+        "clusterId": 2449
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "d4414b6736fea505ab9bce3cfe549d87868f5c31",
-          "parentIds": [
-            "cdda26c30decf36cf196bc6dbe6785b740566be2"
-          ],
+          "parentIds": ["cdda26c30decf36cf196bc6dbe6785b740566be2"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-03T11:50:12.000Z",
           "commitDate": "2019-01-03T11:50:12.000Z",
@@ -14691,30 +13091,20 @@
         "implicitBranchNo": 2638,
         "seq": 15612,
         "isMergeCommit": false,
-        "taskId": 2449
+        "clusterId": 2449
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "084d9e003464a6790a6d62a6ed71c2aa3ddc8dcd",
-          "parentIds": [
-            "d4414b6736fea505ab9bce3cfe549d87868f5c31"
-          ],
+          "parentIds": ["d4414b6736fea505ab9bce3cfe549d87868f5c31"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-04T09:08:58.000Z",
           "commitDate": "2019-01-04T09:08:58.000Z",
@@ -14733,30 +13123,20 @@
         "implicitBranchNo": 2638,
         "seq": 15613,
         "isMergeCommit": false,
-        "taskId": 2449
+        "clusterId": 2449
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "7b5a846a2cb32bd9ab522bba00789bdd4dc687ee",
-          "parentIds": [
-            "084d9e003464a6790a6d62a6ed71c2aa3ddc8dcd"
-          ],
+          "parentIds": ["084d9e003464a6790a6d62a6ed71c2aa3ddc8dcd"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-04T09:45:50.000Z",
           "commitDate": "2019-01-04T09:45:50.000Z",
@@ -14783,30 +13163,20 @@
         "implicitBranchNo": 2638,
         "seq": 15614,
         "isMergeCommit": false,
-        "taskId": 2449
+        "clusterId": 2449
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "d1039926368818f60c0dfc7d07296642e9c8b642",
-          "parentIds": [
-            "7b5a846a2cb32bd9ab522bba00789bdd4dc687ee"
-          ],
+          "parentIds": ["7b5a846a2cb32bd9ab522bba00789bdd4dc687ee"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-04T13:02:07.000Z",
           "commitDate": "2019-01-04T13:02:07.000Z",
@@ -14833,30 +13203,20 @@
         "implicitBranchNo": 2638,
         "seq": 15615,
         "isMergeCommit": false,
-        "taskId": 2449
+        "clusterId": 2449
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "3a3c90ff0b189a54a5a3760ecd56c8a2e94f8264",
-          "parentIds": [
-            "d1039926368818f60c0dfc7d07296642e9c8b642"
-          ],
+          "parentIds": ["d1039926368818f60c0dfc7d07296642e9c8b642"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-04T14:40:51.000Z",
           "commitDate": "2019-01-04T14:40:51.000Z",
@@ -14875,30 +13235,20 @@
         "implicitBranchNo": 2638,
         "seq": 15616,
         "isMergeCommit": false,
-        "taskId": 2449
+        "clusterId": 2449
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "b0e315e62bda8278d66ccbcd45e00f2a7fbf329a",
-          "parentIds": [
-            "3a3c90ff0b189a54a5a3760ecd56c8a2e94f8264"
-          ],
+          "parentIds": ["3a3c90ff0b189a54a5a3760ecd56c8a2e94f8264"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-06T23:44:37.000Z",
           "commitDate": "2019-01-06T23:44:37.000Z",
@@ -14917,30 +13267,20 @@
         "implicitBranchNo": 2638,
         "seq": 15617,
         "isMergeCommit": false,
-        "taskId": 2449
+        "clusterId": 2449
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "4c57d731c0dbee64eab089e7c40ca770cd1aa104",
-          "parentIds": [
-            "b0e315e62bda8278d66ccbcd45e00f2a7fbf329a"
-          ],
+          "parentIds": ["b0e315e62bda8278d66ccbcd45e00f2a7fbf329a"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-07T16:11:33.000Z",
           "commitDate": "2019-01-07T16:11:33.000Z",
@@ -14963,30 +13303,20 @@
         "implicitBranchNo": 2638,
         "seq": 15618,
         "isMergeCommit": false,
-        "taskId": 2449
+        "clusterId": 2449
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "030051915058ecb8e9f5c5a6503d1253c5cdd414",
-          "parentIds": [
-            "4c57d731c0dbee64eab089e7c40ca770cd1aa104"
-          ],
+          "parentIds": ["4c57d731c0dbee64eab089e7c40ca770cd1aa104"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-07T16:31:32.000Z",
           "commitDate": "2019-01-07T16:31:32.000Z",
@@ -15005,30 +13335,20 @@
         "implicitBranchNo": 2638,
         "seq": 15619,
         "isMergeCommit": false,
-        "taskId": 2449
+        "clusterId": 2449
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "9c24ec341d84c2dfcc7da02c693aee0edefc2cf7",
-          "parentIds": [
-            "030051915058ecb8e9f5c5a6503d1253c5cdd414"
-          ],
+          "parentIds": ["030051915058ecb8e9f5c5a6503d1253c5cdd414"],
           "author": {
-            "names": [
-              "Kenneth Geisshirt "
-            ],
-            "emails": [
-              "geisshirt@gmail.com"
-            ]
+            "names": ["Kenneth Geisshirt "],
+            "emails": ["geisshirt@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-01-09T09:48:33.000Z",
           "commitDate": "2019-01-09T09:48:33.000Z",
@@ -15047,7 +13367,7 @@
         "implicitBranchNo": 2638,
         "seq": 15620,
         "isMergeCommit": false,
-        "taskId": 2449
+        "clusterId": 2449
       },
       {
         "nodeTypeName": "COMMIT",
@@ -15058,20 +13378,12 @@
             "72b87276e953d0af782760d69d439af6f9eb1fc9"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-01-10T07:59:54.000Z",
           "commitDate": "2019-01-10T07:59:54.000Z",
@@ -15098,30 +13410,20 @@
         "implicitBranchNo": 2637,
         "seq": 15621,
         "isMergeCommit": true,
-        "taskId": 2449
+        "clusterId": 2449
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "7abca7ca5a1d081ef6ea9793fbd0b7d6e066a8ec",
-          "parentIds": [
-            "a5710890dbf34351e1c93cd9ccda557574f93270"
-          ],
+          "parentIds": ["a5710890dbf34351e1c93cd9ccda557574f93270"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-10T09:12:22.000Z",
           "commitDate": "2019-01-10T09:12:22.000Z",
@@ -15144,30 +13446,20 @@
         "implicitBranchNo": 2643,
         "seq": 15622,
         "isMergeCommit": false,
-        "taskId": 2449
+        "clusterId": 2449
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "448832943f818ff2d5e1e065376666e28832120b",
-          "parentIds": [
-            "7abca7ca5a1d081ef6ea9793fbd0b7d6e066a8ec"
-          ],
+          "parentIds": ["7abca7ca5a1d081ef6ea9793fbd0b7d6e066a8ec"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-10T09:35:21.000Z",
           "commitDate": "2019-01-10T09:35:21.000Z",
@@ -15186,30 +13478,20 @@
         "implicitBranchNo": 2643,
         "seq": 15623,
         "isMergeCommit": false,
-        "taskId": 2449
+        "clusterId": 2449
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "90a137161a6cdc9bca5fd7e9153803b156ee0e7a",
-          "parentIds": [
-            "448832943f818ff2d5e1e065376666e28832120b"
-          ],
+          "parentIds": ["448832943f818ff2d5e1e065376666e28832120b"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-10T10:34:05.000Z",
           "commitDate": "2019-01-10T10:34:05.000Z",
@@ -15232,30 +13514,20 @@
         "implicitBranchNo": 2643,
         "seq": 15624,
         "isMergeCommit": false,
-        "taskId": 2449
+        "clusterId": 2449
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "e360a92b0d40b33ed92e232abaa50827839f1207",
-          "parentIds": [
-            "90a137161a6cdc9bca5fd7e9153803b156ee0e7a"
-          ],
+          "parentIds": ["90a137161a6cdc9bca5fd7e9153803b156ee0e7a"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-10T12:23:13.000Z",
           "commitDate": "2019-01-10T12:23:13.000Z",
@@ -15278,7 +13550,7 @@
         "implicitBranchNo": 2643,
         "seq": 15625,
         "isMergeCommit": false,
-        "taskId": 2449
+        "clusterId": 2449
       },
       {
         "nodeTypeName": "COMMIT",
@@ -15289,20 +13561,12 @@
             "e360a92b0d40b33ed92e232abaa50827839f1207"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-01-10T13:13:54.000Z",
           "commitDate": "2019-01-10T13:13:54.000Z",
@@ -15329,7 +13593,7 @@
         "implicitBranchNo": 2637,
         "seq": 15626,
         "isMergeCommit": true,
-        "taskId": 2449
+        "clusterId": 2449
       },
       {
         "nodeTypeName": "COMMIT",
@@ -15340,20 +13604,12 @@
             "314d9af4c8ea0a9fba55ad0eb6d870b5ec071f33"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-11T09:07:04.000Z",
           "commitDate": "2019-01-11T09:07:04.000Z",
@@ -15380,30 +13636,20 @@
         "implicitBranchNo": 2638,
         "seq": 15627,
         "isMergeCommit": true,
-        "taskId": 2449
+        "clusterId": 2449
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "10d8e9e591df8ed548f224b90c1e7d4ccedd3e14",
-          "parentIds": [
-            "01c64c072cd6e1b1b7c6dfd447d91ab865be324e"
-          ],
+          "parentIds": ["01c64c072cd6e1b1b7c6dfd447d91ab865be324e"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-11T09:36:43.000Z",
           "commitDate": "2019-01-11T09:36:43.000Z",
@@ -15422,7 +13668,7 @@
         "implicitBranchNo": 2638,
         "seq": 15628,
         "isMergeCommit": false,
-        "taskId": 2449
+        "clusterId": 2449
       },
       {
         "nodeTypeName": "COMMIT",
@@ -15433,20 +13679,12 @@
             "0d7b596abdf84dc213230cffc4d3fb8da3db2397"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-11T09:38:01.000Z",
           "commitDate": "2019-01-11T09:38:01.000Z",
@@ -15481,30 +13719,20 @@
         "implicitBranchNo": 2638,
         "seq": 15629,
         "isMergeCommit": true,
-        "taskId": 2449
+        "clusterId": 2449
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "bcba8edfcf7fb3ea52f6b63c018ee13896b467eb",
-          "parentIds": [
-            "1d05f0451b17351bfd1d0cdc5e85025868e7a1ac"
-          ],
+          "parentIds": ["1d05f0451b17351bfd1d0cdc5e85025868e7a1ac"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-14T14:05:05.000Z",
           "commitDate": "2019-01-14T14:05:05.000Z",
@@ -15523,30 +13751,20 @@
         "implicitBranchNo": 2638,
         "seq": 15630,
         "isMergeCommit": false,
-        "taskId": 2449
+        "clusterId": 2449
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "cb1e0f894213889f0b5e0502b62ff25eee683eb6",
-          "parentIds": [
-            "bcba8edfcf7fb3ea52f6b63c018ee13896b467eb"
-          ],
+          "parentIds": ["bcba8edfcf7fb3ea52f6b63c018ee13896b467eb"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-14T21:52:21.000Z",
           "commitDate": "2019-01-14T21:52:21.000Z",
@@ -15565,7 +13783,7 @@
         "implicitBranchNo": 2638,
         "seq": 15631,
         "isMergeCommit": false,
-        "taskId": 2449
+        "clusterId": 2449
       },
       {
         "nodeTypeName": "COMMIT",
@@ -15576,20 +13794,12 @@
             "cb1e0f894213889f0b5e0502b62ff25eee683eb6"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-01-15T08:35:15.000Z",
           "commitDate": "2019-01-15T08:35:15.000Z",
@@ -15660,7 +13870,7 @@
         "implicitBranchNo": 0,
         "seq": 15632,
         "isMergeCommit": true,
-        "taskId": 2449
+        "clusterId": 2449
       }
     ]
   },
@@ -15676,20 +13886,12 @@
             "22e9550594c0a2469d0bc62c5e85ac24f2fae130"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-15T13:02:33.000Z",
           "commitDate": "2019-01-15T13:02:33.000Z",
@@ -15756,30 +13958,20 @@
         "implicitBranchNo": 2637,
         "seq": 15634,
         "isMergeCommit": true,
-        "taskId": 2450
+        "clusterId": 2450
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "9ac616d49fb804411b834216b1ebfa37a358a84b",
-          "parentIds": [
-            "782dc8a80e14718a5f4689a342c73c766b9ee3ef"
-          ],
+          "parentIds": ["782dc8a80e14718a5f4689a342c73c766b9ee3ef"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-15T13:03:48.000Z",
           "commitDate": "2019-01-15T13:03:48.000Z",
@@ -15802,30 +13994,20 @@
         "implicitBranchNo": 2637,
         "seq": 15635,
         "isMergeCommit": false,
-        "taskId": 2450
+        "clusterId": 2450
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "f1bf0965f6288876d06872c39a5d786d3c72d658",
-          "parentIds": [
-            "9ac616d49fb804411b834216b1ebfa37a358a84b"
-          ],
+          "parentIds": ["9ac616d49fb804411b834216b1ebfa37a358a84b"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-15T13:11:38.000Z",
           "commitDate": "2019-01-15T13:11:38.000Z",
@@ -15844,30 +14026,20 @@
         "implicitBranchNo": 2637,
         "seq": 15636,
         "isMergeCommit": false,
-        "taskId": 2450
+        "clusterId": 2450
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "4a16aa85c103f521dac46220908d1cda70407db0",
-          "parentIds": [
-            "f1bf0965f6288876d06872c39a5d786d3c72d658"
-          ],
+          "parentIds": ["f1bf0965f6288876d06872c39a5d786d3c72d658"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-15T13:11:38.000Z",
           "commitDate": "2019-01-15T13:11:38.000Z",
@@ -15886,7 +14058,7 @@
         "implicitBranchNo": 2637,
         "seq": 15637,
         "isMergeCommit": false,
-        "taskId": 2450
+        "clusterId": 2450
       },
       {
         "nodeTypeName": "COMMIT",
@@ -15897,20 +14069,12 @@
             "4a16aa85c103f521dac46220908d1cda70407db0"
           ],
           "author": {
-            "names": [
-              "Realm CI "
-            ],
-            "emails": [
-              "robot@realm.io"
-            ]
+            "names": ["Realm CI "],
+            "emails": ["robot@realm.io"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-01-15T14:05:24.000Z",
           "commitDate": "2019-01-15T14:05:24.000Z",
@@ -15933,7 +14097,7 @@
         "implicitBranchNo": 0,
         "seq": 15638,
         "isMergeCommit": true,
-        "taskId": 2450
+        "clusterId": 2450
       }
     ]
   },
@@ -15944,24 +14108,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "c52ac04cab8e62049106c84af6b435e8546f113d",
-          "parentIds": [
-            "2d87e121ed9558dc55d515fdf7e1708db516a3dc"
-          ],
+          "parentIds": ["2d87e121ed9558dc55d515fdf7e1708db516a3dc"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-15T14:10:58.000Z",
           "commitDate": "2019-01-15T14:10:58.000Z",
@@ -15980,7 +14134,7 @@
         "implicitBranchNo": 0,
         "seq": 15639,
         "isMergeCommit": false,
-        "taskId": 2451
+        "clusterId": 2451
       }
     ]
   },
@@ -15991,24 +14145,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "11d0732ce2b55e283436a6eedbbbed74632ddb77",
-          "parentIds": [
-            "c52ac04cab8e62049106c84af6b435e8546f113d"
-          ],
+          "parentIds": ["c52ac04cab8e62049106c84af6b435e8546f113d"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-01-15T15:05:11.000Z",
           "commitDate": "2019-01-15T15:05:11.000Z",
@@ -16027,7 +14171,7 @@
         "implicitBranchNo": 0,
         "seq": 15640,
         "isMergeCommit": false,
-        "taskId": 2452
+        "clusterId": 2452
       }
     ]
   },
@@ -16038,24 +14182,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "1b498b30e7c4faf7f86c0ea31a06cccefd6a3049",
-          "parentIds": [
-            "11d0732ce2b55e283436a6eedbbbed74632ddb77"
-          ],
+          "parentIds": ["11d0732ce2b55e283436a6eedbbbed74632ddb77"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-27T22:21:52.000Z",
           "commitDate": "2019-01-27T22:21:52.000Z",
@@ -16114,30 +14248,20 @@
         "implicitBranchNo": 2647,
         "seq": 15641,
         "isMergeCommit": false,
-        "taskId": 2453
+        "clusterId": 2453
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "0cd0b9752cb04d46120265687caecc04a442f0ed",
-          "parentIds": [
-            "1b498b30e7c4faf7f86c0ea31a06cccefd6a3049"
-          ],
+          "parentIds": ["1b498b30e7c4faf7f86c0ea31a06cccefd6a3049"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-28T07:10:47.000Z",
           "commitDate": "2019-01-28T07:10:47.000Z",
@@ -16164,30 +14288,20 @@
         "implicitBranchNo": 2647,
         "seq": 15642,
         "isMergeCommit": false,
-        "taskId": 2453
+        "clusterId": 2453
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "332cf2bc4625c7b1752e30567c4ae36ca3c5780c",
-          "parentIds": [
-            "0cd0b9752cb04d46120265687caecc04a442f0ed"
-          ],
+          "parentIds": ["0cd0b9752cb04d46120265687caecc04a442f0ed"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-28T07:32:57.000Z",
           "commitDate": "2019-01-28T07:32:57.000Z",
@@ -16206,30 +14320,20 @@
         "implicitBranchNo": 2647,
         "seq": 15643,
         "isMergeCommit": false,
-        "taskId": 2453
+        "clusterId": 2453
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "e1a10adc8b28c66310e714cf93b82cd1be70db85",
-          "parentIds": [
-            "332cf2bc4625c7b1752e30567c4ae36ca3c5780c"
-          ],
+          "parentIds": ["332cf2bc4625c7b1752e30567c4ae36ca3c5780c"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-28T07:41:32.000Z",
           "commitDate": "2019-01-28T07:41:32.000Z",
@@ -16248,30 +14352,20 @@
         "implicitBranchNo": 2647,
         "seq": 15644,
         "isMergeCommit": false,
-        "taskId": 2453
+        "clusterId": 2453
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "6ee512613ca4f24eb516e1cc194b7659f5268d08",
-          "parentIds": [
-            "e1a10adc8b28c66310e714cf93b82cd1be70db85"
-          ],
+          "parentIds": ["e1a10adc8b28c66310e714cf93b82cd1be70db85"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-28T07:59:32.000Z",
           "commitDate": "2019-01-28T07:59:32.000Z",
@@ -16290,30 +14384,20 @@
         "implicitBranchNo": 2647,
         "seq": 15645,
         "isMergeCommit": false,
-        "taskId": 2453
+        "clusterId": 2453
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "c08893adcaa7afd8dbedea54d710f2284ec904a3",
-          "parentIds": [
-            "6ee512613ca4f24eb516e1cc194b7659f5268d08"
-          ],
+          "parentIds": ["6ee512613ca4f24eb516e1cc194b7659f5268d08"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-29T11:41:37.000Z",
           "commitDate": "2019-01-29T11:41:37.000Z",
@@ -16340,30 +14424,20 @@
         "implicitBranchNo": 2647,
         "seq": 15646,
         "isMergeCommit": false,
-        "taskId": 2453
+        "clusterId": 2453
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "2315df24e36f779dc4fa4cd0e0cf6110db207f54",
-          "parentIds": [
-            "c08893adcaa7afd8dbedea54d710f2284ec904a3"
-          ],
+          "parentIds": ["c08893adcaa7afd8dbedea54d710f2284ec904a3"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-01-31T06:43:38.000Z",
           "commitDate": "2019-01-31T06:43:38.000Z",
@@ -16382,30 +14456,20 @@
         "implicitBranchNo": 2647,
         "seq": 15647,
         "isMergeCommit": false,
-        "taskId": 2453
+        "clusterId": 2453
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "87f533fe07026e4bc5f1ff4f3e7ce969e8a583a5",
-          "parentIds": [
-            "2315df24e36f779dc4fa4cd0e0cf6110db207f54"
-          ],
+          "parentIds": ["2315df24e36f779dc4fa4cd0e0cf6110db207f54"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-01-31T17:34:02.000Z",
           "commitDate": "2019-01-31T17:34:02.000Z",
@@ -16440,7 +14504,7 @@
         "implicitBranchNo": 2647,
         "seq": 15648,
         "isMergeCommit": false,
-        "taskId": 2453
+        "clusterId": 2453
       },
       {
         "nodeTypeName": "COMMIT",
@@ -16451,20 +14515,12 @@
             "87f533fe07026e4bc5f1ff4f3e7ce969e8a583a5"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-02-05T09:07:28.000Z",
           "commitDate": "2019-02-05T09:07:28.000Z",
@@ -16535,7 +14591,7 @@
         "implicitBranchNo": 0,
         "seq": 15649,
         "isMergeCommit": true,
-        "taskId": 2453
+        "clusterId": 2453
       }
     ]
   },
@@ -16546,24 +14602,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "fbf99a4c31088f90dc8578b9c05ee1c9ae385fdd",
-          "parentIds": [
-            "4a16aa85c103f521dac46220908d1cda70407db0"
-          ],
+          "parentIds": ["4a16aa85c103f521dac46220908d1cda70407db0"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-21T08:50:50.000Z",
           "commitDate": "2019-02-21T08:50:50.000Z",
@@ -16590,30 +14636,20 @@
         "implicitBranchNo": 2644,
         "seq": 15653,
         "isMergeCommit": false,
-        "taskId": 2454
+        "clusterId": 2454
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "73ec4d5d62ac815c91314fbf8cd336424797db6a",
-          "parentIds": [
-            "fbf99a4c31088f90dc8578b9c05ee1c9ae385fdd"
-          ],
+          "parentIds": ["fbf99a4c31088f90dc8578b9c05ee1c9ae385fdd"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-21T09:39:03.000Z",
           "commitDate": "2019-02-21T09:39:03.000Z",
@@ -16636,30 +14672,20 @@
         "implicitBranchNo": 2644,
         "seq": 15654,
         "isMergeCommit": false,
-        "taskId": 2454
+        "clusterId": 2454
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "052d1dc20cd2cca9aa8fef2c270732084591cfe1",
-          "parentIds": [
-            "73ec4d5d62ac815c91314fbf8cd336424797db6a"
-          ],
+          "parentIds": ["73ec4d5d62ac815c91314fbf8cd336424797db6a"],
           "author": {
-            "names": [
-              "Kenneth Geisshirt "
-            ],
-            "emails": [
-              "geisshirt@gmail.com"
-            ]
+            "names": ["Kenneth Geisshirt "],
+            "emails": ["geisshirt@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-02-21T10:31:52.000Z",
           "commitDate": "2019-02-21T10:31:52.000Z",
@@ -16678,7 +14704,7 @@
         "implicitBranchNo": 2644,
         "seq": 15655,
         "isMergeCommit": false,
-        "taskId": 2454
+        "clusterId": 2454
       },
       {
         "nodeTypeName": "COMMIT",
@@ -16689,20 +14715,12 @@
             "052d1dc20cd2cca9aa8fef2c270732084591cfe1"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-02-21T10:32:08.000Z",
           "commitDate": "2019-02-21T10:32:08.000Z",
@@ -16725,30 +14743,20 @@
         "implicitBranchNo": 2637,
         "seq": 15656,
         "isMergeCommit": true,
-        "taskId": 2454
+        "clusterId": 2454
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "f42c5f2569d805d1705389b99250819267598280",
-          "parentIds": [
-            "1ba9dbb972395fdfbfe26f3c5783f83b629eaf85"
-          ],
+          "parentIds": ["1ba9dbb972395fdfbfe26f3c5783f83b629eaf85"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-21T10:36:13.000Z",
           "commitDate": "2019-02-21T10:36:13.000Z",
@@ -16767,30 +14775,20 @@
         "implicitBranchNo": 2637,
         "seq": 15657,
         "isMergeCommit": false,
-        "taskId": 2454
+        "clusterId": 2454
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "5ec48197edd9ef66861374e8523e9f3a6281b352",
-          "parentIds": [
-            "f42c5f2569d805d1705389b99250819267598280"
-          ],
+          "parentIds": ["f42c5f2569d805d1705389b99250819267598280"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-21T10:36:47.000Z",
           "commitDate": "2019-02-21T10:36:47.000Z",
@@ -16809,30 +14807,20 @@
         "implicitBranchNo": 2637,
         "seq": 15658,
         "isMergeCommit": false,
-        "taskId": 2454
+        "clusterId": 2454
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "609b3a9c75ce81336e7a14f925ee601b4cb2bfe5",
-          "parentIds": [
-            "5ec48197edd9ef66861374e8523e9f3a6281b352"
-          ],
+          "parentIds": ["5ec48197edd9ef66861374e8523e9f3a6281b352"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-21T10:36:48.000Z",
           "commitDate": "2019-02-21T10:36:48.000Z",
@@ -16851,7 +14839,7 @@
         "implicitBranchNo": 2637,
         "seq": 15659,
         "isMergeCommit": false,
-        "taskId": 2454
+        "clusterId": 2454
       },
       {
         "nodeTypeName": "COMMIT",
@@ -16862,20 +14850,12 @@
             "609b3a9c75ce81336e7a14f925ee601b4cb2bfe5"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-22T16:13:56.000Z",
           "commitDate": "2019-02-22T16:13:56.000Z",
@@ -16902,7 +14882,7 @@
         "implicitBranchNo": 0,
         "seq": 15660,
         "isMergeCommit": true,
-        "taskId": 2454
+        "clusterId": 2454
       }
     ]
   },
@@ -16913,24 +14893,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "ad6281a78bd9dc0a0b722c89b9cc0873a7142531",
-          "parentIds": [
-            "609b3a9c75ce81336e7a14f925ee601b4cb2bfe5"
-          ],
+          "parentIds": ["609b3a9c75ce81336e7a14f925ee601b4cb2bfe5"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-28T12:54:23.000Z",
           "commitDate": "2019-02-28T12:54:23.000Z",
@@ -16949,30 +14919,20 @@
         "implicitBranchNo": 2649,
         "seq": 15677,
         "isMergeCommit": false,
-        "taskId": 2455
+        "clusterId": 2455
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "58baa25fc183b19a2bf6a2d292cf3da955a39995",
-          "parentIds": [
-            "ad6281a78bd9dc0a0b722c89b9cc0873a7142531"
-          ],
+          "parentIds": ["ad6281a78bd9dc0a0b722c89b9cc0873a7142531"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-28T12:57:08.000Z",
           "commitDate": "2019-02-28T12:57:08.000Z",
@@ -16991,7 +14951,7 @@
         "implicitBranchNo": 2649,
         "seq": 15678,
         "isMergeCommit": false,
-        "taskId": 2455
+        "clusterId": 2455
       },
       {
         "nodeTypeName": "COMMIT",
@@ -17002,20 +14962,12 @@
             "58baa25fc183b19a2bf6a2d292cf3da955a39995"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-02-28T13:51:22.000Z",
           "commitDate": "2019-02-28T13:51:22.000Z",
@@ -17038,7 +14990,7 @@
         "implicitBranchNo": 2637,
         "seq": 15679,
         "isMergeCommit": true,
-        "taskId": 2455
+        "clusterId": 2455
       },
       {
         "nodeTypeName": "COMMIT",
@@ -17049,20 +15001,12 @@
             "2ee87b598340231bede0f2dc8ad27bb5cca7b098"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-28T13:53:35.000Z",
           "commitDate": "2019-02-28T13:53:35.000Z",
@@ -17085,7 +15029,7 @@
         "implicitBranchNo": 0,
         "seq": 15680,
         "isMergeCommit": true,
-        "taskId": 2455
+        "clusterId": 2455
       }
     ]
   },
@@ -17096,24 +15040,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "338a4d72e8724b5e7df0ac512fd9b079c1c314e7",
-          "parentIds": [
-            "609b3a9c75ce81336e7a14f925ee601b4cb2bfe5"
-          ],
+          "parentIds": ["609b3a9c75ce81336e7a14f925ee601b4cb2bfe5"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-25T22:00:57.000Z",
           "commitDate": "2019-02-25T22:00:57.000Z",
@@ -17244,30 +15178,20 @@
         "implicitBranchNo": 2650,
         "seq": 15661,
         "isMergeCommit": false,
-        "taskId": 2456
+        "clusterId": 2456
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "26b8734d7e0634d9aa6f53f2af312d5eb5b95a96",
-          "parentIds": [
-            "338a4d72e8724b5e7df0ac512fd9b079c1c314e7"
-          ],
+          "parentIds": ["338a4d72e8724b5e7df0ac512fd9b079c1c314e7"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-26T08:39:26.000Z",
           "commitDate": "2019-02-26T08:39:26.000Z",
@@ -17286,30 +15210,20 @@
         "implicitBranchNo": 2650,
         "seq": 15662,
         "isMergeCommit": false,
-        "taskId": 2456
+        "clusterId": 2456
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "3357427330adebbff73ffead08664af059d2917a",
-          "parentIds": [
-            "26b8734d7e0634d9aa6f53f2af312d5eb5b95a96"
-          ],
+          "parentIds": ["26b8734d7e0634d9aa6f53f2af312d5eb5b95a96"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-26T08:48:14.000Z",
           "commitDate": "2019-02-26T08:48:14.000Z",
@@ -17328,30 +15242,20 @@
         "implicitBranchNo": 2650,
         "seq": 15663,
         "isMergeCommit": false,
-        "taskId": 2456
+        "clusterId": 2456
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "f1f3c2992468eeea9002bfe96e5367fdd09d1406",
-          "parentIds": [
-            "3357427330adebbff73ffead08664af059d2917a"
-          ],
+          "parentIds": ["3357427330adebbff73ffead08664af059d2917a"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-26T13:37:34.000Z",
           "commitDate": "2019-02-26T13:37:34.000Z",
@@ -17370,30 +15274,20 @@
         "implicitBranchNo": 2650,
         "seq": 15664,
         "isMergeCommit": false,
-        "taskId": 2456
+        "clusterId": 2456
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "e8f073c83db4585daf86d28807e890af16a53984",
-          "parentIds": [
-            "f1f3c2992468eeea9002bfe96e5367fdd09d1406"
-          ],
+          "parentIds": ["f1f3c2992468eeea9002bfe96e5367fdd09d1406"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-02-27T08:40:53.000Z",
           "commitDate": "2019-02-27T08:40:53.000Z",
@@ -17412,30 +15306,20 @@
         "implicitBranchNo": 2652,
         "seq": 15665,
         "isMergeCommit": false,
-        "taskId": 2456
+        "clusterId": 2456
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "7f956af8ae7b3d90086ab717971e6bc50b6277ac",
-          "parentIds": [
-            "f1f3c2992468eeea9002bfe96e5367fdd09d1406"
-          ],
+          "parentIds": ["f1f3c2992468eeea9002bfe96e5367fdd09d1406"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-27T12:16:34.000Z",
           "commitDate": "2019-02-27T12:16:34.000Z",
@@ -17482,7 +15366,7 @@
         "implicitBranchNo": 2650,
         "seq": 15666,
         "isMergeCommit": false,
-        "taskId": 2456
+        "clusterId": 2456
       },
       {
         "nodeTypeName": "COMMIT",
@@ -17493,20 +15377,12 @@
             "e8f073c83db4585daf86d28807e890af16a53984"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-27T12:16:55.000Z",
           "commitDate": "2019-02-27T12:16:55.000Z",
@@ -17525,30 +15401,20 @@
         "implicitBranchNo": 2650,
         "seq": 15667,
         "isMergeCommit": true,
-        "taskId": 2456
+        "clusterId": 2456
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "2175ae50858c5691cba44ba3aac11e4b5bfd40bf",
-          "parentIds": [
-            "b96f4e5474775fbac2d52b9e352b218adb39d1ba"
-          ],
+          "parentIds": ["b96f4e5474775fbac2d52b9e352b218adb39d1ba"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-27T12:18:04.000Z",
           "commitDate": "2019-02-27T12:18:04.000Z",
@@ -17567,30 +15433,20 @@
         "implicitBranchNo": 2650,
         "seq": 15668,
         "isMergeCommit": false,
-        "taskId": 2456
+        "clusterId": 2456
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "0b7dd4961dccb6f1ad3ff5915b69fec2ecddee5d",
-          "parentIds": [
-            "2175ae50858c5691cba44ba3aac11e4b5bfd40bf"
-          ],
+          "parentIds": ["2175ae50858c5691cba44ba3aac11e4b5bfd40bf"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-27T13:45:47.000Z",
           "commitDate": "2019-02-27T13:45:47.000Z",
@@ -17661,30 +15517,20 @@
         "implicitBranchNo": 2650,
         "seq": 15669,
         "isMergeCommit": false,
-        "taskId": 2456
+        "clusterId": 2456
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "c9862b040dd65a0ba2a002c3cc21168f9e82a87e",
-          "parentIds": [
-            "0b7dd4961dccb6f1ad3ff5915b69fec2ecddee5d"
-          ],
+          "parentIds": ["0b7dd4961dccb6f1ad3ff5915b69fec2ecddee5d"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-27T14:21:40.000Z",
           "commitDate": "2019-02-27T14:21:40.000Z",
@@ -17703,30 +15549,20 @@
         "implicitBranchNo": 2650,
         "seq": 15670,
         "isMergeCommit": false,
-        "taskId": 2456
+        "clusterId": 2456
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "4887446a2e85d5f22e729b509d798063deb41165",
-          "parentIds": [
-            "c9862b040dd65a0ba2a002c3cc21168f9e82a87e"
-          ],
+          "parentIds": ["c9862b040dd65a0ba2a002c3cc21168f9e82a87e"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-27T21:29:59.000Z",
           "commitDate": "2019-02-27T21:29:59.000Z",
@@ -17745,30 +15581,20 @@
         "implicitBranchNo": 2650,
         "seq": 15671,
         "isMergeCommit": false,
-        "taskId": 2456
+        "clusterId": 2456
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "d86c2638d7b4484ec072237f1a9c6b57428a5b81",
-          "parentIds": [
-            "4887446a2e85d5f22e729b509d798063deb41165"
-          ],
+          "parentIds": ["4887446a2e85d5f22e729b509d798063deb41165"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-28T09:44:07.000Z",
           "commitDate": "2019-02-28T09:44:07.000Z",
@@ -17803,30 +15629,20 @@
         "implicitBranchNo": 2650,
         "seq": 15674,
         "isMergeCommit": false,
-        "taskId": 2456
+        "clusterId": 2456
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "52983e3903f6518e2610a3dbcab14c155eabb30c",
-          "parentIds": [
-            "d86c2638d7b4484ec072237f1a9c6b57428a5b81"
-          ],
+          "parentIds": ["d86c2638d7b4484ec072237f1a9c6b57428a5b81"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-28T11:49:50.000Z",
           "commitDate": "2019-02-28T11:49:50.000Z",
@@ -17845,30 +15661,20 @@
         "implicitBranchNo": 2650,
         "seq": 15675,
         "isMergeCommit": false,
-        "taskId": 2456
+        "clusterId": 2456
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "678cdecfb54ac1a905d39faa9fe61cfd49322370",
-          "parentIds": [
-            "52983e3903f6518e2610a3dbcab14c155eabb30c"
-          ],
+          "parentIds": ["52983e3903f6518e2610a3dbcab14c155eabb30c"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-28T12:00:05.000Z",
           "commitDate": "2019-02-28T12:00:05.000Z",
@@ -17887,7 +15693,7 @@
         "implicitBranchNo": 2650,
         "seq": 15676,
         "isMergeCommit": false,
-        "taskId": 2456
+        "clusterId": 2456
       },
       {
         "nodeTypeName": "COMMIT",
@@ -17898,20 +15704,12 @@
             "2ee87b598340231bede0f2dc8ad27bb5cca7b098"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-28T13:54:25.000Z",
           "commitDate": "2019-02-28T13:54:25.000Z",
@@ -17930,30 +15728,20 @@
         "implicitBranchNo": 2650,
         "seq": 15681,
         "isMergeCommit": true,
-        "taskId": 2456
+        "clusterId": 2456
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "16904f2d3a0eb98d0ae5ca2d30d6df1fdef0c37a",
-          "parentIds": [
-            "d740db3df82cbc943b5f0c69381acbdf74aa2a17"
-          ],
+          "parentIds": ["d740db3df82cbc943b5f0c69381acbdf74aa2a17"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-02-28T17:40:07.000Z",
           "commitDate": "2019-02-28T17:40:07.000Z",
@@ -17972,30 +15760,20 @@
         "implicitBranchNo": 2650,
         "seq": 15683,
         "isMergeCommit": false,
-        "taskId": 2456
+        "clusterId": 2456
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "3a96636bd688578b46656226593778fbc4d962e0",
-          "parentIds": [
-            "16904f2d3a0eb98d0ae5ca2d30d6df1fdef0c37a"
-          ],
+          "parentIds": ["16904f2d3a0eb98d0ae5ca2d30d6df1fdef0c37a"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-01T18:25:11.000Z",
           "commitDate": "2019-03-01T18:25:11.000Z",
@@ -18018,7 +15796,7 @@
         "implicitBranchNo": 2650,
         "seq": 15686,
         "isMergeCommit": false,
-        "taskId": 2456
+        "clusterId": 2456
       },
       {
         "nodeTypeName": "COMMIT",
@@ -18029,20 +15807,12 @@
             "3a96636bd688578b46656226593778fbc4d962e0"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-03-01T18:36:40.000Z",
           "commitDate": "2019-03-01T18:36:40.000Z",
@@ -18261,30 +16031,20 @@
         "implicitBranchNo": 2637,
         "seq": 15687,
         "isMergeCommit": true,
-        "taskId": 2456
+        "clusterId": 2456
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "40ad6203c0f9d2da3615fed7c53e3e17215a1f39",
-          "parentIds": [
-            "4d2a39a98bdbd993655a3f94d8f63c8093a1569d"
-          ],
+          "parentIds": ["4d2a39a98bdbd993655a3f94d8f63c8093a1569d"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-19T14:49:28.000Z",
           "commitDate": "2019-03-19T14:49:28.000Z",
@@ -18303,30 +16063,20 @@
         "implicitBranchNo": 2654,
         "seq": 15715,
         "isMergeCommit": false,
-        "taskId": 2456
+        "clusterId": 2456
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "f65f7246dc2db9eee3f4ce043fc40f5a3f7a1f58",
-          "parentIds": [
-            "40ad6203c0f9d2da3615fed7c53e3e17215a1f39"
-          ],
+          "parentIds": ["40ad6203c0f9d2da3615fed7c53e3e17215a1f39"],
           "author": {
-            "names": [
-              "Kenneth Geisshirt "
-            ],
-            "emails": [
-              "geisshirt@gmail.com"
-            ]
+            "names": ["Kenneth Geisshirt "],
+            "emails": ["geisshirt@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-03-20T09:04:46.000Z",
           "commitDate": "2019-03-20T09:04:46.000Z",
@@ -18345,7 +16095,7 @@
         "implicitBranchNo": 2654,
         "seq": 15716,
         "isMergeCommit": false,
-        "taskId": 2456
+        "clusterId": 2456
       },
       {
         "nodeTypeName": "COMMIT",
@@ -18356,20 +16106,12 @@
             "f65f7246dc2db9eee3f4ce043fc40f5a3f7a1f58"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-03-20T09:06:03.000Z",
           "commitDate": "2019-03-20T09:06:03.000Z",
@@ -18388,7 +16130,7 @@
         "implicitBranchNo": 2637,
         "seq": 15717,
         "isMergeCommit": true,
-        "taskId": 2456
+        "clusterId": 2456
       },
       {
         "nodeTypeName": "COMMIT",
@@ -18399,20 +16141,12 @@
             "06bab97b99abdbacf4fa37713c289c3570f5b6b9"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-20T09:08:41.000Z",
           "commitDate": "2019-03-20T09:08:41.000Z",
@@ -18635,7 +16369,7 @@
         "implicitBranchNo": 0,
         "seq": 15718,
         "isMergeCommit": true,
-        "taskId": 2456
+        "clusterId": 2456
       }
     ]
   },
@@ -18646,24 +16380,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "809a0e78e75d1cc71ae346c552da8046f364c222",
-          "parentIds": [
-            "cec78c7a44c94ba878850d160e3e839b7814329b"
-          ],
+          "parentIds": ["cec78c7a44c94ba878850d160e3e839b7814329b"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-06T13:25:50.000Z",
           "commitDate": "2019-03-06T13:25:50.000Z",
@@ -18694,30 +16418,20 @@
         "implicitBranchNo": 2653,
         "seq": 15688,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "6d541caf3bba880435672cea211c46abc0399ac2",
-          "parentIds": [
-            "809a0e78e75d1cc71ae346c552da8046f364c222"
-          ],
+          "parentIds": ["809a0e78e75d1cc71ae346c552da8046f364c222"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-07T10:15:04.000Z",
           "commitDate": "2019-03-07T10:15:04.000Z",
@@ -18764,30 +16478,20 @@
         "implicitBranchNo": 2653,
         "seq": 15689,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "f4bebc1aef318314cc92cad1957a055ecc3a3361",
-          "parentIds": [
-            "6d541caf3bba880435672cea211c46abc0399ac2"
-          ],
+          "parentIds": ["6d541caf3bba880435672cea211c46abc0399ac2"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-07T10:16:23.000Z",
           "commitDate": "2019-03-07T10:16:23.000Z",
@@ -18806,30 +16510,20 @@
         "implicitBranchNo": 2653,
         "seq": 15690,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "3d37e168156f464cd9544657cb2f7060f778f4cc",
-          "parentIds": [
-            "f4bebc1aef318314cc92cad1957a055ecc3a3361"
-          ],
+          "parentIds": ["f4bebc1aef318314cc92cad1957a055ecc3a3361"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-07T11:14:06.000Z",
           "commitDate": "2019-03-07T11:14:06.000Z",
@@ -18848,30 +16542,20 @@
         "implicitBranchNo": 2653,
         "seq": 15691,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "09361eb67408fd675f22f1cf1acbaeb78209eb4d",
-          "parentIds": [
-            "3d37e168156f464cd9544657cb2f7060f778f4cc"
-          ],
+          "parentIds": ["3d37e168156f464cd9544657cb2f7060f778f4cc"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-07T11:49:58.000Z",
           "commitDate": "2019-03-07T11:49:58.000Z",
@@ -18898,30 +16582,20 @@
         "implicitBranchNo": 2653,
         "seq": 15692,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "318c6dee0e6b295ecc11840de5eafce3644415c9",
-          "parentIds": [
-            "09361eb67408fd675f22f1cf1acbaeb78209eb4d"
-          ],
+          "parentIds": ["09361eb67408fd675f22f1cf1acbaeb78209eb4d"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-07T15:43:13.000Z",
           "commitDate": "2019-03-07T15:43:13.000Z",
@@ -18960,30 +16634,20 @@
         "implicitBranchNo": 2653,
         "seq": 15693,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "aefd7118668c19a00250cbce00d0eafeb7072a6b",
-          "parentIds": [
-            "318c6dee0e6b295ecc11840de5eafce3644415c9"
-          ],
+          "parentIds": ["318c6dee0e6b295ecc11840de5eafce3644415c9"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-08T08:57:40.000Z",
           "commitDate": "2019-03-08T08:57:40.000Z",
@@ -19006,30 +16670,20 @@
         "implicitBranchNo": 2653,
         "seq": 15694,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "cee9b744308ae23e56ca6a1ef0504e3ee5238cee",
-          "parentIds": [
-            "aefd7118668c19a00250cbce00d0eafeb7072a6b"
-          ],
+          "parentIds": ["aefd7118668c19a00250cbce00d0eafeb7072a6b"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-08T10:19:00.000Z",
           "commitDate": "2019-03-08T10:19:00.000Z",
@@ -19048,30 +16702,20 @@
         "implicitBranchNo": 2653,
         "seq": 15695,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "d3315efe71e6ca8178ab7df4d030b143a239cd24",
-          "parentIds": [
-            "cee9b744308ae23e56ca6a1ef0504e3ee5238cee"
-          ],
+          "parentIds": ["cee9b744308ae23e56ca6a1ef0504e3ee5238cee"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-08T11:21:41.000Z",
           "commitDate": "2019-03-08T11:21:41.000Z",
@@ -19094,30 +16738,20 @@
         "implicitBranchNo": 2653,
         "seq": 15696,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "b1254950b01afe332ecf51df742b517062adf325",
-          "parentIds": [
-            "d3315efe71e6ca8178ab7df4d030b143a239cd24"
-          ],
+          "parentIds": ["d3315efe71e6ca8178ab7df4d030b143a239cd24"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-11T10:19:49.000Z",
           "commitDate": "2019-03-11T10:19:49.000Z",
@@ -19136,30 +16770,20 @@
         "implicitBranchNo": 2653,
         "seq": 15697,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "ca88d747ca2f309d5185789862486af07dfcd2cb",
-          "parentIds": [
-            "b1254950b01afe332ecf51df742b517062adf325"
-          ],
+          "parentIds": ["b1254950b01afe332ecf51df742b517062adf325"],
           "author": {
-            "names": [
-              "Kenneth Geisshirt "
-            ],
-            "emails": [
-              "geisshirt@gmail.com"
-            ]
+            "names": ["Kenneth Geisshirt "],
+            "emails": ["geisshirt@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-03-11T12:49:33.000Z",
           "commitDate": "2019-03-11T12:49:33.000Z",
@@ -19178,30 +16802,20 @@
         "implicitBranchNo": 2653,
         "seq": 15698,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "02816aefebce5420a7096c19961e60d98eb6ac73",
-          "parentIds": [
-            "ca88d747ca2f309d5185789862486af07dfcd2cb"
-          ],
+          "parentIds": ["ca88d747ca2f309d5185789862486af07dfcd2cb"],
           "author": {
-            "names": [
-              "Kenneth Geisshirt "
-            ],
-            "emails": [
-              "geisshirt@gmail.com"
-            ]
+            "names": ["Kenneth Geisshirt "],
+            "emails": ["geisshirt@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-03-11T12:49:44.000Z",
           "commitDate": "2019-03-11T12:49:44.000Z",
@@ -19220,30 +16834,20 @@
         "implicitBranchNo": 2653,
         "seq": 15699,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "90139617c0173f3963e6f73bb94b9502037d3401",
-          "parentIds": [
-            "02816aefebce5420a7096c19961e60d98eb6ac73"
-          ],
+          "parentIds": ["02816aefebce5420a7096c19961e60d98eb6ac73"],
           "author": {
-            "names": [
-              "Kenneth Geisshirt "
-            ],
-            "emails": [
-              "geisshirt@gmail.com"
-            ]
+            "names": ["Kenneth Geisshirt "],
+            "emails": ["geisshirt@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-03-11T12:49:55.000Z",
           "commitDate": "2019-03-11T12:49:55.000Z",
@@ -19262,30 +16866,20 @@
         "implicitBranchNo": 2653,
         "seq": 15700,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "472ee05e469cd4bcc45990a39c39a99b3ea4a1a2",
-          "parentIds": [
-            "90139617c0173f3963e6f73bb94b9502037d3401"
-          ],
+          "parentIds": ["90139617c0173f3963e6f73bb94b9502037d3401"],
           "author": {
-            "names": [
-              "Kenneth Geisshirt "
-            ],
-            "emails": [
-              "geisshirt@gmail.com"
-            ]
+            "names": ["Kenneth Geisshirt "],
+            "emails": ["geisshirt@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-03-11T12:50:03.000Z",
           "commitDate": "2019-03-11T12:50:03.000Z",
@@ -19304,30 +16898,20 @@
         "implicitBranchNo": 2653,
         "seq": 15701,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "7ae2003181670be84d0e7bf6c91963aed405ec03",
-          "parentIds": [
-            "472ee05e469cd4bcc45990a39c39a99b3ea4a1a2"
-          ],
+          "parentIds": ["472ee05e469cd4bcc45990a39c39a99b3ea4a1a2"],
           "author": {
-            "names": [
-              "Brian Munkholm "
-            ],
-            "emails": [
-              "bmunkholm@users.noreply.github.com"
-            ]
+            "names": ["Brian Munkholm "],
+            "emails": ["bmunkholm@users.noreply.github.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-03-11T12:50:14.000Z",
           "commitDate": "2019-03-11T12:50:14.000Z",
@@ -19346,30 +16930,20 @@
         "implicitBranchNo": 2653,
         "seq": 15702,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "32509cccf646ec533730bb8d1731efb3dc402024",
-          "parentIds": [
-            "7ae2003181670be84d0e7bf6c91963aed405ec03"
-          ],
+          "parentIds": ["7ae2003181670be84d0e7bf6c91963aed405ec03"],
           "author": {
-            "names": [
-              "Kenneth Geisshirt "
-            ],
-            "emails": [
-              "geisshirt@gmail.com"
-            ]
+            "names": ["Kenneth Geisshirt "],
+            "emails": ["geisshirt@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-03-11T12:50:38.000Z",
           "commitDate": "2019-03-11T12:50:38.000Z",
@@ -19388,30 +16962,20 @@
         "implicitBranchNo": 2653,
         "seq": 15703,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "acfed9c411c8da87ee742ede149efd9bb005ac0e",
-          "parentIds": [
-            "32509cccf646ec533730bb8d1731efb3dc402024"
-          ],
+          "parentIds": ["32509cccf646ec533730bb8d1731efb3dc402024"],
           "author": {
-            "names": [
-              "Kenneth Geisshirt "
-            ],
-            "emails": [
-              "geisshirt@gmail.com"
-            ]
+            "names": ["Kenneth Geisshirt "],
+            "emails": ["geisshirt@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-03-11T12:50:50.000Z",
           "commitDate": "2019-03-11T12:50:50.000Z",
@@ -19430,30 +16994,20 @@
         "implicitBranchNo": 2653,
         "seq": 15704,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "363b2ce050ffa8c4276dedc69c566cde4b9f3822",
-          "parentIds": [
-            "acfed9c411c8da87ee742ede149efd9bb005ac0e"
-          ],
+          "parentIds": ["acfed9c411c8da87ee742ede149efd9bb005ac0e"],
           "author": {
-            "names": [
-              "Kenneth Geisshirt "
-            ],
-            "emails": [
-              "geisshirt@gmail.com"
-            ]
+            "names": ["Kenneth Geisshirt "],
+            "emails": ["geisshirt@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-03-11T12:51:03.000Z",
           "commitDate": "2019-03-11T12:51:03.000Z",
@@ -19472,30 +17026,20 @@
         "implicitBranchNo": 2653,
         "seq": 15705,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "6e0108f28a6139a738355ecebddfd2c07339c8a3",
-          "parentIds": [
-            "363b2ce050ffa8c4276dedc69c566cde4b9f3822"
-          ],
+          "parentIds": ["363b2ce050ffa8c4276dedc69c566cde4b9f3822"],
           "author": {
-            "names": [
-              "Kenneth Geisshirt "
-            ],
-            "emails": [
-              "geisshirt@gmail.com"
-            ]
+            "names": ["Kenneth Geisshirt "],
+            "emails": ["geisshirt@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-03-11T12:51:13.000Z",
           "commitDate": "2019-03-11T12:51:13.000Z",
@@ -19514,30 +17058,20 @@
         "implicitBranchNo": 2653,
         "seq": 15706,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "c076ea8459d9c7732b9548c591e10f656bad43eb",
-          "parentIds": [
-            "6e0108f28a6139a738355ecebddfd2c07339c8a3"
-          ],
+          "parentIds": ["6e0108f28a6139a738355ecebddfd2c07339c8a3"],
           "author": {
-            "names": [
-              "Kenneth Geisshirt "
-            ],
-            "emails": [
-              "geisshirt@gmail.com"
-            ]
+            "names": ["Kenneth Geisshirt "],
+            "emails": ["geisshirt@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-03-11T12:51:27.000Z",
           "commitDate": "2019-03-11T12:51:27.000Z",
@@ -19556,30 +17090,20 @@
         "implicitBranchNo": 2653,
         "seq": 15707,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "165c65d8adeff1773f188fe0d4d43f5b6c93c91b",
-          "parentIds": [
-            "c076ea8459d9c7732b9548c591e10f656bad43eb"
-          ],
+          "parentIds": ["c076ea8459d9c7732b9548c591e10f656bad43eb"],
           "author": {
-            "names": [
-              "Kenneth Geisshirt "
-            ],
-            "emails": [
-              "geisshirt@gmail.com"
-            ]
+            "names": ["Kenneth Geisshirt "],
+            "emails": ["geisshirt@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-03-11T12:51:38.000Z",
           "commitDate": "2019-03-11T12:51:38.000Z",
@@ -19598,30 +17122,20 @@
         "implicitBranchNo": 2653,
         "seq": 15708,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "43e71cbec167afa7b524488ee6041f335f345ab3",
-          "parentIds": [
-            "165c65d8adeff1773f188fe0d4d43f5b6c93c91b"
-          ],
+          "parentIds": ["165c65d8adeff1773f188fe0d4d43f5b6c93c91b"],
           "author": {
-            "names": [
-              "Kenneth Geisshirt "
-            ],
-            "emails": [
-              "geisshirt@gmail.com"
-            ]
+            "names": ["Kenneth Geisshirt "],
+            "emails": ["geisshirt@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-03-11T12:51:46.000Z",
           "commitDate": "2019-03-11T12:51:46.000Z",
@@ -19640,30 +17154,20 @@
         "implicitBranchNo": 2653,
         "seq": 15709,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "7153ff12e7706cf5ba8631741ef854db7183b1c4",
-          "parentIds": [
-            "43e71cbec167afa7b524488ee6041f335f345ab3"
-          ],
+          "parentIds": ["43e71cbec167afa7b524488ee6041f335f345ab3"],
           "author": {
-            "names": [
-              "Brian Munkholm "
-            ],
-            "emails": [
-              "bmunkholm@users.noreply.github.com"
-            ]
+            "names": ["Brian Munkholm "],
+            "emails": ["bmunkholm@users.noreply.github.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-03-12T10:53:21.000Z",
           "commitDate": "2019-03-12T10:53:21.000Z",
@@ -19682,30 +17186,20 @@
         "implicitBranchNo": 2653,
         "seq": 15710,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "61de8e3dd001fa881e999ab69aba48d8780d41a4",
-          "parentIds": [
-            "7153ff12e7706cf5ba8631741ef854db7183b1c4"
-          ],
+          "parentIds": ["7153ff12e7706cf5ba8631741ef854db7183b1c4"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-12T11:54:34.000Z",
           "commitDate": "2019-03-12T11:54:34.000Z",
@@ -19732,30 +17226,20 @@
         "implicitBranchNo": 2653,
         "seq": 15711,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "e5d59929958247ab8dea123d3364e267c797dc42",
-          "parentIds": [
-            "61de8e3dd001fa881e999ab69aba48d8780d41a4"
-          ],
+          "parentIds": ["61de8e3dd001fa881e999ab69aba48d8780d41a4"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-12T14:38:07.000Z",
           "commitDate": "2019-03-12T14:38:07.000Z",
@@ -19786,30 +17270,20 @@
         "implicitBranchNo": 2653,
         "seq": 15712,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "aa9b2be90d3c381b45d253a9fc71de430bf4aeaf",
-          "parentIds": [
-            "e5d59929958247ab8dea123d3364e267c797dc42"
-          ],
+          "parentIds": ["e5d59929958247ab8dea123d3364e267c797dc42"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-14T08:40:18.000Z",
           "commitDate": "2019-03-14T08:40:18.000Z",
@@ -19832,7 +17306,7 @@
         "implicitBranchNo": 2653,
         "seq": 15714,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
@@ -19843,20 +17317,12 @@
             "ddbb134155d760a1a55378c7fec601a23dbdd551"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-20T09:14:26.000Z",
           "commitDate": "2019-03-20T09:14:26.000Z",
@@ -20079,30 +17545,20 @@
         "implicitBranchNo": 2653,
         "seq": 15719,
         "isMergeCommit": true,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "21960a527bec4181a79d1820413e7a539f8dd1ac",
-          "parentIds": [
-            "f14e6230a17f7008d3df2453d8eebc99e07d8b89"
-          ],
+          "parentIds": ["f14e6230a17f7008d3df2453d8eebc99e07d8b89"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-20T09:18:11.000Z",
           "commitDate": "2019-03-20T09:18:11.000Z",
@@ -20125,30 +17581,20 @@
         "implicitBranchNo": 2653,
         "seq": 15720,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "913e4c177b1dd4ff6f52bc4f2104e034fbf80fe1",
-          "parentIds": [
-            "21960a527bec4181a79d1820413e7a539f8dd1ac"
-          ],
+          "parentIds": ["21960a527bec4181a79d1820413e7a539f8dd1ac"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-20T13:18:42.000Z",
           "commitDate": "2019-03-20T13:18:42.000Z",
@@ -20175,30 +17621,20 @@
         "implicitBranchNo": 2653,
         "seq": 15721,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "9d74d6521b05a7dd918713e64a41f6cbadf7d501",
-          "parentIds": [
-            "913e4c177b1dd4ff6f52bc4f2104e034fbf80fe1"
-          ],
+          "parentIds": ["913e4c177b1dd4ff6f52bc4f2104e034fbf80fe1"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-20T21:16:03.000Z",
           "commitDate": "2019-03-20T21:16:03.000Z",
@@ -20229,30 +17665,20 @@
         "implicitBranchNo": 2653,
         "seq": 15722,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "1d8347444c9b7fa255ceb0272c3398669ec9c93d",
-          "parentIds": [
-            "9d74d6521b05a7dd918713e64a41f6cbadf7d501"
-          ],
+          "parentIds": ["9d74d6521b05a7dd918713e64a41f6cbadf7d501"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-20T21:58:53.000Z",
           "commitDate": "2019-03-20T21:58:53.000Z",
@@ -20275,30 +17701,20 @@
         "implicitBranchNo": 2653,
         "seq": 15723,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "1d4d37af53f12a35fcbf127cb2087d526fa13340",
-          "parentIds": [
-            "1d8347444c9b7fa255ceb0272c3398669ec9c93d"
-          ],
+          "parentIds": ["1d8347444c9b7fa255ceb0272c3398669ec9c93d"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-21T00:12:30.000Z",
           "commitDate": "2019-03-21T00:12:30.000Z",
@@ -20321,30 +17737,20 @@
         "implicitBranchNo": 2653,
         "seq": 15724,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "5f82586245a19b695f4f5ca6f72670f9b501d910",
-          "parentIds": [
-            "1d4d37af53f12a35fcbf127cb2087d526fa13340"
-          ],
+          "parentIds": ["1d4d37af53f12a35fcbf127cb2087d526fa13340"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-21T08:15:02.000Z",
           "commitDate": "2019-03-21T08:15:02.000Z",
@@ -20363,30 +17769,20 @@
         "implicitBranchNo": 2653,
         "seq": 15725,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "fabf1e115c1f8510a1d2ad28caf1e18dd47e51b9",
-          "parentIds": [
-            "5f82586245a19b695f4f5ca6f72670f9b501d910"
-          ],
+          "parentIds": ["5f82586245a19b695f4f5ca6f72670f9b501d910"],
           "author": {
-            "names": [
-              "Kenneth Geisshirt "
-            ],
-            "emails": [
-              "geisshirt@gmail.com"
-            ]
+            "names": ["Kenneth Geisshirt "],
+            "emails": ["geisshirt@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-03-21T10:21:16.000Z",
           "commitDate": "2019-03-21T10:21:16.000Z",
@@ -20405,30 +17801,20 @@
         "implicitBranchNo": 2653,
         "seq": 15726,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "c23e3d5ab3fa10ce6403d70d34ff098a91ca1e56",
-          "parentIds": [
-            "fabf1e115c1f8510a1d2ad28caf1e18dd47e51b9"
-          ],
+          "parentIds": ["fabf1e115c1f8510a1d2ad28caf1e18dd47e51b9"],
           "author": {
-            "names": [
-              "Kenneth Geisshirt "
-            ],
-            "emails": [
-              "geisshirt@gmail.com"
-            ]
+            "names": ["Kenneth Geisshirt "],
+            "emails": ["geisshirt@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-03-21T10:21:30.000Z",
           "commitDate": "2019-03-21T10:21:30.000Z",
@@ -20447,30 +17833,20 @@
         "implicitBranchNo": 2653,
         "seq": 15727,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "d18214485b98dc183d0c88ac160a25303296c92f",
-          "parentIds": [
-            "c23e3d5ab3fa10ce6403d70d34ff098a91ca1e56"
-          ],
+          "parentIds": ["c23e3d5ab3fa10ce6403d70d34ff098a91ca1e56"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-21T19:23:53.000Z",
           "commitDate": "2019-03-21T19:23:53.000Z",
@@ -20501,7 +17877,7 @@
         "implicitBranchNo": 2653,
         "seq": 15728,
         "isMergeCommit": false,
-        "taskId": 2457
+        "clusterId": 2457
       },
       {
         "nodeTypeName": "COMMIT",
@@ -20512,20 +17888,12 @@
             "d18214485b98dc183d0c88ac160a25303296c92f"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-03-21T19:55:29.000Z",
           "commitDate": "2019-03-21T19:55:29.000Z",
@@ -20636,7 +18004,7 @@
         "implicitBranchNo": 0,
         "seq": 15729,
         "isMergeCommit": true,
-        "taskId": 2457
+        "clusterId": 2457
       }
     ]
   },
@@ -20647,24 +18015,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "9ecefb0c027995ba303cefdab3fff6593fd3ed39",
-          "parentIds": [
-            "40bd57486076f2bba79f8ccc8891f07137c8dcba"
-          ],
+          "parentIds": ["40bd57486076f2bba79f8ccc8891f07137c8dcba"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-22T06:32:09.000Z",
           "commitDate": "2019-03-22T06:32:09.000Z",
@@ -20683,7 +18041,7 @@
         "implicitBranchNo": 0,
         "seq": 15730,
         "isMergeCommit": false,
-        "taskId": 2458
+        "clusterId": 2458
       }
     ]
   },
@@ -20694,24 +18052,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "c5257981064d9b0429496ddfd280fa0c4d3d793c",
-          "parentIds": [
-            "9ecefb0c027995ba303cefdab3fff6593fd3ed39"
-          ],
+          "parentIds": ["9ecefb0c027995ba303cefdab3fff6593fd3ed39"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-22T06:34:25.000Z",
           "commitDate": "2019-03-22T06:34:25.000Z",
@@ -20730,7 +18078,7 @@
         "implicitBranchNo": 0,
         "seq": 15731,
         "isMergeCommit": false,
-        "taskId": 2459
+        "clusterId": 2459
       }
     ]
   },
@@ -20741,24 +18089,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "46e67bd70c29fe0fad5c390315cc607ca0c940bc",
-          "parentIds": [
-            "c5257981064d9b0429496ddfd280fa0c4d3d793c"
-          ],
+          "parentIds": ["c5257981064d9b0429496ddfd280fa0c4d3d793c"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-22T06:34:25.000Z",
           "commitDate": "2019-03-22T06:34:25.000Z",
@@ -20777,7 +18115,7 @@
         "implicitBranchNo": 0,
         "seq": 15732,
         "isMergeCommit": false,
-        "taskId": 2460
+        "clusterId": 2460
       }
     ]
   },
@@ -20788,24 +18126,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "6904e943a6897c037ee05064b08710e9af0baf24",
-          "parentIds": [
-            "46e67bd70c29fe0fad5c390315cc607ca0c940bc"
-          ],
+          "parentIds": ["46e67bd70c29fe0fad5c390315cc607ca0c940bc"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-04-05T12:05:46.000Z",
           "commitDate": "2019-04-05T12:05:46.000Z",
@@ -20832,30 +18160,20 @@
         "implicitBranchNo": 2655,
         "seq": 15734,
         "isMergeCommit": false,
-        "taskId": 2461
+        "clusterId": 2461
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "bde68deb28f9ac44cb72ed6eaf66a255f63bd09c",
-          "parentIds": [
-            "6904e943a6897c037ee05064b08710e9af0baf24"
-          ],
+          "parentIds": ["6904e943a6897c037ee05064b08710e9af0baf24"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-04-10T07:35:52.000Z",
           "commitDate": "2019-04-10T07:35:52.000Z",
@@ -20874,7 +18192,7 @@
         "implicitBranchNo": 2655,
         "seq": 15735,
         "isMergeCommit": false,
-        "taskId": 2461
+        "clusterId": 2461
       },
       {
         "nodeTypeName": "COMMIT",
@@ -20885,20 +18203,12 @@
             "bde68deb28f9ac44cb72ed6eaf66a255f63bd09c"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-04-10T09:40:30.000Z",
           "commitDate": "2019-04-10T09:40:30.000Z",
@@ -20929,7 +18239,7 @@
         "implicitBranchNo": 0,
         "seq": 15736,
         "isMergeCommit": true,
-        "taskId": 2461
+        "clusterId": 2461
       }
     ]
   },
@@ -20940,24 +18250,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "6a91a7cbfbf99dfaec9173ffc8e6b3b61640e504",
-          "parentIds": [
-            "82d6c5b2b315e994068b485d8f337e258f35ac1d"
-          ],
+          "parentIds": ["82d6c5b2b315e994068b485d8f337e258f35ac1d"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-01T08:29:55.000Z",
           "commitDate": "2019-05-01T08:29:55.000Z",
@@ -20976,7 +18276,7 @@
         "implicitBranchNo": 0,
         "seq": 15753,
         "isMergeCommit": false,
-        "taskId": 2462
+        "clusterId": 2462
       }
     ]
   },
@@ -20987,24 +18287,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "7ca0c8c4f4715df9bacd586cb4bec66b78faf8b3",
-          "parentIds": [
-            "46e67bd70c29fe0fad5c390315cc607ca0c940bc"
-          ],
+          "parentIds": ["46e67bd70c29fe0fad5c390315cc607ca0c940bc"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-03-22T08:05:29.000Z",
           "commitDate": "2019-03-22T08:05:29.000Z",
@@ -21023,30 +18313,20 @@
         "implicitBranchNo": 2656,
         "seq": 15733,
         "isMergeCommit": false,
-        "taskId": 2463
+        "clusterId": 2463
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "fb60deb79db32ec006f57efc9b03f77a7dd19027",
-          "parentIds": [
-            "7ca0c8c4f4715df9bacd586cb4bec66b78faf8b3"
-          ],
+          "parentIds": ["7ca0c8c4f4715df9bacd586cb4bec66b78faf8b3"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-04-10T11:24:21.000Z",
           "commitDate": "2019-04-10T11:24:21.000Z",
@@ -21077,30 +18357,20 @@
         "implicitBranchNo": 2657,
         "seq": 15737,
         "isMergeCommit": false,
-        "taskId": 2463
+        "clusterId": 2463
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "858bc0a9d3a590361daee5080fe7cd16acd9c17d",
-          "parentIds": [
-            "fb60deb79db32ec006f57efc9b03f77a7dd19027"
-          ],
+          "parentIds": ["fb60deb79db32ec006f57efc9b03f77a7dd19027"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-04-12T08:54:59.000Z",
           "commitDate": "2019-04-12T08:54:59.000Z",
@@ -21151,7 +18421,7 @@
         "implicitBranchNo": 2657,
         "seq": 15738,
         "isMergeCommit": false,
-        "taskId": 2463
+        "clusterId": 2463
       },
       {
         "nodeTypeName": "COMMIT",
@@ -21162,20 +18432,12 @@
             "82d6c5b2b315e994068b485d8f337e258f35ac1d"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-04-12T08:55:19.000Z",
           "commitDate": "2019-04-12T08:55:19.000Z",
@@ -21206,7 +18468,7 @@
         "implicitBranchNo": 2656,
         "seq": 15739,
         "isMergeCommit": true,
-        "taskId": 2463
+        "clusterId": 2463
       },
       {
         "nodeTypeName": "COMMIT",
@@ -21217,20 +18479,12 @@
             "c84e22ab4ca345436baa0650aa10a681b4309eeb"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-04-12T08:56:14.000Z",
           "commitDate": "2019-04-12T08:56:14.000Z",
@@ -21257,30 +18511,20 @@
         "implicitBranchNo": 2657,
         "seq": 15740,
         "isMergeCommit": true,
-        "taskId": 2463
+        "clusterId": 2463
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "011149fd097b82a33b65daf1c9b35103b0690cdc",
-          "parentIds": [
-            "cb1e46274ea60f35a7660244fba9f730efd057d6"
-          ],
+          "parentIds": ["cb1e46274ea60f35a7660244fba9f730efd057d6"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-04-12T10:02:32.000Z",
           "commitDate": "2019-04-12T10:02:32.000Z",
@@ -21299,30 +18543,20 @@
         "implicitBranchNo": 2657,
         "seq": 15741,
         "isMergeCommit": false,
-        "taskId": 2463
+        "clusterId": 2463
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "ab3e9f51b2c2f244b79eee537ff27612fbd56353",
-          "parentIds": [
-            "c84e22ab4ca345436baa0650aa10a681b4309eeb"
-          ],
+          "parentIds": ["c84e22ab4ca345436baa0650aa10a681b4309eeb"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-04-19T19:05:51.000Z",
           "commitDate": "2019-04-19T19:05:51.000Z",
@@ -21357,7 +18591,7 @@
         "implicitBranchNo": 2660,
         "seq": 15742,
         "isMergeCommit": false,
-        "taskId": 2463
+        "clusterId": 2463
       },
       {
         "nodeTypeName": "COMMIT",
@@ -21368,20 +18602,12 @@
             "ab3e9f51b2c2f244b79eee537ff27612fbd56353"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-04-24T21:32:36.000Z",
           "commitDate": "2019-04-24T21:32:36.000Z",
@@ -21416,30 +18642,20 @@
         "implicitBranchNo": 2658,
         "seq": 15744,
         "isMergeCommit": true,
-        "taskId": 2463
+        "clusterId": 2463
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "c481295eb57359b76073f35597f008fe08d97453",
-          "parentIds": [
-            "011149fd097b82a33b65daf1c9b35103b0690cdc"
-          ],
+          "parentIds": ["011149fd097b82a33b65daf1c9b35103b0690cdc"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-04-25T17:28:08.000Z",
           "commitDate": "2019-04-25T17:28:08.000Z",
@@ -21486,30 +18702,20 @@
         "implicitBranchNo": 2657,
         "seq": 15745,
         "isMergeCommit": false,
-        "taskId": 2463
+        "clusterId": 2463
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "19e88083fd7c980cd9ba6c1c19cc60470af0337d",
-          "parentIds": [
-            "c481295eb57359b76073f35597f008fe08d97453"
-          ],
+          "parentIds": ["c481295eb57359b76073f35597f008fe08d97453"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-04-26T08:12:31.000Z",
           "commitDate": "2019-04-26T08:12:31.000Z",
@@ -21576,30 +18782,20 @@
         "implicitBranchNo": 2657,
         "seq": 15746,
         "isMergeCommit": false,
-        "taskId": 2463
+        "clusterId": 2463
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "10b988ec47cb5b0fc88940d811946ff71893aadd",
-          "parentIds": [
-            "19e88083fd7c980cd9ba6c1c19cc60470af0337d"
-          ],
+          "parentIds": ["19e88083fd7c980cd9ba6c1c19cc60470af0337d"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-04-26T09:38:21.000Z",
           "commitDate": "2019-04-26T09:38:21.000Z",
@@ -21646,7 +18842,7 @@
         "implicitBranchNo": 2657,
         "seq": 15747,
         "isMergeCommit": false,
-        "taskId": 2463
+        "clusterId": 2463
       },
       {
         "nodeTypeName": "COMMIT",
@@ -21657,20 +18853,12 @@
             "28cf578442ef31b1b9dd323c0e26e1fd4fbba0a1"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-04-26T09:40:11.000Z",
           "commitDate": "2019-04-26T09:40:11.000Z",
@@ -21705,30 +18893,20 @@
         "implicitBranchNo": 2657,
         "seq": 15748,
         "isMergeCommit": true,
-        "taskId": 2463
+        "clusterId": 2463
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "ed7f024901407107028276f241bf4fa18daed140",
-          "parentIds": [
-            "faab72ce1a750abd4c4a0f81a20d605fdca788fb"
-          ],
+          "parentIds": ["faab72ce1a750abd4c4a0f81a20d605fdca788fb"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-04-26T10:18:53.000Z",
           "commitDate": "2019-04-26T10:18:53.000Z",
@@ -21755,30 +18933,20 @@
         "implicitBranchNo": 2657,
         "seq": 15749,
         "isMergeCommit": false,
-        "taskId": 2463
+        "clusterId": 2463
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "2602d772951e8238add4714b69d06e2d127020ed",
-          "parentIds": [
-            "ed7f024901407107028276f241bf4fa18daed140"
-          ],
+          "parentIds": ["ed7f024901407107028276f241bf4fa18daed140"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-01T07:41:06.000Z",
           "commitDate": "2019-05-01T07:41:06.000Z",
@@ -21801,7 +18969,7 @@
         "implicitBranchNo": 2657,
         "seq": 15751,
         "isMergeCommit": false,
-        "taskId": 2463
+        "clusterId": 2463
       },
       {
         "nodeTypeName": "COMMIT",
@@ -21812,20 +18980,12 @@
             "2602d772951e8238add4714b69d06e2d127020ed"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-05-01T08:25:35.000Z",
           "commitDate": "2019-05-01T08:25:35.000Z",
@@ -21916,7 +19076,7 @@
         "implicitBranchNo": 2658,
         "seq": 15752,
         "isMergeCommit": true,
-        "taskId": 2463
+        "clusterId": 2463
       },
       {
         "nodeTypeName": "COMMIT",
@@ -21927,20 +19087,12 @@
             "3e2f9d724eb599da3d6d9ba3c7952ad638dde663"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-01T08:30:01.000Z",
           "commitDate": "2019-05-01T08:30:01.000Z",
@@ -22051,7 +19203,7 @@
         "implicitBranchNo": 0,
         "seq": 15754,
         "isMergeCommit": true,
-        "taskId": 2463
+        "clusterId": 2463
       }
     ]
   },
@@ -22062,24 +19214,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "dd520f410231a6a9f5d3ace7a597b3be76d6451d",
-          "parentIds": [
-            "8e6cf4af2a16448a0e9edc39f24d8d74fa403901"
-          ],
+          "parentIds": ["8e6cf4af2a16448a0e9edc39f24d8d74fa403901"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-01T08:33:42.000Z",
           "commitDate": "2019-05-01T08:33:42.000Z",
@@ -22098,7 +19240,7 @@
         "implicitBranchNo": 0,
         "seq": 15755,
         "isMergeCommit": false,
-        "taskId": 2464
+        "clusterId": 2464
       }
     ]
   },
@@ -22109,24 +19251,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "1455bffd885cbf2ae32ccc9036b17f7aa3d15f6e",
-          "parentIds": [
-            "dd520f410231a6a9f5d3ace7a597b3be76d6451d"
-          ],
+          "parentIds": ["dd520f410231a6a9f5d3ace7a597b3be76d6451d"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-01T08:35:05.000Z",
           "commitDate": "2019-05-01T08:35:05.000Z",
@@ -22145,7 +19277,7 @@
         "implicitBranchNo": 0,
         "seq": 15756,
         "isMergeCommit": false,
-        "taskId": 2465
+        "clusterId": 2465
       }
     ]
   },
@@ -22156,24 +19288,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "e4d7db462c0daa7d023811b6cb69f24b8cf8c9b4",
-          "parentIds": [
-            "1455bffd885cbf2ae32ccc9036b17f7aa3d15f6e"
-          ],
+          "parentIds": ["1455bffd885cbf2ae32ccc9036b17f7aa3d15f6e"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-01T08:35:05.000Z",
           "commitDate": "2019-05-01T08:35:05.000Z",
@@ -22192,7 +19314,7 @@
         "implicitBranchNo": 0,
         "seq": 15757,
         "isMergeCommit": false,
-        "taskId": 2466
+        "clusterId": 2466
       }
     ]
   },
@@ -22203,24 +19325,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "e5b4c2cb04ac94fcd6e54e86873f4b4eeecc7fae",
-          "parentIds": [
-            "e4d7db462c0daa7d023811b6cb69f24b8cf8c9b4"
-          ],
+          "parentIds": ["e4d7db462c0daa7d023811b6cb69f24b8cf8c9b4"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-01T10:58:27.000Z",
           "commitDate": "2019-05-01T10:58:27.000Z",
@@ -22239,7 +19351,7 @@
         "implicitBranchNo": 0,
         "seq": 15758,
         "isMergeCommit": false,
-        "taskId": 2467
+        "clusterId": 2467
       }
     ]
   },
@@ -22250,24 +19362,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "402230537fdcaa2dce5fac5cabdd7ad722d684a8",
-          "parentIds": [
-            "e5b4c2cb04ac94fcd6e54e86873f4b4eeecc7fae"
-          ],
+          "parentIds": ["e5b4c2cb04ac94fcd6e54e86873f4b4eeecc7fae"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-01T13:15:28.000Z",
           "commitDate": "2019-05-01T13:15:28.000Z",
@@ -22290,30 +19392,20 @@
         "implicitBranchNo": 2665,
         "seq": 15759,
         "isMergeCommit": false,
-        "taskId": 2468
+        "clusterId": 2468
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "a83b5e701bea14ba4bbbc235a934a954f05f91d5",
-          "parentIds": [
-            "402230537fdcaa2dce5fac5cabdd7ad722d684a8"
-          ],
+          "parentIds": ["402230537fdcaa2dce5fac5cabdd7ad722d684a8"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-01T13:18:25.000Z",
           "commitDate": "2019-05-01T13:18:25.000Z",
@@ -22336,30 +19428,20 @@
         "implicitBranchNo": 2665,
         "seq": 15760,
         "isMergeCommit": false,
-        "taskId": 2468
+        "clusterId": 2468
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "aeca9ee299cd158db321e9dac88616386c61bc08",
-          "parentIds": [
-            "a83b5e701bea14ba4bbbc235a934a954f05f91d5"
-          ],
+          "parentIds": ["a83b5e701bea14ba4bbbc235a934a954f05f91d5"],
           "author": {
-            "names": [
-              "Brian Munkholm "
-            ],
-            "emails": [
-              "bmunkholm@users.noreply.github.com"
-            ]
+            "names": ["Brian Munkholm "],
+            "emails": ["bmunkholm@users.noreply.github.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-05-01T14:00:57.000Z",
           "commitDate": "2019-05-01T14:00:57.000Z",
@@ -22378,30 +19460,20 @@
         "implicitBranchNo": 2666,
         "seq": 15761,
         "isMergeCommit": false,
-        "taskId": 2468
+        "clusterId": 2468
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "a4f07bba55b7569b285e3c7bb8267cab793ee7b5",
-          "parentIds": [
-            "a83b5e701bea14ba4bbbc235a934a954f05f91d5"
-          ],
+          "parentIds": ["a83b5e701bea14ba4bbbc235a934a954f05f91d5"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-01T17:05:34.000Z",
           "commitDate": "2019-05-01T17:05:34.000Z",
@@ -22420,7 +19492,7 @@
         "implicitBranchNo": 2665,
         "seq": 15762,
         "isMergeCommit": false,
-        "taskId": 2468
+        "clusterId": 2468
       },
       {
         "nodeTypeName": "COMMIT",
@@ -22431,20 +19503,12 @@
             "aeca9ee299cd158db321e9dac88616386c61bc08"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-01T17:06:09.000Z",
           "commitDate": "2019-05-01T17:06:09.000Z",
@@ -22463,30 +19527,20 @@
         "implicitBranchNo": 2665,
         "seq": 15763,
         "isMergeCommit": true,
-        "taskId": 2468
+        "clusterId": 2468
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "98bae31e7ed9344b5f9a48ff23f2092b748c3bff",
-          "parentIds": [
-            "435b93df994210a24ca3df7b127e5d12983cfd30"
-          ],
+          "parentIds": ["435b93df994210a24ca3df7b127e5d12983cfd30"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-01T17:10:51.000Z",
           "commitDate": "2019-05-01T17:10:51.000Z",
@@ -22509,7 +19563,7 @@
         "implicitBranchNo": 2665,
         "seq": 15764,
         "isMergeCommit": false,
-        "taskId": 2468
+        "clusterId": 2468
       },
       {
         "nodeTypeName": "COMMIT",
@@ -22520,20 +19574,12 @@
             "98bae31e7ed9344b5f9a48ff23f2092b748c3bff"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-05-03T09:58:37.000Z",
           "commitDate": "2019-05-03T09:58:37.000Z",
@@ -22556,7 +19602,7 @@
         "implicitBranchNo": 0,
         "seq": 15766,
         "isMergeCommit": true,
-        "taskId": 2468
+        "clusterId": 2468
       }
     ]
   },
@@ -22567,24 +19613,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "4114628f9fcbb4bef50be79401cb30b393887dba",
-          "parentIds": [
-            "e5b4c2cb04ac94fcd6e54e86873f4b4eeecc7fae"
-          ],
+          "parentIds": ["e5b4c2cb04ac94fcd6e54e86873f4b4eeecc7fae"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-03T09:57:05.000Z",
           "commitDate": "2019-05-03T09:57:05.000Z",
@@ -22615,7 +19651,7 @@
         "implicitBranchNo": 2664,
         "seq": 15765,
         "isMergeCommit": false,
-        "taskId": 2469
+        "clusterId": 2469
       },
       {
         "nodeTypeName": "COMMIT",
@@ -22626,20 +19662,12 @@
             "e7b4e424539db4c96bd7eca83d5eeb08024729c3"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-03T09:59:15.000Z",
           "commitDate": "2019-05-03T09:59:15.000Z",
@@ -22662,30 +19690,20 @@
         "implicitBranchNo": 2664,
         "seq": 15767,
         "isMergeCommit": true,
-        "taskId": 2469
+        "clusterId": 2469
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "8c76ad207feb92aa8c7fbc5f337d702495cf9938",
-          "parentIds": [
-            "c76ffc5b2c105612e72945edf1dc99a54b0221de"
-          ],
+          "parentIds": ["c76ffc5b2c105612e72945edf1dc99a54b0221de"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-03T09:59:46.000Z",
           "commitDate": "2019-05-03T09:59:46.000Z",
@@ -22704,30 +19722,20 @@
         "implicitBranchNo": 2664,
         "seq": 15768,
         "isMergeCommit": false,
-        "taskId": 2469
+        "clusterId": 2469
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "f62df5a9f27547d6777c423680dad3c9d87b7dd8",
-          "parentIds": [
-            "8c76ad207feb92aa8c7fbc5f337d702495cf9938"
-          ],
+          "parentIds": ["8c76ad207feb92aa8c7fbc5f337d702495cf9938"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-03T11:47:39.000Z",
           "commitDate": "2019-05-03T11:47:39.000Z",
@@ -22746,30 +19754,20 @@
         "implicitBranchNo": 2664,
         "seq": 15769,
         "isMergeCommit": false,
-        "taskId": 2469
+        "clusterId": 2469
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "8e1a58665c8b940c28738bf30bd2c30aac18b995",
-          "parentIds": [
-            "f62df5a9f27547d6777c423680dad3c9d87b7dd8"
-          ],
+          "parentIds": ["f62df5a9f27547d6777c423680dad3c9d87b7dd8"],
           "author": {
-            "names": [
-              "Kenneth Geisshirt "
-            ],
-            "emails": [
-              "geisshirt@gmail.com"
-            ]
+            "names": ["Kenneth Geisshirt "],
+            "emails": ["geisshirt@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-05-03T12:53:37.000Z",
           "commitDate": "2019-05-03T12:53:37.000Z",
@@ -22788,30 +19786,20 @@
         "implicitBranchNo": 2664,
         "seq": 15770,
         "isMergeCommit": false,
-        "taskId": 2469
+        "clusterId": 2469
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "edf4c37a00042227807566711dcc877fa63efefc",
-          "parentIds": [
-            "8e1a58665c8b940c28738bf30bd2c30aac18b995"
-          ],
+          "parentIds": ["8e1a58665c8b940c28738bf30bd2c30aac18b995"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-05-03T22:11:35.000Z",
           "commitDate": "2019-05-03T22:11:35.000Z",
@@ -22830,7 +19818,7 @@
         "implicitBranchNo": 2664,
         "seq": 15771,
         "isMergeCommit": false,
-        "taskId": 2469
+        "clusterId": 2469
       },
       {
         "nodeTypeName": "COMMIT",
@@ -22841,20 +19829,12 @@
             "edf4c37a00042227807566711dcc877fa63efefc"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-05-03T22:12:11.000Z",
           "commitDate": "2019-05-03T22:12:11.000Z",
@@ -22885,7 +19865,7 @@
         "implicitBranchNo": 0,
         "seq": 15772,
         "isMergeCommit": true,
-        "taskId": 2469
+        "clusterId": 2469
       }
     ]
   },
@@ -22896,24 +19876,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "38e7b4aea718bde5f9af1bf86f52fef4d6eec902",
-          "parentIds": [
-            "fa111cd983ebb8fc09d0c3615f21bbe3ff8e0f72"
-          ],
+          "parentIds": ["fa111cd983ebb8fc09d0c3615f21bbe3ff8e0f72"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T10:31:47.000Z",
           "commitDate": "2019-05-09T10:31:47.000Z",
@@ -22932,7 +19902,7 @@
         "implicitBranchNo": 0,
         "seq": 15773,
         "isMergeCommit": false,
-        "taskId": 2470
+        "clusterId": 2470
       }
     ]
   },
@@ -22943,24 +19913,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "9f66c9aa26d74af836e32aa41eb7234a6fcdde76",
-          "parentIds": [
-            "38e7b4aea718bde5f9af1bf86f52fef4d6eec902"
-          ],
+          "parentIds": ["38e7b4aea718bde5f9af1bf86f52fef4d6eec902"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T20:15:15.000Z",
           "commitDate": "2019-05-09T20:15:15.000Z",
@@ -22983,7 +19943,7 @@
         "implicitBranchNo": 0,
         "seq": 15774,
         "isMergeCommit": false,
-        "taskId": 2471
+        "clusterId": 2471
       }
     ]
   },
@@ -22994,24 +19954,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "753acff9a2ccaac64901da8f560723c0c4d3fd99",
-          "parentIds": [
-            "9f66c9aa26d74af836e32aa41eb7234a6fcdde76"
-          ],
+          "parentIds": ["9f66c9aa26d74af836e32aa41eb7234a6fcdde76"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-12T17:57:37.000Z",
           "commitDate": "2019-05-12T17:57:37.000Z",
@@ -23118,30 +20068,20 @@
         "implicitBranchNo": 2668,
         "seq": 15825,
         "isMergeCommit": false,
-        "taskId": 2472
+        "clusterId": 2472
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "5ac7f26cb7b843cacec2c320a69695cbbea4e3b4",
-          "parentIds": [
-            "753acff9a2ccaac64901da8f560723c0c4d3fd99"
-          ],
+          "parentIds": ["753acff9a2ccaac64901da8f560723c0c4d3fd99"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-22T06:59:51.000Z",
           "commitDate": "2019-05-22T06:59:51.000Z",
@@ -23192,7 +20132,7 @@
         "implicitBranchNo": 2668,
         "seq": 15849,
         "isMergeCommit": false,
-        "taskId": 2472
+        "clusterId": 2472
       },
       {
         "nodeTypeName": "COMMIT",
@@ -23203,20 +20143,12 @@
             "5ac7f26cb7b843cacec2c320a69695cbbea4e3b4"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-05-22T08:03:14.000Z",
           "commitDate": "2019-05-22T08:03:14.000Z",
@@ -23323,7 +20255,7 @@
         "implicitBranchNo": 0,
         "seq": 15851,
         "isMergeCommit": true,
-        "taskId": 2472
+        "clusterId": 2472
       }
     ]
   },
@@ -23334,24 +20266,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "a690b9fb9ca510022c76624c687a5ed7da908e2a",
-          "parentIds": [
-            "9f66c9aa26d74af836e32aa41eb7234a6fcdde76"
-          ],
+          "parentIds": ["9f66c9aa26d74af836e32aa41eb7234a6fcdde76"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T22:01:22.000Z",
           "commitDate": "2019-05-09T22:01:22.000Z",
@@ -23402,30 +20324,20 @@
         "implicitBranchNo": 2669,
         "seq": 15775,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "3a6354483aa9840ca9b18859808494f5bed22142",
-          "parentIds": [
-            "a690b9fb9ca510022c76624c687a5ed7da908e2a"
-          ],
+          "parentIds": ["a690b9fb9ca510022c76624c687a5ed7da908e2a"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T22:29:42.000Z",
           "commitDate": "2019-05-09T22:29:42.000Z",
@@ -23464,30 +20376,20 @@
         "implicitBranchNo": 2669,
         "seq": 15776,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "d7f01003c36f29be726d2d5fc3221ca0f9064a78",
-          "parentIds": [
-            "3a6354483aa9840ca9b18859808494f5bed22142"
-          ],
+          "parentIds": ["3a6354483aa9840ca9b18859808494f5bed22142"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T22:33:42.000Z",
           "commitDate": "2019-05-09T22:33:42.000Z",
@@ -23510,30 +20412,20 @@
         "implicitBranchNo": 2669,
         "seq": 15777,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "63aeb514bc3571d88762ceb5880eea1f7c58d61b",
-          "parentIds": [
-            "d7f01003c36f29be726d2d5fc3221ca0f9064a78"
-          ],
+          "parentIds": ["d7f01003c36f29be726d2d5fc3221ca0f9064a78"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T22:38:21.000Z",
           "commitDate": "2019-05-09T22:38:21.000Z",
@@ -23552,30 +20444,20 @@
         "implicitBranchNo": 2669,
         "seq": 15778,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "4407f72ccffd7e431787403d1bbc9d7b2f65f8b4",
-          "parentIds": [
-            "63aeb514bc3571d88762ceb5880eea1f7c58d61b"
-          ],
+          "parentIds": ["63aeb514bc3571d88762ceb5880eea1f7c58d61b"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T22:41:30.000Z",
           "commitDate": "2019-05-09T22:41:30.000Z",
@@ -23594,30 +20476,20 @@
         "implicitBranchNo": 2669,
         "seq": 15779,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "52e224fa30c944453c0e739ef0d7482288d98632",
-          "parentIds": [
-            "4407f72ccffd7e431787403d1bbc9d7b2f65f8b4"
-          ],
+          "parentIds": ["4407f72ccffd7e431787403d1bbc9d7b2f65f8b4"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T22:43:39.000Z",
           "commitDate": "2019-05-09T22:43:39.000Z",
@@ -23636,30 +20508,20 @@
         "implicitBranchNo": 2669,
         "seq": 15780,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "c7f48b626d6473578c1459191e35b65ded035fa2",
-          "parentIds": [
-            "52e224fa30c944453c0e739ef0d7482288d98632"
-          ],
+          "parentIds": ["52e224fa30c944453c0e739ef0d7482288d98632"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T23:09:05.000Z",
           "commitDate": "2019-05-09T23:09:05.000Z",
@@ -23678,30 +20540,20 @@
         "implicitBranchNo": 2669,
         "seq": 15781,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "d8d3c1777e548cda05eeb022162af3b77d61a267",
-          "parentIds": [
-            "c7f48b626d6473578c1459191e35b65ded035fa2"
-          ],
+          "parentIds": ["c7f48b626d6473578c1459191e35b65ded035fa2"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T23:12:50.000Z",
           "commitDate": "2019-05-09T23:12:50.000Z",
@@ -23720,30 +20572,20 @@
         "implicitBranchNo": 2669,
         "seq": 15782,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "28f88b1b219f12a6aea1a3e077e6f89ea97f75dd",
-          "parentIds": [
-            "d8d3c1777e548cda05eeb022162af3b77d61a267"
-          ],
+          "parentIds": ["d8d3c1777e548cda05eeb022162af3b77d61a267"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T23:18:02.000Z",
           "commitDate": "2019-05-09T23:18:02.000Z",
@@ -23766,30 +20608,20 @@
         "implicitBranchNo": 2669,
         "seq": 15783,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "477abc9b45fcff586e2c65a9424ce4c080ed8005",
-          "parentIds": [
-            "28f88b1b219f12a6aea1a3e077e6f89ea97f75dd"
-          ],
+          "parentIds": ["28f88b1b219f12a6aea1a3e077e6f89ea97f75dd"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T23:19:14.000Z",
           "commitDate": "2019-05-09T23:19:14.000Z",
@@ -23808,30 +20640,20 @@
         "implicitBranchNo": 2669,
         "seq": 15784,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "8bf979ef63b2d152b741ede541bf88fa0765e964",
-          "parentIds": [
-            "477abc9b45fcff586e2c65a9424ce4c080ed8005"
-          ],
+          "parentIds": ["477abc9b45fcff586e2c65a9424ce4c080ed8005"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T23:22:44.000Z",
           "commitDate": "2019-05-09T23:22:44.000Z",
@@ -23850,30 +20672,20 @@
         "implicitBranchNo": 2669,
         "seq": 15785,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "9607081a0c1e1bcdec16e11085eac118dc510a44",
-          "parentIds": [
-            "8bf979ef63b2d152b741ede541bf88fa0765e964"
-          ],
+          "parentIds": ["8bf979ef63b2d152b741ede541bf88fa0765e964"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T23:24:10.000Z",
           "commitDate": "2019-05-09T23:24:10.000Z",
@@ -23892,30 +20704,20 @@
         "implicitBranchNo": 2669,
         "seq": 15786,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "a783d0b4b82580109c76379d615c4d577bec92e8",
-          "parentIds": [
-            "9607081a0c1e1bcdec16e11085eac118dc510a44"
-          ],
+          "parentIds": ["9607081a0c1e1bcdec16e11085eac118dc510a44"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T23:25:35.000Z",
           "commitDate": "2019-05-09T23:25:35.000Z",
@@ -23938,30 +20740,20 @@
         "implicitBranchNo": 2669,
         "seq": 15787,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "e550b8b538ab751e253f2d3ffe833cecfc83f3aa",
-          "parentIds": [
-            "a783d0b4b82580109c76379d615c4d577bec92e8"
-          ],
+          "parentIds": ["a783d0b4b82580109c76379d615c4d577bec92e8"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T23:29:46.000Z",
           "commitDate": "2019-05-09T23:29:46.000Z",
@@ -23980,30 +20772,20 @@
         "implicitBranchNo": 2669,
         "seq": 15788,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "4c96eca2ed98e1c3573735bb9dff7a3f522a1bde",
-          "parentIds": [
-            "e550b8b538ab751e253f2d3ffe833cecfc83f3aa"
-          ],
+          "parentIds": ["e550b8b538ab751e253f2d3ffe833cecfc83f3aa"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T23:31:34.000Z",
           "commitDate": "2019-05-09T23:31:34.000Z",
@@ -24022,30 +20804,20 @@
         "implicitBranchNo": 2669,
         "seq": 15789,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "028f64422a65ad6e1f7bf5a666eb435aa6446731",
-          "parentIds": [
-            "4c96eca2ed98e1c3573735bb9dff7a3f522a1bde"
-          ],
+          "parentIds": ["4c96eca2ed98e1c3573735bb9dff7a3f522a1bde"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T23:35:30.000Z",
           "commitDate": "2019-05-09T23:35:30.000Z",
@@ -24064,30 +20836,20 @@
         "implicitBranchNo": 2669,
         "seq": 15790,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "99f1002e5fd5f05a8364008a3744663894a51c73",
-          "parentIds": [
-            "028f64422a65ad6e1f7bf5a666eb435aa6446731"
-          ],
+          "parentIds": ["028f64422a65ad6e1f7bf5a666eb435aa6446731"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T23:36:44.000Z",
           "commitDate": "2019-05-09T23:36:44.000Z",
@@ -24106,30 +20868,20 @@
         "implicitBranchNo": 2669,
         "seq": 15791,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "1824a6962a60f6ff4b7f19793c28de35ea1f978e",
-          "parentIds": [
-            "99f1002e5fd5f05a8364008a3744663894a51c73"
-          ],
+          "parentIds": ["99f1002e5fd5f05a8364008a3744663894a51c73"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T23:40:47.000Z",
           "commitDate": "2019-05-09T23:40:47.000Z",
@@ -24148,30 +20900,20 @@
         "implicitBranchNo": 2669,
         "seq": 15792,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "6819ce6ac41806ad2bbec651d9a2698897f46d1f",
-          "parentIds": [
-            "1824a6962a60f6ff4b7f19793c28de35ea1f978e"
-          ],
+          "parentIds": ["1824a6962a60f6ff4b7f19793c28de35ea1f978e"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T23:41:10.000Z",
           "commitDate": "2019-05-09T23:41:10.000Z",
@@ -24190,30 +20932,20 @@
         "implicitBranchNo": 2669,
         "seq": 15793,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "91d69dc6ae34df715497f28cb3fcf4b880228137",
-          "parentIds": [
-            "6819ce6ac41806ad2bbec651d9a2698897f46d1f"
-          ],
+          "parentIds": ["6819ce6ac41806ad2bbec651d9a2698897f46d1f"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T23:43:17.000Z",
           "commitDate": "2019-05-09T23:43:17.000Z",
@@ -24232,30 +20964,20 @@
         "implicitBranchNo": 2669,
         "seq": 15794,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "20a111c7dd00a2a14b8c9cac49bb15d44ce5620f",
-          "parentIds": [
-            "91d69dc6ae34df715497f28cb3fcf4b880228137"
-          ],
+          "parentIds": ["91d69dc6ae34df715497f28cb3fcf4b880228137"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T23:53:22.000Z",
           "commitDate": "2019-05-09T23:53:22.000Z",
@@ -24278,30 +21000,20 @@
         "implicitBranchNo": 2669,
         "seq": 15795,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "6020e57261179d4426796f32ff46069047e35df7",
-          "parentIds": [
-            "20a111c7dd00a2a14b8c9cac49bb15d44ce5620f"
-          ],
+          "parentIds": ["20a111c7dd00a2a14b8c9cac49bb15d44ce5620f"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-09T23:59:27.000Z",
           "commitDate": "2019-05-09T23:59:27.000Z",
@@ -24320,30 +21032,20 @@
         "implicitBranchNo": 2669,
         "seq": 15796,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "81a8374002e19349ab5d3add7d3ede7bbe5550fd",
-          "parentIds": [
-            "6020e57261179d4426796f32ff46069047e35df7"
-          ],
+          "parentIds": ["6020e57261179d4426796f32ff46069047e35df7"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T00:06:49.000Z",
           "commitDate": "2019-05-10T00:06:49.000Z",
@@ -24362,30 +21064,20 @@
         "implicitBranchNo": 2669,
         "seq": 15797,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "234c7336ca38135ca438ae89e39910afd8919bf1",
-          "parentIds": [
-            "81a8374002e19349ab5d3add7d3ede7bbe5550fd"
-          ],
+          "parentIds": ["81a8374002e19349ab5d3add7d3ede7bbe5550fd"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T00:15:24.000Z",
           "commitDate": "2019-05-10T00:15:24.000Z",
@@ -24404,30 +21096,20 @@
         "implicitBranchNo": 2669,
         "seq": 15798,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "479757fa1d09d6c1b588e2e3e9037103f961790e",
-          "parentIds": [
-            "234c7336ca38135ca438ae89e39910afd8919bf1"
-          ],
+          "parentIds": ["234c7336ca38135ca438ae89e39910afd8919bf1"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T00:17:04.000Z",
           "commitDate": "2019-05-10T00:17:04.000Z",
@@ -24446,30 +21128,20 @@
         "implicitBranchNo": 2669,
         "seq": 15799,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "92355d5454f4781150082962135383ea4ce6d593",
-          "parentIds": [
-            "479757fa1d09d6c1b588e2e3e9037103f961790e"
-          ],
+          "parentIds": ["479757fa1d09d6c1b588e2e3e9037103f961790e"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T00:19:19.000Z",
           "commitDate": "2019-05-10T00:19:19.000Z",
@@ -24488,30 +21160,20 @@
         "implicitBranchNo": 2669,
         "seq": 15800,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "375e7b51e39d52a38ba621baf9a808787784f94b",
-          "parentIds": [
-            "92355d5454f4781150082962135383ea4ce6d593"
-          ],
+          "parentIds": ["92355d5454f4781150082962135383ea4ce6d593"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T00:26:07.000Z",
           "commitDate": "2019-05-10T00:26:07.000Z",
@@ -24538,30 +21200,20 @@
         "implicitBranchNo": 2669,
         "seq": 15801,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "b3da59a6ed40f79f5d283b6abeb5cd321983bab5",
-          "parentIds": [
-            "375e7b51e39d52a38ba621baf9a808787784f94b"
-          ],
+          "parentIds": ["375e7b51e39d52a38ba621baf9a808787784f94b"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T00:29:30.000Z",
           "commitDate": "2019-05-10T00:29:30.000Z",
@@ -24580,30 +21232,20 @@
         "implicitBranchNo": 2669,
         "seq": 15802,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "4544b7d7599aa963bbcc747c88e3529cd8413479",
-          "parentIds": [
-            "b3da59a6ed40f79f5d283b6abeb5cd321983bab5"
-          ],
+          "parentIds": ["b3da59a6ed40f79f5d283b6abeb5cd321983bab5"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T00:31:26.000Z",
           "commitDate": "2019-05-10T00:31:26.000Z",
@@ -24622,30 +21264,20 @@
         "implicitBranchNo": 2669,
         "seq": 15803,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "1d02793190bcfc75757d7a5802463b6935f42363",
-          "parentIds": [
-            "4544b7d7599aa963bbcc747c88e3529cd8413479"
-          ],
+          "parentIds": ["4544b7d7599aa963bbcc747c88e3529cd8413479"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T00:32:59.000Z",
           "commitDate": "2019-05-10T00:32:59.000Z",
@@ -24664,30 +21296,20 @@
         "implicitBranchNo": 2669,
         "seq": 15804,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "e26c084ab522c79ee4dd172c202fa5e4918994f9",
-          "parentIds": [
-            "1d02793190bcfc75757d7a5802463b6935f42363"
-          ],
+          "parentIds": ["1d02793190bcfc75757d7a5802463b6935f42363"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T00:35:50.000Z",
           "commitDate": "2019-05-10T00:35:50.000Z",
@@ -24706,30 +21328,20 @@
         "implicitBranchNo": 2669,
         "seq": 15805,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "e1ac6f297bc19a20fa40a6d8639744427c52ec16",
-          "parentIds": [
-            "e26c084ab522c79ee4dd172c202fa5e4918994f9"
-          ],
+          "parentIds": ["e26c084ab522c79ee4dd172c202fa5e4918994f9"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T00:40:39.000Z",
           "commitDate": "2019-05-10T00:40:39.000Z",
@@ -24752,30 +21364,20 @@
         "implicitBranchNo": 2669,
         "seq": 15806,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "131ba58cd8cac008e7ff319d036299b9cb077f19",
-          "parentIds": [
-            "e1ac6f297bc19a20fa40a6d8639744427c52ec16"
-          ],
+          "parentIds": ["e1ac6f297bc19a20fa40a6d8639744427c52ec16"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T00:41:31.000Z",
           "commitDate": "2019-05-10T00:41:31.000Z",
@@ -24794,30 +21396,20 @@
         "implicitBranchNo": 2669,
         "seq": 15807,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "09a0ce9590480244b126f4d37d661b2e1d8e1002",
-          "parentIds": [
-            "131ba58cd8cac008e7ff319d036299b9cb077f19"
-          ],
+          "parentIds": ["131ba58cd8cac008e7ff319d036299b9cb077f19"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T00:55:29.000Z",
           "commitDate": "2019-05-10T00:55:29.000Z",
@@ -24840,30 +21432,20 @@
         "implicitBranchNo": 2669,
         "seq": 15808,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "56c34fe25b9b63cc4a4ea694d61565775eb42905",
-          "parentIds": [
-            "09a0ce9590480244b126f4d37d661b2e1d8e1002"
-          ],
+          "parentIds": ["09a0ce9590480244b126f4d37d661b2e1d8e1002"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T01:01:08.000Z",
           "commitDate": "2019-05-10T01:01:08.000Z",
@@ -24914,30 +21496,20 @@
         "implicitBranchNo": 2669,
         "seq": 15809,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "d9ab0d2acfd944f3325a7b11296a6c15fad33d29",
-          "parentIds": [
-            "56c34fe25b9b63cc4a4ea694d61565775eb42905"
-          ],
+          "parentIds": ["56c34fe25b9b63cc4a4ea694d61565775eb42905"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T01:15:19.000Z",
           "commitDate": "2019-05-10T01:15:19.000Z",
@@ -24956,30 +21528,20 @@
         "implicitBranchNo": 2669,
         "seq": 15810,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "e46d4ab8d63122c9b8e41ceb58c016c6fcc9e306",
-          "parentIds": [
-            "d9ab0d2acfd944f3325a7b11296a6c15fad33d29"
-          ],
+          "parentIds": ["d9ab0d2acfd944f3325a7b11296a6c15fad33d29"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T08:34:19.000Z",
           "commitDate": "2019-05-10T08:34:19.000Z",
@@ -25014,30 +21576,20 @@
         "implicitBranchNo": 2669,
         "seq": 15811,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "225bdc1ac3c1c84883a78567e2dbabbf0771146f",
-          "parentIds": [
-            "e46d4ab8d63122c9b8e41ceb58c016c6fcc9e306"
-          ],
+          "parentIds": ["e46d4ab8d63122c9b8e41ceb58c016c6fcc9e306"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T08:56:52.000Z",
           "commitDate": "2019-05-10T08:56:52.000Z",
@@ -25060,30 +21612,20 @@
         "implicitBranchNo": 2669,
         "seq": 15812,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "fe9438a96d09bffc8a04e87911e42d9bb561b088",
-          "parentIds": [
-            "225bdc1ac3c1c84883a78567e2dbabbf0771146f"
-          ],
+          "parentIds": ["225bdc1ac3c1c84883a78567e2dbabbf0771146f"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T09:14:57.000Z",
           "commitDate": "2019-05-10T09:14:57.000Z",
@@ -25102,30 +21644,20 @@
         "implicitBranchNo": 2669,
         "seq": 15813,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "d424c21df25fe817eb161862db5b6c8e765ea011",
-          "parentIds": [
-            "fe9438a96d09bffc8a04e87911e42d9bb561b088"
-          ],
+          "parentIds": ["fe9438a96d09bffc8a04e87911e42d9bb561b088"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T09:27:55.000Z",
           "commitDate": "2019-05-10T09:27:55.000Z",
@@ -25144,30 +21676,20 @@
         "implicitBranchNo": 2669,
         "seq": 15814,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "3ac3535ed07d3b9d235757f613ea25fe023b6c4b",
-          "parentIds": [
-            "d424c21df25fe817eb161862db5b6c8e765ea011"
-          ],
+          "parentIds": ["d424c21df25fe817eb161862db5b6c8e765ea011"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T11:03:07.000Z",
           "commitDate": "2019-05-10T11:03:07.000Z",
@@ -25186,30 +21708,20 @@
         "implicitBranchNo": 2669,
         "seq": 15815,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "64d507e1ef5eaf00ff2edefbb1e559b2b90fc823",
-          "parentIds": [
-            "3ac3535ed07d3b9d235757f613ea25fe023b6c4b"
-          ],
+          "parentIds": ["3ac3535ed07d3b9d235757f613ea25fe023b6c4b"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T11:35:40.000Z",
           "commitDate": "2019-05-10T11:35:40.000Z",
@@ -25228,30 +21740,20 @@
         "implicitBranchNo": 2669,
         "seq": 15816,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "b8bf7406ddbb18b97cd323e54628990f34ed6543",
-          "parentIds": [
-            "64d507e1ef5eaf00ff2edefbb1e559b2b90fc823"
-          ],
+          "parentIds": ["64d507e1ef5eaf00ff2edefbb1e559b2b90fc823"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T11:56:47.000Z",
           "commitDate": "2019-05-10T11:56:47.000Z",
@@ -25270,30 +21772,20 @@
         "implicitBranchNo": 2669,
         "seq": 15817,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "399419588ec6952fdd4c6692233604b771fcf824",
-          "parentIds": [
-            "b8bf7406ddbb18b97cd323e54628990f34ed6543"
-          ],
+          "parentIds": ["b8bf7406ddbb18b97cd323e54628990f34ed6543"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T13:31:03.000Z",
           "commitDate": "2019-05-10T13:31:03.000Z",
@@ -25312,30 +21804,20 @@
         "implicitBranchNo": 2669,
         "seq": 15818,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "45ade8aab22d1b1c46cd1c9128797d1e7bcd1a0b",
-          "parentIds": [
-            "399419588ec6952fdd4c6692233604b771fcf824"
-          ],
+          "parentIds": ["399419588ec6952fdd4c6692233604b771fcf824"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-10T13:40:44.000Z",
           "commitDate": "2019-05-10T13:40:44.000Z",
@@ -25354,30 +21836,20 @@
         "implicitBranchNo": 2669,
         "seq": 15819,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "9e4941f9da558035700a3f0015c16e7021e270cb",
-          "parentIds": [
-            "45ade8aab22d1b1c46cd1c9128797d1e7bcd1a0b"
-          ],
+          "parentIds": ["45ade8aab22d1b1c46cd1c9128797d1e7bcd1a0b"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-12T11:08:48.000Z",
           "commitDate": "2019-05-12T11:08:48.000Z",
@@ -25400,30 +21872,20 @@
         "implicitBranchNo": 2669,
         "seq": 15820,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "b942b5e82e4a781edcbf7d0c94903021ab01bb8c",
-          "parentIds": [
-            "9e4941f9da558035700a3f0015c16e7021e270cb"
-          ],
+          "parentIds": ["9e4941f9da558035700a3f0015c16e7021e270cb"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-12T11:13:43.000Z",
           "commitDate": "2019-05-12T11:13:43.000Z",
@@ -25442,30 +21904,20 @@
         "implicitBranchNo": 2669,
         "seq": 15821,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "52b03c830b3981304098fe60cd3679a83e493078",
-          "parentIds": [
-            "b942b5e82e4a781edcbf7d0c94903021ab01bb8c"
-          ],
+          "parentIds": ["b942b5e82e4a781edcbf7d0c94903021ab01bb8c"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-12T11:48:45.000Z",
           "commitDate": "2019-05-12T11:48:45.000Z",
@@ -25488,30 +21940,20 @@
         "implicitBranchNo": 2669,
         "seq": 15822,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "0d6c0c6283ef7c448a8a0a3ef488b9af1485c50d",
-          "parentIds": [
-            "52b03c830b3981304098fe60cd3679a83e493078"
-          ],
+          "parentIds": ["52b03c830b3981304098fe60cd3679a83e493078"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-12T11:55:10.000Z",
           "commitDate": "2019-05-12T11:55:10.000Z",
@@ -25530,30 +21972,20 @@
         "implicitBranchNo": 2669,
         "seq": 15823,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "53b5db6d281fbbbecd314e69ab80797714c09f15",
-          "parentIds": [
-            "0d6c0c6283ef7c448a8a0a3ef488b9af1485c50d"
-          ],
+          "parentIds": ["0d6c0c6283ef7c448a8a0a3ef488b9af1485c50d"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-12T15:04:38.000Z",
           "commitDate": "2019-05-12T15:04:38.000Z",
@@ -25620,30 +22052,20 @@
         "implicitBranchNo": 2669,
         "seq": 15824,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "a03e9e3a0b8cc34d4772f7cea3bfcb6041cfdecd",
-          "parentIds": [
-            "53b5db6d281fbbbecd314e69ab80797714c09f15"
-          ],
+          "parentIds": ["53b5db6d281fbbbecd314e69ab80797714c09f15"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-12T20:30:08.000Z",
           "commitDate": "2019-05-12T20:30:08.000Z",
@@ -25662,30 +22084,20 @@
         "implicitBranchNo": 2669,
         "seq": 15826,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "95e1db82ff38fdcc64cfe9b9a6a39bbf3d913ae4",
-          "parentIds": [
-            "a03e9e3a0b8cc34d4772f7cea3bfcb6041cfdecd"
-          ],
+          "parentIds": ["a03e9e3a0b8cc34d4772f7cea3bfcb6041cfdecd"],
           "author": {
-            "names": [
-              "Brian Munkholm "
-            ],
-            "emails": [
-              "bmunkholm@users.noreply.github.com"
-            ]
+            "names": ["Brian Munkholm "],
+            "emails": ["bmunkholm@users.noreply.github.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-05-17T09:46:19.000Z",
           "commitDate": "2019-05-17T09:46:19.000Z",
@@ -25776,30 +22188,20 @@
         "implicitBranchNo": 2669,
         "seq": 15844,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "8740dd4539233369d195bf4b32267491c211e321",
-          "parentIds": [
-            "95e1db82ff38fdcc64cfe9b9a6a39bbf3d913ae4"
-          ],
+          "parentIds": ["95e1db82ff38fdcc64cfe9b9a6a39bbf3d913ae4"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-20T21:15:50.000Z",
           "commitDate": "2019-05-20T21:15:50.000Z",
@@ -25822,30 +22224,20 @@
         "implicitBranchNo": 2669,
         "seq": 15847,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "b1b152c780b2c72c4a6f85de407890d6b93a3553",
-          "parentIds": [
-            "8740dd4539233369d195bf4b32267491c211e321"
-          ],
+          "parentIds": ["8740dd4539233369d195bf4b32267491c211e321"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-05-22T08:00:09.000Z",
           "commitDate": "2019-05-22T08:00:09.000Z",
@@ -25868,7 +22260,7 @@
         "implicitBranchNo": 2669,
         "seq": 15850,
         "isMergeCommit": false,
-        "taskId": 2473
+        "clusterId": 2473
       },
       {
         "nodeTypeName": "COMMIT",
@@ -25879,20 +22271,12 @@
             "b1b152c780b2c72c4a6f85de407890d6b93a3553"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-05-22T08:33:48.000Z",
           "commitDate": "2019-05-22T08:33:48.000Z",
@@ -26087,7 +22471,7 @@
         "implicitBranchNo": 0,
         "seq": 15852,
         "isMergeCommit": true,
-        "taskId": 2473
+        "clusterId": 2473
       }
     ]
   },
@@ -26098,24 +22482,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "6de7b332f55517ee3392e712cc9dc6b4c306a286",
-          "parentIds": [
-            "93de40d513b9978dc8a0e28eedfca698ea5a760f"
-          ],
+          "parentIds": ["93de40d513b9978dc8a0e28eedfca698ea5a760f"],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "authorDate": "2019-06-19T00:22:13.000Z",
           "commitDate": "2019-06-19T00:22:13.000Z",
@@ -26146,30 +22520,20 @@
         "implicitBranchNo": 2670,
         "seq": 15856,
         "isMergeCommit": false,
-        "taskId": 2474
+        "clusterId": 2474
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "6bece9e3f2b96c59134cd59b88565f22730a094b",
-          "parentIds": [
-            "6de7b332f55517ee3392e712cc9dc6b4c306a286"
-          ],
+          "parentIds": ["6de7b332f55517ee3392e712cc9dc6b4c306a286"],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "authorDate": "2019-06-19T01:15:32.000Z",
           "commitDate": "2019-06-19T01:15:32.000Z",
@@ -26188,30 +22552,20 @@
         "implicitBranchNo": 2670,
         "seq": 15857,
         "isMergeCommit": false,
-        "taskId": 2474
+        "clusterId": 2474
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "9a3e4be32556fc0609afa2d34fb5d31744ec5da4",
-          "parentIds": [
-            "6bece9e3f2b96c59134cd59b88565f22730a094b"
-          ],
+          "parentIds": ["6bece9e3f2b96c59134cd59b88565f22730a094b"],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "authorDate": "2019-06-19T18:35:38.000Z",
           "commitDate": "2019-06-19T18:35:38.000Z",
@@ -26230,30 +22584,20 @@
         "implicitBranchNo": 2670,
         "seq": 15859,
         "isMergeCommit": false,
-        "taskId": 2474
+        "clusterId": 2474
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "562cce66fb3b13a873114965288f5f63dcfc0335",
-          "parentIds": [
-            "9a3e4be32556fc0609afa2d34fb5d31744ec5da4"
-          ],
+          "parentIds": ["9a3e4be32556fc0609afa2d34fb5d31744ec5da4"],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "authorDate": "2019-06-19T19:00:03.000Z",
           "commitDate": "2019-06-19T19:00:03.000Z",
@@ -26272,30 +22616,20 @@
         "implicitBranchNo": 2670,
         "seq": 15860,
         "isMergeCommit": false,
-        "taskId": 2474
+        "clusterId": 2474
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "db44938d769855f3b2224a99f5fbde189e468fe9",
-          "parentIds": [
-            "562cce66fb3b13a873114965288f5f63dcfc0335"
-          ],
+          "parentIds": ["562cce66fb3b13a873114965288f5f63dcfc0335"],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "authorDate": "2019-06-20T14:12:24.000Z",
           "commitDate": "2019-06-20T14:12:24.000Z",
@@ -26314,30 +22648,20 @@
         "implicitBranchNo": 2670,
         "seq": 15863,
         "isMergeCommit": false,
-        "taskId": 2474
+        "clusterId": 2474
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "1c9163f2bd2c89da0938cf5047365643592a6484",
-          "parentIds": [
-            "db44938d769855f3b2224a99f5fbde189e468fe9"
-          ],
+          "parentIds": ["db44938d769855f3b2224a99f5fbde189e468fe9"],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "authorDate": "2019-06-20T15:37:10.000Z",
           "commitDate": "2019-06-20T15:37:10.000Z",
@@ -26356,30 +22680,20 @@
         "implicitBranchNo": 2670,
         "seq": 15865,
         "isMergeCommit": false,
-        "taskId": 2474
+        "clusterId": 2474
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "46eda9f53c342db52f439cbee62bd799f86f6e6a",
-          "parentIds": [
-            "1c9163f2bd2c89da0938cf5047365643592a6484"
-          ],
+          "parentIds": ["1c9163f2bd2c89da0938cf5047365643592a6484"],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "authorDate": "2019-06-20T15:38:46.000Z",
           "commitDate": "2019-06-20T15:38:46.000Z",
@@ -26398,30 +22712,20 @@
         "implicitBranchNo": 2670,
         "seq": 15866,
         "isMergeCommit": false,
-        "taskId": 2474
+        "clusterId": 2474
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "29d6b1c3954f0d9cd1ae15c2ea6e4b733376751e",
-          "parentIds": [
-            "46eda9f53c342db52f439cbee62bd799f86f6e6a"
-          ],
+          "parentIds": ["46eda9f53c342db52f439cbee62bd799f86f6e6a"],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "authorDate": "2019-06-20T15:45:30.000Z",
           "commitDate": "2019-06-20T15:45:30.000Z",
@@ -26440,30 +22744,20 @@
         "implicitBranchNo": 2670,
         "seq": 15867,
         "isMergeCommit": false,
-        "taskId": 2474
+        "clusterId": 2474
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "77de5c1b43ccd75f3191ecb51f481d26f2c66cd1",
-          "parentIds": [
-            "29d6b1c3954f0d9cd1ae15c2ea6e4b733376751e"
-          ],
+          "parentIds": ["29d6b1c3954f0d9cd1ae15c2ea6e4b733376751e"],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "authorDate": "2019-06-20T15:49:54.000Z",
           "commitDate": "2019-06-20T15:49:54.000Z",
@@ -26482,7 +22776,7 @@
         "implicitBranchNo": 2670,
         "seq": 15868,
         "isMergeCommit": false,
-        "taskId": 2474
+        "clusterId": 2474
       },
       {
         "nodeTypeName": "COMMIT",
@@ -26493,20 +22787,12 @@
             "77de5c1b43ccd75f3191ecb51f481d26f2c66cd1"
           ],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nh@realm.io"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nh@realm.io"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-06-20T16:14:37.000Z",
           "commitDate": "2019-06-20T16:14:37.000Z",
@@ -26553,7 +22839,7 @@
         "implicitBranchNo": 0,
         "seq": 15870,
         "isMergeCommit": true,
-        "taskId": 2474
+        "clusterId": 2474
       }
     ]
   },
@@ -26564,24 +22850,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "6757222429cdab75bbda0d829cb5ec5f6ec36173",
-          "parentIds": [
-            "e4d7db462c0daa7d023811b6cb69f24b8cf8c9b4"
-          ],
+          "parentIds": ["e4d7db462c0daa7d023811b6cb69f24b8cf8c9b4"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-06-19T11:48:38.000Z",
           "commitDate": "2019-06-19T11:48:38.000Z",
@@ -26604,30 +22880,20 @@
         "implicitBranchNo": 2663,
         "seq": 15858,
         "isMergeCommit": false,
-        "taskId": 2475
+        "clusterId": 2475
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "539a631f36ac2f72ea803d14b17eaf5a5d6a8fa1",
-          "parentIds": [
-            "6757222429cdab75bbda0d829cb5ec5f6ec36173"
-          ],
+          "parentIds": ["6757222429cdab75bbda0d829cb5ec5f6ec36173"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-06-20T10:27:57.000Z",
           "commitDate": "2019-06-20T10:27:57.000Z",
@@ -26646,30 +22912,20 @@
         "implicitBranchNo": 2663,
         "seq": 15861,
         "isMergeCommit": false,
-        "taskId": 2475
+        "clusterId": 2475
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "59441ccbe8b4856a357a63fd9c18ccf9744e17b3",
-          "parentIds": [
-            "539a631f36ac2f72ea803d14b17eaf5a5d6a8fa1"
-          ],
+          "parentIds": ["539a631f36ac2f72ea803d14b17eaf5a5d6a8fa1"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-06-20T12:56:12.000Z",
           "commitDate": "2019-06-20T12:56:12.000Z",
@@ -26688,7 +22944,7 @@
         "implicitBranchNo": 2663,
         "seq": 15862,
         "isMergeCommit": false,
-        "taskId": 2475
+        "clusterId": 2475
       },
       {
         "nodeTypeName": "COMMIT",
@@ -26699,20 +22955,12 @@
             "59441ccbe8b4856a357a63fd9c18ccf9744e17b3"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-06-20T14:23:07.000Z",
           "commitDate": "2019-06-20T14:23:07.000Z",
@@ -26743,7 +22991,7 @@
         "implicitBranchNo": 2662,
         "seq": 15864,
         "isMergeCommit": true,
-        "taskId": 2475
+        "clusterId": 2475
       },
       {
         "nodeTypeName": "COMMIT",
@@ -26754,20 +23002,12 @@
             "97ee36d8aefc7fea0c991c68577f2cbcb3486f0b"
           ],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "authorDate": "2019-06-20T17:01:08.000Z",
           "commitDate": "2019-06-20T17:01:08.000Z",
@@ -27106,30 +23346,20 @@
         "implicitBranchNo": 2671,
         "seq": 15871,
         "isMergeCommit": true,
-        "taskId": 2475
+        "clusterId": 2475
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "9f6d95e5ab99ca3391f2050b8ddfe86e6c8f4ae4",
-          "parentIds": [
-            "d9a26ca38ba4369301e41647f804cd8e4d6a38e5"
-          ],
+          "parentIds": ["d9a26ca38ba4369301e41647f804cd8e4d6a38e5"],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "authorDate": "2019-06-20T17:03:35.000Z",
           "commitDate": "2019-06-20T17:03:35.000Z",
@@ -27148,30 +23378,20 @@
         "implicitBranchNo": 2671,
         "seq": 15872,
         "isMergeCommit": false,
-        "taskId": 2475
+        "clusterId": 2475
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "85527b6060fb3f3678b79734b9081196a0c7d43b",
-          "parentIds": [
-            "9f6d95e5ab99ca3391f2050b8ddfe86e6c8f4ae4"
-          ],
+          "parentIds": ["9f6d95e5ab99ca3391f2050b8ddfe86e6c8f4ae4"],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "authorDate": "2019-06-20T17:03:35.000Z",
           "commitDate": "2019-06-20T17:03:35.000Z",
@@ -27190,7 +23410,7 @@
         "implicitBranchNo": 2671,
         "seq": 15873,
         "isMergeCommit": false,
-        "taskId": 2475
+        "clusterId": 2475
       },
       {
         "nodeTypeName": "COMMIT",
@@ -27201,20 +23421,12 @@
             "85527b6060fb3f3678b79734b9081196a0c7d43b"
           ],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nh@realm.io"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nh@realm.io"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-06-20T23:43:13.000Z",
           "commitDate": "2019-06-20T23:43:13.000Z",
@@ -27245,7 +23457,7 @@
         "implicitBranchNo": 0,
         "seq": 15874,
         "isMergeCommit": true,
-        "taskId": 2475
+        "clusterId": 2475
       }
     ]
   },
@@ -27256,24 +23468,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "2145449fa49501ae3a762a8faaf1bdb82770c7e0",
-          "parentIds": [
-            "8e2a45f38d9305bee76bd428c5e71c6ca1f43e6f"
-          ],
+          "parentIds": ["8e2a45f38d9305bee76bd428c5e71c6ca1f43e6f"],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nh@realm.io"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nh@realm.io"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-06-20T23:45:04.000Z",
           "commitDate": "2019-06-20T23:45:04.000Z",
@@ -27292,7 +23494,7 @@
         "implicitBranchNo": 2672,
         "seq": 15875,
         "isMergeCommit": false,
-        "taskId": 2476
+        "clusterId": 2476
       },
       {
         "nodeTypeName": "COMMIT",
@@ -27303,20 +23505,12 @@
             "2145449fa49501ae3a762a8faaf1bdb82770c7e0"
           ],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nh@realm.io"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nh@realm.io"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-06-20T23:45:40.000Z",
           "commitDate": "2019-06-20T23:45:40.000Z",
@@ -27335,7 +23529,7 @@
         "implicitBranchNo": 0,
         "seq": 15876,
         "isMergeCommit": true,
-        "taskId": 2476
+        "clusterId": 2476
       }
     ]
   },
@@ -27346,24 +23540,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "a96a0701342bbb47d578b8de11793569fde4f09c",
-          "parentIds": [
-            "aef9e4897084b3330da46aedc39ee22b1de6fcc0"
-          ],
+          "parentIds": ["aef9e4897084b3330da46aedc39ee22b1de6fcc0"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-07-02T09:49:40.000Z",
           "commitDate": "2019-07-02T09:49:40.000Z",
@@ -27394,30 +23578,20 @@
         "implicitBranchNo": 2673,
         "seq": 15879,
         "isMergeCommit": false,
-        "taskId": 2477
+        "clusterId": 2477
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "860df4e610f5eb127b93e1171aea49eafd750bbc",
-          "parentIds": [
-            "a96a0701342bbb47d578b8de11793569fde4f09c"
-          ],
+          "parentIds": ["a96a0701342bbb47d578b8de11793569fde4f09c"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-07-02T09:51:33.000Z",
           "commitDate": "2019-07-02T09:51:33.000Z",
@@ -27436,30 +23610,20 @@
         "implicitBranchNo": 2673,
         "seq": 15880,
         "isMergeCommit": false,
-        "taskId": 2477
+        "clusterId": 2477
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "22ba4459de1f413185bf3afd17416b11a84fd3fd",
-          "parentIds": [
-            "860df4e610f5eb127b93e1171aea49eafd750bbc"
-          ],
+          "parentIds": ["860df4e610f5eb127b93e1171aea49eafd750bbc"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-07-02T12:27:31.000Z",
           "commitDate": "2019-07-02T12:27:31.000Z",
@@ -27478,7 +23642,7 @@
         "implicitBranchNo": 2673,
         "seq": 15881,
         "isMergeCommit": false,
-        "taskId": 2477
+        "clusterId": 2477
       },
       {
         "nodeTypeName": "COMMIT",
@@ -27489,20 +23653,12 @@
             "22ba4459de1f413185bf3afd17416b11a84fd3fd"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-07-03T14:22:53.000Z",
           "commitDate": "2019-07-03T14:22:53.000Z",
@@ -27533,7 +23689,7 @@
         "implicitBranchNo": 0,
         "seq": 15882,
         "isMergeCommit": true,
-        "taskId": 2477
+        "clusterId": 2477
       }
     ]
   },
@@ -27544,24 +23700,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "65252178f541204a494d8fd8e2ef18f66549b57c",
-          "parentIds": [
-            "aef9e4897084b3330da46aedc39ee22b1de6fcc0"
-          ],
+          "parentIds": ["aef9e4897084b3330da46aedc39ee22b1de6fcc0"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-06-27T20:31:09.000Z",
           "commitDate": "2019-06-27T20:31:09.000Z",
@@ -27608,30 +23754,20 @@
         "implicitBranchNo": 2674,
         "seq": 15878,
         "isMergeCommit": false,
-        "taskId": 2478
+        "clusterId": 2478
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "5b133b6d233fa363387f5acef432714277e70d18",
-          "parentIds": [
-            "65252178f541204a494d8fd8e2ef18f66549b57c"
-          ],
+          "parentIds": ["65252178f541204a494d8fd8e2ef18f66549b57c"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-07-04T07:04:48.000Z",
           "commitDate": "2019-07-04T07:04:48.000Z",
@@ -27670,7 +23806,7 @@
         "implicitBranchNo": 2674,
         "seq": 15883,
         "isMergeCommit": false,
-        "taskId": 2478
+        "clusterId": 2478
       },
       {
         "nodeTypeName": "COMMIT",
@@ -27681,20 +23817,12 @@
             "81568ef06d9d595fb5249083ca01ae2c718f5ae9"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-07-04T07:06:15.000Z",
           "commitDate": "2019-07-04T07:06:15.000Z",
@@ -27725,30 +23853,20 @@
         "implicitBranchNo": 2674,
         "seq": 15884,
         "isMergeCommit": true,
-        "taskId": 2478
+        "clusterId": 2478
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "5335f5be32d87d8400d418908464541986fede55",
-          "parentIds": [
-            "1fb35cdb698ad86cc5cf5af98223004e6bd852e8"
-          ],
+          "parentIds": ["1fb35cdb698ad86cc5cf5af98223004e6bd852e8"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-07-04T07:51:49.000Z",
           "commitDate": "2019-07-04T07:51:49.000Z",
@@ -27771,30 +23889,20 @@
         "implicitBranchNo": 2674,
         "seq": 15885,
         "isMergeCommit": false,
-        "taskId": 2478
+        "clusterId": 2478
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "5ac2971934b0b063e6ccf0cae04b50ff2ea67ccc",
-          "parentIds": [
-            "5335f5be32d87d8400d418908464541986fede55"
-          ],
+          "parentIds": ["5335f5be32d87d8400d418908464541986fede55"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-07-04T09:11:15.000Z",
           "commitDate": "2019-07-04T09:11:15.000Z",
@@ -27813,30 +23921,20 @@
         "implicitBranchNo": 2674,
         "seq": 15886,
         "isMergeCommit": false,
-        "taskId": 2478
+        "clusterId": 2478
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "008ba33b2cca2d088ec645525f03e84dd4a51d50",
-          "parentIds": [
-            "5ac2971934b0b063e6ccf0cae04b50ff2ea67ccc"
-          ],
+          "parentIds": ["5ac2971934b0b063e6ccf0cae04b50ff2ea67ccc"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-07-04T10:36:52.000Z",
           "commitDate": "2019-07-04T10:36:52.000Z",
@@ -27867,30 +23965,20 @@
         "implicitBranchNo": 2674,
         "seq": 15887,
         "isMergeCommit": false,
-        "taskId": 2478
+        "clusterId": 2478
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "38a89714ec3efe4d5e84a8d2924950f265b5f879",
-          "parentIds": [
-            "008ba33b2cca2d088ec645525f03e84dd4a51d50"
-          ],
+          "parentIds": ["008ba33b2cca2d088ec645525f03e84dd4a51d50"],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "authorDate": "2019-07-23T19:02:35.000Z",
           "commitDate": "2019-07-23T19:02:35.000Z",
@@ -27913,7 +24001,7 @@
         "implicitBranchNo": 2674,
         "seq": 15888,
         "isMergeCommit": false,
-        "taskId": 2478
+        "clusterId": 2478
       },
       {
         "nodeTypeName": "COMMIT",
@@ -27924,20 +24012,12 @@
             "38a89714ec3efe4d5e84a8d2924950f265b5f879"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nh@realm.io"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nh@realm.io"]
           },
           "authorDate": "2019-07-23T20:18:09.000Z",
           "commitDate": "2019-07-23T20:18:09.000Z",
@@ -28004,7 +24084,7 @@
         "implicitBranchNo": 0,
         "seq": 15889,
         "isMergeCommit": true,
-        "taskId": 2478
+        "clusterId": 2478
       }
     ]
   },
@@ -28015,24 +24095,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "f2b7594765352cfb0e53efdc3bdc4371fe8b617f",
-          "parentIds": [
-            "4371f7cf3c1b5fd114757618be5f630851de355f"
-          ],
+          "parentIds": ["4371f7cf3c1b5fd114757618be5f630851de355f"],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "authorDate": "2019-07-23T20:44:26.000Z",
           "commitDate": "2019-07-23T20:44:26.000Z",
@@ -28051,7 +24121,7 @@
         "implicitBranchNo": 0,
         "seq": 15890,
         "isMergeCommit": false,
-        "taskId": 2479
+        "clusterId": 2479
       }
     ]
   },
@@ -28062,24 +24132,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "180e09d75d3b813a0c6d27517b53ac9dfd203f2e",
-          "parentIds": [
-            "f2b7594765352cfb0e53efdc3bdc4371fe8b617f"
-          ],
+          "parentIds": ["f2b7594765352cfb0e53efdc3bdc4371fe8b617f"],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "authorDate": "2019-07-23T20:45:07.000Z",
           "commitDate": "2019-07-23T20:45:07.000Z",
@@ -28098,7 +24158,7 @@
         "implicitBranchNo": 0,
         "seq": 15891,
         "isMergeCommit": false,
-        "taskId": 2480
+        "clusterId": 2480
       }
     ]
   },
@@ -28109,24 +24169,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "39202ee6bde28afeaa2db8e11a964d1ac361821f",
-          "parentIds": [
-            "180e09d75d3b813a0c6d27517b53ac9dfd203f2e"
-          ],
+          "parentIds": ["180e09d75d3b813a0c6d27517b53ac9dfd203f2e"],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nabil.hachicha@gmail.com"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nabil.hachicha@gmail.com"]
           },
           "authorDate": "2019-07-23T20:45:07.000Z",
           "commitDate": "2019-07-23T20:45:07.000Z",
@@ -28145,7 +24195,7 @@
         "implicitBranchNo": 0,
         "seq": 15892,
         "isMergeCommit": false,
-        "taskId": 2481
+        "clusterId": 2481
       }
     ]
   },
@@ -28156,24 +24206,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "8a56e7e69c4ec878708cc6705bf7cfe9d53e76c7",
-          "parentIds": [
-            "39202ee6bde28afeaa2db8e11a964d1ac361821f"
-          ],
+          "parentIds": ["39202ee6bde28afeaa2db8e11a964d1ac361821f"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-05T08:38:23.000Z",
           "commitDate": "2019-08-05T08:38:23.000Z",
@@ -28212,7 +24252,7 @@
         "implicitBranchNo": 2676,
         "seq": 15906,
         "isMergeCommit": false,
-        "taskId": 2482
+        "clusterId": 2482
       },
       {
         "nodeTypeName": "COMMIT",
@@ -28223,20 +24263,12 @@
             "8a56e7e69c4ec878708cc6705bf7cfe9d53e76c7"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-08-05T13:32:20.000Z",
           "commitDate": "2019-08-05T13:32:20.000Z",
@@ -28275,7 +24307,7 @@
         "implicitBranchNo": 0,
         "seq": 15907,
         "isMergeCommit": true,
-        "taskId": 2482
+        "clusterId": 2482
       }
     ]
   },
@@ -28291,20 +24323,12 @@
             "39202ee6bde28afeaa2db8e11a964d1ac361821f"
           ],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nh@realm.io"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nh@realm.io"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-07-25T14:23:29.000Z",
           "commitDate": "2019-07-25T14:23:29.000Z",
@@ -28327,30 +24351,20 @@
         "implicitBranchNo": 2675,
         "seq": 15893,
         "isMergeCommit": true,
-        "taskId": 2483
+        "clusterId": 2483
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "3fa349a0902f6cd1e03c678a537f767a474376f8",
-          "parentIds": [
-            "c64428d15da8847ed3befe6d7ac25e865a39df15"
-          ],
+          "parentIds": ["c64428d15da8847ed3befe6d7ac25e865a39df15"],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nh@realm.io"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nh@realm.io"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-07-25T14:24:36.000Z",
           "commitDate": "2019-07-25T14:24:36.000Z",
@@ -28369,7 +24383,7 @@
         "implicitBranchNo": 2678,
         "seq": 15894,
         "isMergeCommit": false,
-        "taskId": 2483
+        "clusterId": 2483
       },
       {
         "nodeTypeName": "COMMIT",
@@ -28380,20 +24394,12 @@
             "3fa349a0902f6cd1e03c678a537f767a474376f8"
           ],
           "author": {
-            "names": [
-              "Nabil Hachicha "
-            ],
-            "emails": [
-              "nh@realm.io"
-            ]
+            "names": ["Nabil Hachicha "],
+            "emails": ["nh@realm.io"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-07-25T14:25:07.000Z",
           "commitDate": "2019-07-25T14:25:07.000Z",
@@ -28412,30 +24418,20 @@
         "implicitBranchNo": 2675,
         "seq": 15895,
         "isMergeCommit": true,
-        "taskId": 2483
+        "clusterId": 2483
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "a55f5eadabcbf1e3aeb23bdb59a1a18290730344",
-          "parentIds": [
-            "fd5e041c38b8451c8ba1fe344fa4e19a6811beea"
-          ],
+          "parentIds": ["fd5e041c38b8451c8ba1fe344fa4e19a6811beea"],
           "author": {
-            "names": [
-              "Tobias Preuss "
-            ],
-            "emails": [
-              "tobias.preuss@googlemail.com"
-            ]
+            "names": ["Tobias Preuss "],
+            "emails": ["tobias.preuss@googlemail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-07-31T14:40:07.000Z",
           "commitDate": "2019-07-31T14:40:07.000Z",
@@ -28454,30 +24450,20 @@
         "implicitBranchNo": 2680,
         "seq": 15899,
         "isMergeCommit": false,
-        "taskId": 2483
+        "clusterId": 2483
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "cf5992bd5ddcc6f028dbbb5a9e0e481406e0dc8b",
-          "parentIds": [
-            "fd5e041c38b8451c8ba1fe344fa4e19a6811beea"
-          ],
+          "parentIds": ["fd5e041c38b8451c8ba1fe344fa4e19a6811beea"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-07-31T16:35:34.000Z",
           "commitDate": "2019-07-31T16:35:34.000Z",
@@ -28508,30 +24494,20 @@
         "implicitBranchNo": 2679,
         "seq": 15900,
         "isMergeCommit": false,
-        "taskId": 2483
+        "clusterId": 2483
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "628a422223e4f134c7a089beacb0b2d1af3af469",
-          "parentIds": [
-            "cf5992bd5ddcc6f028dbbb5a9e0e481406e0dc8b"
-          ],
+          "parentIds": ["cf5992bd5ddcc6f028dbbb5a9e0e481406e0dc8b"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-07-31T16:39:52.000Z",
           "commitDate": "2019-07-31T16:39:52.000Z",
@@ -28550,7 +24526,7 @@
         "implicitBranchNo": 2679,
         "seq": 15901,
         "isMergeCommit": false,
-        "taskId": 2483
+        "clusterId": 2483
       },
       {
         "nodeTypeName": "COMMIT",
@@ -28561,20 +24537,12 @@
             "a55f5eadabcbf1e3aeb23bdb59a1a18290730344"
           ],
           "author": {
-            "names": [
-              "Tobias Preuss "
-            ],
-            "emails": [
-              "tobias.preuss@googlemail.com"
-            ]
+            "names": ["Tobias Preuss "],
+            "emails": ["tobias.preuss@googlemail.com"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-01T11:09:14.000Z",
           "commitDate": "2019-08-01T11:09:14.000Z",
@@ -28593,30 +24561,20 @@
         "implicitBranchNo": 2675,
         "seq": 15902,
         "isMergeCommit": true,
-        "taskId": 2483
+        "clusterId": 2483
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "61b4a962316a39e0330987f920698db73692764d",
-          "parentIds": [
-            "628a422223e4f134c7a089beacb0b2d1af3af469"
-          ],
+          "parentIds": ["628a422223e4f134c7a089beacb0b2d1af3af469"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-08-02T11:19:03.000Z",
           "commitDate": "2019-08-02T11:19:03.000Z",
@@ -28635,7 +24593,7 @@
         "implicitBranchNo": 2679,
         "seq": 15903,
         "isMergeCommit": false,
-        "taskId": 2483
+        "clusterId": 2483
       },
       {
         "nodeTypeName": "COMMIT",
@@ -28646,20 +24604,12 @@
             "61b4a962316a39e0330987f920698db73692764d"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-08-02T11:19:19.000Z",
           "commitDate": "2019-08-02T11:19:19.000Z",
@@ -28690,30 +24640,20 @@
         "implicitBranchNo": 2681,
         "seq": 15904,
         "isMergeCommit": true,
-        "taskId": 2483
+        "clusterId": 2483
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "bbbe14352fd4665388c6c4469aa0936e0a2f937f",
-          "parentIds": [
-            "ab067ea2029dfee96e7e2c7d09e68f4083ef4d87"
-          ],
+          "parentIds": ["ab067ea2029dfee96e7e2c7d09e68f4083ef4d87"],
           "author": {
-            "names": [
-              "Yavor Georgiev "
-            ],
-            "emails": [
-              "fealebenpae@gmail.com"
-            ]
+            "names": ["Yavor Georgiev "],
+            "emails": ["fealebenpae@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Yavor Georgiev "
-            ],
-            "emails": [
-              "fealebenpae@gmail.com"
-            ]
+            "names": ["Yavor Georgiev "],
+            "emails": ["fealebenpae@gmail.com"]
           },
           "authorDate": "2019-08-04T20:55:34.000Z",
           "commitDate": "2019-08-04T20:55:34.000Z",
@@ -28740,30 +24680,20 @@
         "implicitBranchNo": 2675,
         "seq": 15905,
         "isMergeCommit": false,
-        "taskId": 2483
+        "clusterId": 2483
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "f01acb88708b021848cd9de62f6d64cf71bf9a15",
-          "parentIds": [
-            "bbbe14352fd4665388c6c4469aa0936e0a2f937f"
-          ],
+          "parentIds": ["bbbe14352fd4665388c6c4469aa0936e0a2f937f"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-05T13:40:59.000Z",
           "commitDate": "2019-08-05T13:40:59.000Z",
@@ -28790,30 +24720,20 @@
         "implicitBranchNo": 2675,
         "seq": 15908,
         "isMergeCommit": false,
-        "taskId": 2483
+        "clusterId": 2483
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "43be05c39151b0fd1da0d43cff0aa88d253807b2",
-          "parentIds": [
-            "f01acb88708b021848cd9de62f6d64cf71bf9a15"
-          ],
+          "parentIds": ["f01acb88708b021848cd9de62f6d64cf71bf9a15"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-05T13:44:44.000Z",
           "commitDate": "2019-08-05T13:44:44.000Z",
@@ -28832,7 +24752,7 @@
         "implicitBranchNo": 2675,
         "seq": 15909,
         "isMergeCommit": false,
-        "taskId": 2483
+        "clusterId": 2483
       },
       {
         "nodeTypeName": "COMMIT",
@@ -28843,20 +24763,12 @@
             "43be05c39151b0fd1da0d43cff0aa88d253807b2"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-08-05T15:13:20.000Z",
           "commitDate": "2019-08-05T15:13:20.000Z",
@@ -28891,7 +24803,7 @@
         "implicitBranchNo": 2681,
         "seq": 15910,
         "isMergeCommit": true,
-        "taskId": 2483
+        "clusterId": 2483
       },
       {
         "nodeTypeName": "COMMIT",
@@ -28902,20 +24814,12 @@
             "beff07199509ea7d3d5d3ebdb30be90bd45120a0"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-05T15:14:46.000Z",
           "commitDate": "2019-08-05T15:14:46.000Z",
@@ -28966,7 +24870,7 @@
         "implicitBranchNo": 0,
         "seq": 15911,
         "isMergeCommit": true,
-        "taskId": 2483
+        "clusterId": 2483
       }
     ]
   },
@@ -28977,24 +24881,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "7d90396b292346ba39ac91c10b3e9fc453a533f5",
-          "parentIds": [
-            "e4ebc48375502d5729cfd3c9e530dfb35467d9b4"
-          ],
+          "parentIds": ["e4ebc48375502d5729cfd3c9e530dfb35467d9b4"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-05T20:04:11.000Z",
           "commitDate": "2019-08-05T20:04:11.000Z",
@@ -29013,7 +24907,7 @@
         "implicitBranchNo": 0,
         "seq": 15915,
         "isMergeCommit": false,
-        "taskId": 2484
+        "clusterId": 2484
       }
     ]
   },
@@ -29024,24 +24918,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "5f735dad5ec4585557c4f6921fbfacc25aa966b8",
-          "parentIds": [
-            "7d90396b292346ba39ac91c10b3e9fc453a533f5"
-          ],
+          "parentIds": ["7d90396b292346ba39ac91c10b3e9fc453a533f5"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-05T20:06:39.000Z",
           "commitDate": "2019-08-05T20:06:39.000Z",
@@ -29060,7 +24944,7 @@
         "implicitBranchNo": 0,
         "seq": 15916,
         "isMergeCommit": false,
-        "taskId": 2485
+        "clusterId": 2485
       }
     ]
   },
@@ -29071,24 +24955,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "1844788c3cd478a1d1a13452a15823394363e722",
-          "parentIds": [
-            "5f735dad5ec4585557c4f6921fbfacc25aa966b8"
-          ],
+          "parentIds": ["5f735dad5ec4585557c4f6921fbfacc25aa966b8"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-05T20:07:16.000Z",
           "commitDate": "2019-08-05T20:07:16.000Z",
@@ -29107,7 +24981,7 @@
         "implicitBranchNo": 0,
         "seq": 15917,
         "isMergeCommit": false,
-        "taskId": 2486
+        "clusterId": 2486
       }
     ]
   },
@@ -29118,24 +24992,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "5d001370280101e5ca7df870ae6f9dbf2513a556",
-          "parentIds": [
-            "1844788c3cd478a1d1a13452a15823394363e722"
-          ],
+          "parentIds": ["1844788c3cd478a1d1a13452a15823394363e722"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-05T20:07:44.000Z",
           "commitDate": "2019-08-05T20:07:44.000Z",
@@ -29154,7 +25018,7 @@
         "implicitBranchNo": 0,
         "seq": 15918,
         "isMergeCommit": false,
-        "taskId": 2487
+        "clusterId": 2487
       }
     ]
   },
@@ -29165,24 +25029,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "e3e27931e16b2223677a31989c4835e08957cbdb",
-          "parentIds": [
-            "5d001370280101e5ca7df870ae6f9dbf2513a556"
-          ],
+          "parentIds": ["5d001370280101e5ca7df870ae6f9dbf2513a556"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-05T20:07:44.000Z",
           "commitDate": "2019-08-05T20:07:44.000Z",
@@ -29201,7 +25055,7 @@
         "implicitBranchNo": 0,
         "seq": 15919,
         "isMergeCommit": false,
-        "taskId": 2488
+        "clusterId": 2488
       }
     ]
   },
@@ -29212,24 +25066,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "141c9eba1c76c6e79ca1dd377d939323b0941808",
-          "parentIds": [
-            "e3e27931e16b2223677a31989c4835e08957cbdb"
-          ],
+          "parentIds": ["e3e27931e16b2223677a31989c4835e08957cbdb"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-05T21:12:45.000Z",
           "commitDate": "2019-08-05T21:12:45.000Z",
@@ -29248,7 +25092,7 @@
         "implicitBranchNo": 0,
         "seq": 15920,
         "isMergeCommit": false,
-        "taskId": 2489
+        "clusterId": 2489
       }
     ]
   },
@@ -29259,24 +25103,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "62fe3a8afa9d0a072d09231fdc5e610bf183bce7",
-          "parentIds": [
-            "fa111cd983ebb8fc09d0c3615f21bbe3ff8e0f72"
-          ],
+          "parentIds": ["fa111cd983ebb8fc09d0c3615f21bbe3ff8e0f72"],
           "author": {
-            "names": [
-              "Jason Flax "
-            ],
-            "emails": [
-              "jsflax@gmail.com"
-            ]
+            "names": ["Jason Flax "],
+            "emails": ["jsflax@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Jason Flax "
-            ],
-            "emails": [
-              "jsflax@gmail.com"
-            ]
+            "names": ["Jason Flax "],
+            "emails": ["jsflax@gmail.com"]
           },
           "authorDate": "2019-08-06T14:44:34.000Z",
           "commitDate": "2019-08-06T14:44:34.000Z",
@@ -29295,30 +25129,20 @@
         "implicitBranchNo": 2667,
         "seq": 15921,
         "isMergeCommit": false,
-        "taskId": 2490
+        "clusterId": 2490
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "f6d16a5652638d40e9024aa2129169c0fca688da",
-          "parentIds": [
-            "62fe3a8afa9d0a072d09231fdc5e610bf183bce7"
-          ],
+          "parentIds": ["62fe3a8afa9d0a072d09231fdc5e610bf183bce7"],
           "author": {
-            "names": [
-              "Jason Flax "
-            ],
-            "emails": [
-              "jsflax@gmail.com"
-            ]
+            "names": ["Jason Flax "],
+            "emails": ["jsflax@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Jason Flax "
-            ],
-            "emails": [
-              "jsflax@gmail.com"
-            ]
+            "names": ["Jason Flax "],
+            "emails": ["jsflax@gmail.com"]
           },
           "authorDate": "2019-08-06T15:12:00.000Z",
           "commitDate": "2019-08-06T15:12:00.000Z",
@@ -29341,7 +25165,7 @@
         "implicitBranchNo": 2667,
         "seq": 15922,
         "isMergeCommit": false,
-        "taskId": 2490
+        "clusterId": 2490
       },
       {
         "nodeTypeName": "COMMIT",
@@ -29352,20 +25176,12 @@
             "141c9eba1c76c6e79ca1dd377d939323b0941808"
           ],
           "author": {
-            "names": [
-              "Jason Flax "
-            ],
-            "emails": [
-              "jsflax@gmail.com"
-            ]
+            "names": ["Jason Flax "],
+            "emails": ["jsflax@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Jason Flax "
-            ],
-            "emails": [
-              "jsflax@gmail.com"
-            ]
+            "names": ["Jason Flax "],
+            "emails": ["jsflax@gmail.com"]
           },
           "authorDate": "2019-08-07T10:47:01.000Z",
           "commitDate": "2019-08-07T10:47:01.000Z",
@@ -29780,7 +25596,7 @@
         "implicitBranchNo": 2667,
         "seq": 15923,
         "isMergeCommit": true,
-        "taskId": 2490
+        "clusterId": 2490
       },
       {
         "nodeTypeName": "COMMIT",
@@ -29791,20 +25607,12 @@
             "6f626ce73ddf22e6347e8ba6de8352c7fe078caf"
           ],
           "author": {
-            "names": [
-              "Jason Flax "
-            ],
-            "emails": [
-              "jsflax@gmail.com"
-            ]
+            "names": ["Jason Flax "],
+            "emails": ["jsflax@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-08-07T11:47:28.000Z",
           "commitDate": "2019-08-07T11:47:28.000Z",
@@ -29827,7 +25635,7 @@
         "implicitBranchNo": 0,
         "seq": 15924,
         "isMergeCommit": true,
-        "taskId": 2490
+        "clusterId": 2490
       }
     ]
   },
@@ -29838,24 +25646,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "b8436c394f2213ea01f292a22884d7cfd25f2a18",
-          "parentIds": [
-            "92c239ca32fcf4132bad2e2673c55b8f71976d6c"
-          ],
+          "parentIds": ["92c239ca32fcf4132bad2e2673c55b8f71976d6c"],
           "author": {
-            "names": [
-              "Jason Flax "
-            ],
-            "emails": [
-              "jsflax@gmail.com"
-            ]
+            "names": ["Jason Flax "],
+            "emails": ["jsflax@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Jason Flax "
-            ],
-            "emails": [
-              "jsflax@gmail.com"
-            ]
+            "names": ["Jason Flax "],
+            "emails": ["jsflax@gmail.com"]
           },
           "authorDate": "2019-08-12T10:31:06.000Z",
           "commitDate": "2019-08-12T10:31:06.000Z",
@@ -29874,7 +25672,7 @@
         "implicitBranchNo": 0,
         "seq": 15927,
         "isMergeCommit": false,
-        "taskId": 2491
+        "clusterId": 2491
       }
     ]
   },
@@ -29885,24 +25683,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "05d3dcee03c9ae85e6847f081ef58100fe1fb5e3",
-          "parentIds": [
-            "b8436c394f2213ea01f292a22884d7cfd25f2a18"
-          ],
+          "parentIds": ["b8436c394f2213ea01f292a22884d7cfd25f2a18"],
           "author": {
-            "names": [
-              "Jason Flax "
-            ],
-            "emails": [
-              "jsflax@gmail.com"
-            ]
+            "names": ["Jason Flax "],
+            "emails": ["jsflax@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Jason Flax "
-            ],
-            "emails": [
-              "jsflax@gmail.com"
-            ]
+            "names": ["Jason Flax "],
+            "emails": ["jsflax@gmail.com"]
           },
           "authorDate": "2019-08-12T10:33:26.000Z",
           "commitDate": "2019-08-12T10:33:26.000Z",
@@ -29921,7 +25709,7 @@
         "implicitBranchNo": 0,
         "seq": 15928,
         "isMergeCommit": false,
-        "taskId": 2492
+        "clusterId": 2492
       }
     ]
   },
@@ -29932,24 +25720,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "4176427cd7920c2acf84f1925093827f0c42ce62",
-          "parentIds": [
-            "05d3dcee03c9ae85e6847f081ef58100fe1fb5e3"
-          ],
+          "parentIds": ["05d3dcee03c9ae85e6847f081ef58100fe1fb5e3"],
           "author": {
-            "names": [
-              "Jason Flax "
-            ],
-            "emails": [
-              "jsflax@gmail.com"
-            ]
+            "names": ["Jason Flax "],
+            "emails": ["jsflax@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Jason Flax "
-            ],
-            "emails": [
-              "jsflax@gmail.com"
-            ]
+            "names": ["Jason Flax "],
+            "emails": ["jsflax@gmail.com"]
           },
           "authorDate": "2019-08-12T10:33:27.000Z",
           "commitDate": "2019-08-12T10:33:27.000Z",
@@ -29968,7 +25746,7 @@
         "implicitBranchNo": 0,
         "seq": 15929,
         "isMergeCommit": false,
-        "taskId": 2493
+        "clusterId": 2493
       }
     ]
   },
@@ -29979,24 +25757,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "60be73f367b89df0be041a91568dcea8019194cd",
-          "parentIds": [
-            "e3e27931e16b2223677a31989c4835e08957cbdb"
-          ],
+          "parentIds": ["e3e27931e16b2223677a31989c4835e08957cbdb"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-12T10:43:44.000Z",
           "commitDate": "2019-08-12T10:43:44.000Z",
@@ -30027,30 +25795,20 @@
         "implicitBranchNo": 2682,
         "seq": 15930,
         "isMergeCommit": false,
-        "taskId": 2494
+        "clusterId": 2494
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "9fd3cd13add128888d1535a131218162fa7dcfab",
-          "parentIds": [
-            "60be73f367b89df0be041a91568dcea8019194cd"
-          ],
+          "parentIds": ["60be73f367b89df0be041a91568dcea8019194cd"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-12T12:33:49.000Z",
           "commitDate": "2019-08-12T12:33:49.000Z",
@@ -30069,7 +25827,7 @@
         "implicitBranchNo": 2682,
         "seq": 15931,
         "isMergeCommit": false,
-        "taskId": 2494
+        "clusterId": 2494
       },
       {
         "nodeTypeName": "COMMIT",
@@ -30080,20 +25838,12 @@
             "4176427cd7920c2acf84f1925093827f0c42ce62"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-14T06:27:08.000Z",
           "commitDate": "2019-08-14T06:27:08.000Z",
@@ -30120,30 +25870,20 @@
         "implicitBranchNo": 2682,
         "seq": 15933,
         "isMergeCommit": true,
-        "taskId": 2494
+        "clusterId": 2494
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "89ae68e8df5ef046f26ef496f80048521d757446",
-          "parentIds": [
-            "34eb1e4e315ac019e8cb73ff68d2af2baeb0f42e"
-          ],
+          "parentIds": ["34eb1e4e315ac019e8cb73ff68d2af2baeb0f42e"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-14T06:44:03.000Z",
           "commitDate": "2019-08-14T06:44:03.000Z",
@@ -30162,7 +25902,7 @@
         "implicitBranchNo": 2682,
         "seq": 15934,
         "isMergeCommit": false,
-        "taskId": 2494
+        "clusterId": 2494
       },
       {
         "nodeTypeName": "COMMIT",
@@ -30173,20 +25913,12 @@
             "89ae68e8df5ef046f26ef496f80048521d757446"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-08-14T06:44:43.000Z",
           "commitDate": "2019-08-14T06:44:43.000Z",
@@ -30217,7 +25949,7 @@
         "implicitBranchNo": 0,
         "seq": 15935,
         "isMergeCommit": true,
-        "taskId": 2494
+        "clusterId": 2494
       }
     ]
   },
@@ -30228,24 +25960,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "0900f506c784dc467810dd11aacbd7595088e59e",
-          "parentIds": [
-            "221f076256ebd4aebd55e56cbbbebec84bb3f372"
-          ],
+          "parentIds": ["221f076256ebd4aebd55e56cbbbebec84bb3f372"],
           "author": {
-            "names": [
-              "Gaetan Muller "
-            ],
-            "emails": [
-              "gaetan.muller@swissquote.ch"
-            ]
+            "names": ["Gaetan Muller "],
+            "emails": ["gaetan.muller@swissquote.ch"]
           },
           "committer": {
-            "names": [
-              "Gaetan Muller "
-            ],
-            "emails": [
-              "gaetan.muller@swissquote.ch"
-            ]
+            "names": ["Gaetan Muller "],
+            "emails": ["gaetan.muller@swissquote.ch"]
           },
           "authorDate": "2019-08-28T09:41:37.000Z",
           "commitDate": "2019-08-28T09:41:37.000Z",
@@ -30264,30 +25986,20 @@
         "implicitBranchNo": 2683,
         "seq": 15943,
         "isMergeCommit": false,
-        "taskId": 2495
+        "clusterId": 2495
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "71d098d9ebbaf1079f70da4377d2cd455bac2306",
-          "parentIds": [
-            "0900f506c784dc467810dd11aacbd7595088e59e"
-          ],
+          "parentIds": ["0900f506c784dc467810dd11aacbd7595088e59e"],
           "author": {
-            "names": [
-              "Gaetan Muller "
-            ],
-            "emails": [
-              "gaetan.muller@swissquote.ch"
-            ]
+            "names": ["Gaetan Muller "],
+            "emails": ["gaetan.muller@swissquote.ch"]
           },
           "committer": {
-            "names": [
-              "Gaetan Muller "
-            ],
-            "emails": [
-              "gaetan.muller@swissquote.ch"
-            ]
+            "names": ["Gaetan Muller "],
+            "emails": ["gaetan.muller@swissquote.ch"]
           },
           "authorDate": "2019-08-28T09:46:59.000Z",
           "commitDate": "2019-08-28T09:46:59.000Z",
@@ -30306,7 +26018,7 @@
         "implicitBranchNo": 2683,
         "seq": 15945,
         "isMergeCommit": false,
-        "taskId": 2495
+        "clusterId": 2495
       },
       {
         "nodeTypeName": "COMMIT",
@@ -30317,20 +26029,12 @@
             "71d098d9ebbaf1079f70da4377d2cd455bac2306"
           ],
           "author": {
-            "names": [
-              "Gaëtan Muller "
-            ],
-            "emails": [
-              "m.gaetan89@gmail.com"
-            ]
+            "names": ["Gaëtan Muller "],
+            "emails": ["m.gaetan89@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-28T12:20:38.000Z",
           "commitDate": "2019-08-28T12:20:38.000Z",
@@ -30353,7 +26057,7 @@
         "implicitBranchNo": 0,
         "seq": 15946,
         "isMergeCommit": true,
-        "taskId": 2495
+        "clusterId": 2495
       }
     ]
   },
@@ -30364,24 +26068,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "822f643be3335559bb743720e533779d9976c799",
-          "parentIds": [
-            "221f076256ebd4aebd55e56cbbbebec84bb3f372"
-          ],
+          "parentIds": ["221f076256ebd4aebd55e56cbbbebec84bb3f372"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-27T12:41:30.000Z",
           "commitDate": "2019-08-27T12:41:30.000Z",
@@ -30436,30 +26130,20 @@
         "implicitBranchNo": 2684,
         "seq": 15939,
         "isMergeCommit": false,
-        "taskId": 2496
+        "clusterId": 2496
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "7abca96fa59992e32915e9f56ecc9fb72bb8b8e9",
-          "parentIds": [
-            "822f643be3335559bb743720e533779d9976c799"
-          ],
+          "parentIds": ["822f643be3335559bb743720e533779d9976c799"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-27T17:22:07.000Z",
           "commitDate": "2019-08-27T17:22:07.000Z",
@@ -30486,30 +26170,20 @@
         "implicitBranchNo": 2684,
         "seq": 15940,
         "isMergeCommit": false,
-        "taskId": 2496
+        "clusterId": 2496
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "45053a7162c3114fd362551949dcb16bd222ecc5",
-          "parentIds": [
-            "7abca96fa59992e32915e9f56ecc9fb72bb8b8e9"
-          ],
+          "parentIds": ["7abca96fa59992e32915e9f56ecc9fb72bb8b8e9"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-27T18:07:29.000Z",
           "commitDate": "2019-08-27T18:07:29.000Z",
@@ -30528,30 +26202,20 @@
         "implicitBranchNo": 2684,
         "seq": 15941,
         "isMergeCommit": false,
-        "taskId": 2496
+        "clusterId": 2496
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "552fa471c1a7ba8424b7598ba892eb039a2a081c",
-          "parentIds": [
-            "45053a7162c3114fd362551949dcb16bd222ecc5"
-          ],
+          "parentIds": ["45053a7162c3114fd362551949dcb16bd222ecc5"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-28T09:14:08.000Z",
           "commitDate": "2019-08-28T09:14:08.000Z",
@@ -30574,30 +26238,20 @@
         "implicitBranchNo": 2684,
         "seq": 15942,
         "isMergeCommit": false,
-        "taskId": 2496
+        "clusterId": 2496
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "00c344b6760369be471bbe9d3be66fd4cf311349",
-          "parentIds": [
-            "552fa471c1a7ba8424b7598ba892eb039a2a081c"
-          ],
+          "parentIds": ["552fa471c1a7ba8424b7598ba892eb039a2a081c"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-28T09:42:10.000Z",
           "commitDate": "2019-08-28T09:42:10.000Z",
@@ -30616,30 +26270,20 @@
         "implicitBranchNo": 2684,
         "seq": 15944,
         "isMergeCommit": false,
-        "taskId": 2496
+        "clusterId": 2496
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "31ce5e88946571043ebf66739d75163a0922f47a",
-          "parentIds": [
-            "00c344b6760369be471bbe9d3be66fd4cf311349"
-          ],
+          "parentIds": ["00c344b6760369be471bbe9d3be66fd4cf311349"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-08-28T13:32:24.000Z",
           "commitDate": "2019-08-28T13:32:24.000Z",
@@ -30662,30 +26306,20 @@
         "implicitBranchNo": 2686,
         "seq": 15947,
         "isMergeCommit": false,
-        "taskId": 2496
+        "clusterId": 2496
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "039b6eb6bf0910f6e75f5df9dcde1a875a6bea15",
-          "parentIds": [
-            "00c344b6760369be471bbe9d3be66fd4cf311349"
-          ],
+          "parentIds": ["00c344b6760369be471bbe9d3be66fd4cf311349"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-28T13:36:11.000Z",
           "commitDate": "2019-08-28T13:36:11.000Z",
@@ -30704,7 +26338,7 @@
         "implicitBranchNo": 2684,
         "seq": 15948,
         "isMergeCommit": false,
-        "taskId": 2496
+        "clusterId": 2496
       },
       {
         "nodeTypeName": "COMMIT",
@@ -30715,20 +26349,12 @@
             "31ce5e88946571043ebf66739d75163a0922f47a"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-28T13:36:59.000Z",
           "commitDate": "2019-08-28T13:36:59.000Z",
@@ -30751,30 +26377,20 @@
         "implicitBranchNo": 2684,
         "seq": 15949,
         "isMergeCommit": true,
-        "taskId": 2496
+        "clusterId": 2496
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "b97829a227cd0149e5f8c3df40e944651796b5ae",
-          "parentIds": [
-            "921a079ad3e46543c21503887104447b3e91eef7"
-          ],
+          "parentIds": ["921a079ad3e46543c21503887104447b3e91eef7"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-08-28T13:38:53.000Z",
           "commitDate": "2019-08-28T13:38:53.000Z",
@@ -30793,7 +26409,7 @@
         "implicitBranchNo": 2684,
         "seq": 15950,
         "isMergeCommit": false,
-        "taskId": 2496
+        "clusterId": 2496
       },
       {
         "nodeTypeName": "COMMIT",
@@ -30804,20 +26420,12 @@
             "b97829a227cd0149e5f8c3df40e944651796b5ae"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-08-29T08:18:08.000Z",
           "commitDate": "2019-08-29T08:18:08.000Z",
@@ -30888,7 +26496,7 @@
         "implicitBranchNo": 0,
         "seq": 15951,
         "isMergeCommit": true,
-        "taskId": 2496
+        "clusterId": 2496
       }
     ]
   },
@@ -30899,24 +26507,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "91de4c1c791f3fcd408c479b218e1a228010a703",
-          "parentIds": [
-            "e32b141b6a68236192f7c235d317f9a350c38a5e"
-          ],
+          "parentIds": ["e32b141b6a68236192f7c235d317f9a350c38a5e"],
           "author": {
-            "names": [
-              "Yavor Georgiev "
-            ],
-            "emails": [
-              "fealebenpae@gmail.com"
-            ]
+            "names": ["Yavor Georgiev "],
+            "emails": ["fealebenpae@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Yavor Georgiev "
-            ],
-            "emails": [
-              "fealebenpae@gmail.com"
-            ]
+            "names": ["Yavor Georgiev "],
+            "emails": ["fealebenpae@gmail.com"]
           },
           "authorDate": "2019-08-28T09:47:49.000Z",
           "commitDate": "2019-08-29T11:25:41.000Z",
@@ -30947,30 +26545,20 @@
         "implicitBranchNo": 2687,
         "seq": 15952,
         "isMergeCommit": false,
-        "taskId": 2497
+        "clusterId": 2497
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "4cf56b61bcaf26a88b6287f87b643c5b14b83f01",
-          "parentIds": [
-            "91de4c1c791f3fcd408c479b218e1a228010a703"
-          ],
+          "parentIds": ["91de4c1c791f3fcd408c479b218e1a228010a703"],
           "author": {
-            "names": [
-              "Yavor Georgiev "
-            ],
-            "emails": [
-              "fealebenpae@gmail.com"
-            ]
+            "names": ["Yavor Georgiev "],
+            "emails": ["fealebenpae@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Yavor Georgiev "
-            ],
-            "emails": [
-              "fealebenpae@gmail.com"
-            ]
+            "names": ["Yavor Georgiev "],
+            "emails": ["fealebenpae@gmail.com"]
           },
           "authorDate": "2019-08-29T11:30:33.000Z",
           "commitDate": "2019-08-29T11:30:33.000Z",
@@ -30989,30 +26577,20 @@
         "implicitBranchNo": 2687,
         "seq": 15953,
         "isMergeCommit": false,
-        "taskId": 2497
+        "clusterId": 2497
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "ca139a9bd60fb9eda48ae20f30b07780520a2ed2",
-          "parentIds": [
-            "4cf56b61bcaf26a88b6287f87b643c5b14b83f01"
-          ],
+          "parentIds": ["4cf56b61bcaf26a88b6287f87b643c5b14b83f01"],
           "author": {
-            "names": [
-              "Yavor Georgiev "
-            ],
-            "emails": [
-              "fealebenpae@gmail.com"
-            ]
+            "names": ["Yavor Georgiev "],
+            "emails": ["fealebenpae@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Yavor Georgiev "
-            ],
-            "emails": [
-              "fealebenpae@gmail.com"
-            ]
+            "names": ["Yavor Georgiev "],
+            "emails": ["fealebenpae@gmail.com"]
           },
           "authorDate": "2019-08-29T11:31:51.000Z",
           "commitDate": "2019-08-29T11:31:51.000Z",
@@ -31031,7 +26609,7 @@
         "implicitBranchNo": 2687,
         "seq": 15954,
         "isMergeCommit": false,
-        "taskId": 2497
+        "clusterId": 2497
       },
       {
         "nodeTypeName": "COMMIT",
@@ -31042,20 +26620,12 @@
             "ca139a9bd60fb9eda48ae20f30b07780520a2ed2"
           ],
           "author": {
-            "names": [
-              "Yavor Georgiev "
-            ],
-            "emails": [
-              "fealebenpae@users.noreply.github.com"
-            ]
+            "names": ["Yavor Georgiev "],
+            "emails": ["fealebenpae@users.noreply.github.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-08-29T14:24:52.000Z",
           "commitDate": "2019-08-29T14:24:52.000Z",
@@ -31090,7 +26660,7 @@
         "implicitBranchNo": 0,
         "seq": 15955,
         "isMergeCommit": true,
-        "taskId": 2497
+        "clusterId": 2497
       }
     ]
   },
@@ -31101,24 +26671,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "2c58e11bd7601d511adc5c1500c8beae874814c1",
-          "parentIds": [
-            "17290057cd808e4dea7c3612b9b92d76e6ee7f6e"
-          ],
+          "parentIds": ["17290057cd808e4dea7c3612b9b92d76e6ee7f6e"],
           "author": {
-            "names": [
-              "Gaetan Muller "
-            ],
-            "emails": [
-              "gaetan.muller@swissquote.ch"
-            ]
+            "names": ["Gaetan Muller "],
+            "emails": ["gaetan.muller@swissquote.ch"]
           },
           "committer": {
-            "names": [
-              "Gaetan Muller "
-            ],
-            "emails": [
-              "gaetan.muller@swissquote.ch"
-            ]
+            "names": ["Gaetan Muller "],
+            "emails": ["gaetan.muller@swissquote.ch"]
           },
           "authorDate": "2019-08-30T08:48:38.000Z",
           "commitDate": "2019-08-30T08:48:38.000Z",
@@ -31141,7 +26701,7 @@
         "implicitBranchNo": 2689,
         "seq": 15956,
         "isMergeCommit": false,
-        "taskId": 2498
+        "clusterId": 2498
       },
       {
         "nodeTypeName": "COMMIT",
@@ -31152,20 +26712,12 @@
             "2c58e11bd7601d511adc5c1500c8beae874814c1"
           ],
           "author": {
-            "names": [
-              "Gaëtan Muller "
-            ],
-            "emails": [
-              "gaetan.muller@swissquote.ch"
-            ]
+            "names": ["Gaëtan Muller "],
+            "emails": ["gaetan.muller@swissquote.ch"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-02T09:54:20.000Z",
           "commitDate": "2019-09-02T09:54:20.000Z",
@@ -31188,7 +26740,7 @@
         "implicitBranchNo": 0,
         "seq": 15958,
         "isMergeCommit": true,
-        "taskId": 2498
+        "clusterId": 2498
       }
     ]
   },
@@ -31199,24 +26751,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "f95792dc710789f979d521c904315b5f21c8ad6a",
-          "parentIds": [
-            "17290057cd808e4dea7c3612b9b92d76e6ee7f6e"
-          ],
+          "parentIds": ["17290057cd808e4dea7c3612b9b92d76e6ee7f6e"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-02T08:55:46.000Z",
           "commitDate": "2019-09-02T08:55:46.000Z",
@@ -31247,7 +26789,7 @@
         "implicitBranchNo": 2688,
         "seq": 15957,
         "isMergeCommit": false,
-        "taskId": 2499
+        "clusterId": 2499
       },
       {
         "nodeTypeName": "COMMIT",
@@ -31258,20 +26800,12 @@
             "76a71e386aa8629739a5a62c023fca8930052add"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-02T10:27:42.000Z",
           "commitDate": "2019-09-02T10:27:42.000Z",
@@ -31294,30 +26828,20 @@
         "implicitBranchNo": 2688,
         "seq": 15959,
         "isMergeCommit": true,
-        "taskId": 2499
+        "clusterId": 2499
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "66fd29a03a4604930ec9f38374cd32c0576aad94",
-          "parentIds": [
-            "d51340d4e04067cc7174863ba9b08f4e07fd965f"
-          ],
+          "parentIds": ["d51340d4e04067cc7174863ba9b08f4e07fd965f"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-02T10:28:05.000Z",
           "commitDate": "2019-09-02T10:28:05.000Z",
@@ -31336,30 +26860,20 @@
         "implicitBranchNo": 2688,
         "seq": 15960,
         "isMergeCommit": false,
-        "taskId": 2499
+        "clusterId": 2499
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "ecd48d349de423d940bfc8f078edcb36108871af",
-          "parentIds": [
-            "66fd29a03a4604930ec9f38374cd32c0576aad94"
-          ],
+          "parentIds": ["66fd29a03a4604930ec9f38374cd32c0576aad94"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-03T11:33:43.000Z",
           "commitDate": "2019-09-03T11:33:43.000Z",
@@ -31382,30 +26896,20 @@
         "implicitBranchNo": 2688,
         "seq": 15961,
         "isMergeCommit": false,
-        "taskId": 2499
+        "clusterId": 2499
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "94f46343f1677328ae10b2b349ecb4b36bf8dcc6",
-          "parentIds": [
-            "ecd48d349de423d940bfc8f078edcb36108871af"
-          ],
+          "parentIds": ["ecd48d349de423d940bfc8f078edcb36108871af"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-03T12:52:02.000Z",
           "commitDate": "2019-09-03T12:52:02.000Z",
@@ -31428,30 +26932,20 @@
         "implicitBranchNo": 2688,
         "seq": 15962,
         "isMergeCommit": false,
-        "taskId": 2499
+        "clusterId": 2499
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "1ccbe983b797e91a2cf488778017d4e80011faf3",
-          "parentIds": [
-            "94f46343f1677328ae10b2b349ecb4b36bf8dcc6"
-          ],
+          "parentIds": ["94f46343f1677328ae10b2b349ecb4b36bf8dcc6"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-03T13:24:51.000Z",
           "commitDate": "2019-09-03T13:24:51.000Z",
@@ -31474,30 +26968,20 @@
         "implicitBranchNo": 2688,
         "seq": 15963,
         "isMergeCommit": false,
-        "taskId": 2499
+        "clusterId": 2499
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "ae876cca7e771ebe54377e1e35efdb2de944be78",
-          "parentIds": [
-            "1ccbe983b797e91a2cf488778017d4e80011faf3"
-          ],
+          "parentIds": ["1ccbe983b797e91a2cf488778017d4e80011faf3"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-03T14:03:05.000Z",
           "commitDate": "2019-09-03T14:03:05.000Z",
@@ -31516,30 +27000,20 @@
         "implicitBranchNo": 2688,
         "seq": 15964,
         "isMergeCommit": false,
-        "taskId": 2499
+        "clusterId": 2499
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "12239bf961eafe7f9bcc6e0a407026885315dfc6",
-          "parentIds": [
-            "ae876cca7e771ebe54377e1e35efdb2de944be78"
-          ],
+          "parentIds": ["ae876cca7e771ebe54377e1e35efdb2de944be78"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-03T15:18:09.000Z",
           "commitDate": "2019-09-03T15:18:09.000Z",
@@ -31558,30 +27032,20 @@
         "implicitBranchNo": 2688,
         "seq": 15965,
         "isMergeCommit": false,
-        "taskId": 2499
+        "clusterId": 2499
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "6a671a19aba7a13d7ac0780bdebbe4ce7b37315f",
-          "parentIds": [
-            "12239bf961eafe7f9bcc6e0a407026885315dfc6"
-          ],
+          "parentIds": ["12239bf961eafe7f9bcc6e0a407026885315dfc6"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-03T20:55:39.000Z",
           "commitDate": "2019-09-03T20:55:39.000Z",
@@ -31604,30 +27068,20 @@
         "implicitBranchNo": 2688,
         "seq": 15966,
         "isMergeCommit": false,
-        "taskId": 2499
+        "clusterId": 2499
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "5f898df32c4b6804547367f4c17964772c8c0670",
-          "parentIds": [
-            "6a671a19aba7a13d7ac0780bdebbe4ce7b37315f"
-          ],
+          "parentIds": ["6a671a19aba7a13d7ac0780bdebbe4ce7b37315f"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-04T05:55:02.000Z",
           "commitDate": "2019-09-04T05:55:02.000Z",
@@ -31650,30 +27104,20 @@
         "implicitBranchNo": 2688,
         "seq": 15967,
         "isMergeCommit": false,
-        "taskId": 2499
+        "clusterId": 2499
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "a3bfaf018ce8c84e86eb7b1b6345c56af450f6c3",
-          "parentIds": [
-            "5f898df32c4b6804547367f4c17964772c8c0670"
-          ],
+          "parentIds": ["5f898df32c4b6804547367f4c17964772c8c0670"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-04T07:34:33.000Z",
           "commitDate": "2019-09-04T07:34:33.000Z",
@@ -31692,30 +27136,20 @@
         "implicitBranchNo": 2688,
         "seq": 15968,
         "isMergeCommit": false,
-        "taskId": 2499
+        "clusterId": 2499
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "a3f614aea72ec9bbd4a4b448ad7305dba26a3323",
-          "parentIds": [
-            "a3bfaf018ce8c84e86eb7b1b6345c56af450f6c3"
-          ],
+          "parentIds": ["a3bfaf018ce8c84e86eb7b1b6345c56af450f6c3"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-09-04T13:12:05.000Z",
           "commitDate": "2019-09-04T13:12:05.000Z",
@@ -31734,7 +27168,7 @@
         "implicitBranchNo": 2688,
         "seq": 15969,
         "isMergeCommit": false,
-        "taskId": 2499
+        "clusterId": 2499
       },
       {
         "nodeTypeName": "COMMIT",
@@ -31745,20 +27179,12 @@
             "a3f614aea72ec9bbd4a4b448ad7305dba26a3323"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-09-04T13:12:37.000Z",
           "commitDate": "2019-09-04T13:12:37.000Z",
@@ -31805,7 +27231,7 @@
         "implicitBranchNo": 0,
         "seq": 15970,
         "isMergeCommit": true,
-        "taskId": 2499
+        "clusterId": 2499
       }
     ]
   },
@@ -31816,24 +27242,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "889a57fc5bd1ca123b27ee754400be67402230c8",
-          "parentIds": [
-            "00698d17d1348160e002af961f4f5722f7faaf26"
-          ],
+          "parentIds": ["00698d17d1348160e002af961f4f5722f7faaf26"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-05T10:57:08.000Z",
           "commitDate": "2019-09-05T10:57:08.000Z",
@@ -31852,7 +27268,7 @@
         "implicitBranchNo": 0,
         "seq": 15971,
         "isMergeCommit": false,
-        "taskId": 2500
+        "clusterId": 2500
       }
     ]
   },
@@ -31863,24 +27279,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "a4afa55eb122999dfe8497a33433e5a9a0245637",
-          "parentIds": [
-            "889a57fc5bd1ca123b27ee754400be67402230c8"
-          ],
+          "parentIds": ["889a57fc5bd1ca123b27ee754400be67402230c8"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-05T10:58:01.000Z",
           "commitDate": "2019-09-05T10:58:01.000Z",
@@ -31899,7 +27305,7 @@
         "implicitBranchNo": 0,
         "seq": 15972,
         "isMergeCommit": false,
-        "taskId": 2501
+        "clusterId": 2501
       }
     ]
   },
@@ -31910,24 +27316,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "7805374b0631ad1aa9aa3eaba6a5ec00f43a6c5a",
-          "parentIds": [
-            "a4afa55eb122999dfe8497a33433e5a9a0245637"
-          ],
+          "parentIds": ["a4afa55eb122999dfe8497a33433e5a9a0245637"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-05T10:58:01.000Z",
           "commitDate": "2019-09-05T10:58:01.000Z",
@@ -31946,7 +27342,7 @@
         "implicitBranchNo": 0,
         "seq": 15973,
         "isMergeCommit": false,
-        "taskId": 2502
+        "clusterId": 2502
       }
     ]
   },
@@ -31957,24 +27353,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "61c38bdaec9d8f518b998483a06f375dd76ce55d",
-          "parentIds": [
-            "7805374b0631ad1aa9aa3eaba6a5ec00f43a6c5a"
-          ],
+          "parentIds": ["7805374b0631ad1aa9aa3eaba6a5ec00f43a6c5a"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-05T13:07:34.000Z",
           "commitDate": "2019-09-05T13:07:34.000Z",
@@ -31993,7 +27379,7 @@
         "implicitBranchNo": 0,
         "seq": 15974,
         "isMergeCommit": false,
-        "taskId": 2503
+        "clusterId": 2503
       }
     ]
   },
@@ -32004,24 +27390,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "75e8ed544432647a2acb00feb37772292898caf2",
-          "parentIds": [
-            "7805374b0631ad1aa9aa3eaba6a5ec00f43a6c5a"
-          ],
+          "parentIds": ["7805374b0631ad1aa9aa3eaba6a5ec00f43a6c5a"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-09T07:23:29.000Z",
           "commitDate": "2019-09-09T07:23:29.000Z",
@@ -32048,7 +27424,7 @@
         "implicitBranchNo": 2692,
         "seq": 15975,
         "isMergeCommit": false,
-        "taskId": 2504
+        "clusterId": 2504
       },
       {
         "nodeTypeName": "COMMIT",
@@ -32059,20 +27435,12 @@
             "75e8ed544432647a2acb00feb37772292898caf2"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-09-09T08:45:50.000Z",
           "commitDate": "2019-09-09T08:45:50.000Z",
@@ -32099,30 +27467,20 @@
         "implicitBranchNo": 2691,
         "seq": 15976,
         "isMergeCommit": true,
-        "taskId": 2504
+        "clusterId": 2504
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "25e838af836db25645838fa28300880d52339455",
-          "parentIds": [
-            "44a9c882392b88fa76868716f9d720bc3a76becf"
-          ],
+          "parentIds": ["44a9c882392b88fa76868716f9d720bc3a76becf"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-09T08:53:11.000Z",
           "commitDate": "2019-09-09T08:53:11.000Z",
@@ -32141,30 +27499,20 @@
         "implicitBranchNo": 2691,
         "seq": 15977,
         "isMergeCommit": false,
-        "taskId": 2504
+        "clusterId": 2504
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "521f2fff5b1a8f4278e25ae8fd6ae2f5d442d0c6",
-          "parentIds": [
-            "25e838af836db25645838fa28300880d52339455"
-          ],
+          "parentIds": ["25e838af836db25645838fa28300880d52339455"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-09T08:53:11.000Z",
           "commitDate": "2019-09-09T08:53:11.000Z",
@@ -32183,7 +27531,7 @@
         "implicitBranchNo": 2691,
         "seq": 15978,
         "isMergeCommit": false,
-        "taskId": 2504
+        "clusterId": 2504
       },
       {
         "nodeTypeName": "COMMIT",
@@ -32194,20 +27542,12 @@
             "521f2fff5b1a8f4278e25ae8fd6ae2f5d442d0c6"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-09T09:38:23.000Z",
           "commitDate": "2019-09-09T09:38:23.000Z",
@@ -32234,7 +27574,7 @@
         "implicitBranchNo": 0,
         "seq": 15979,
         "isMergeCommit": true,
-        "taskId": 2504
+        "clusterId": 2504
       }
     ]
   },
@@ -32245,24 +27585,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "e15fcf241c5fc6ef9e6ca19ac5ffd65902053ac0",
-          "parentIds": [
-            "e84f281962840e119b5f10f83a080ea58a91c406"
-          ],
+          "parentIds": ["e84f281962840e119b5f10f83a080ea58a91c406"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-12T14:18:23.000Z",
           "commitDate": "2019-09-12T14:18:23.000Z",
@@ -32281,30 +27611,20 @@
         "implicitBranchNo": 2694,
         "seq": 15994,
         "isMergeCommit": false,
-        "taskId": 2505
+        "clusterId": 2505
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "be38dee3b3d1df282deedf5ca565fd88448a8864",
-          "parentIds": [
-            "e15fcf241c5fc6ef9e6ca19ac5ffd65902053ac0"
-          ],
+          "parentIds": ["e15fcf241c5fc6ef9e6ca19ac5ffd65902053ac0"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-09-13T10:36:23.000Z",
           "commitDate": "2019-09-13T10:36:23.000Z",
@@ -32323,7 +27643,7 @@
         "implicitBranchNo": 2694,
         "seq": 15995,
         "isMergeCommit": false,
-        "taskId": 2505
+        "clusterId": 2505
       },
       {
         "nodeTypeName": "COMMIT",
@@ -32334,20 +27654,12 @@
             "be38dee3b3d1df282deedf5ca565fd88448a8864"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-09-13T10:36:34.000Z",
           "commitDate": "2019-09-13T10:36:34.000Z",
@@ -32366,7 +27678,7 @@
         "implicitBranchNo": 0,
         "seq": 15996,
         "isMergeCommit": true,
-        "taskId": 2505
+        "clusterId": 2505
       }
     ]
   },
@@ -32377,24 +27689,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "8f1395b02cc5659c751138526e5644fdc48b203e",
-          "parentIds": [
-            "00698d17d1348160e002af961f4f5722f7faaf26"
-          ],
+          "parentIds": ["00698d17d1348160e002af961f4f5722f7faaf26"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-10T14:27:35.000Z",
           "commitDate": "2019-09-10T14:27:35.000Z",
@@ -32525,30 +27827,20 @@
         "implicitBranchNo": 2690,
         "seq": 15980,
         "isMergeCommit": false,
-        "taskId": 2506
+        "clusterId": 2506
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "fd804ebd93337c36dc1c5e3227c0eb0121a30a68",
-          "parentIds": [
-            "8f1395b02cc5659c751138526e5644fdc48b203e"
-          ],
+          "parentIds": ["8f1395b02cc5659c751138526e5644fdc48b203e"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-11T07:51:36.000Z",
           "commitDate": "2019-09-11T07:51:36.000Z",
@@ -32579,30 +27871,20 @@
         "implicitBranchNo": 2690,
         "seq": 15981,
         "isMergeCommit": false,
-        "taskId": 2506
+        "clusterId": 2506
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "8c0008883c1611f163167b0e5322d70ef9df1cbc",
-          "parentIds": [
-            "fd804ebd93337c36dc1c5e3227c0eb0121a30a68"
-          ],
+          "parentIds": ["fd804ebd93337c36dc1c5e3227c0eb0121a30a68"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-11T12:16:41.000Z",
           "commitDate": "2019-09-11T12:16:41.000Z",
@@ -32653,30 +27935,20 @@
         "implicitBranchNo": 2690,
         "seq": 15982,
         "isMergeCommit": false,
-        "taskId": 2506
+        "clusterId": 2506
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "1eceb66df4b4060b62ed3a5cc153d1eee871bb2e",
-          "parentIds": [
-            "8c0008883c1611f163167b0e5322d70ef9df1cbc"
-          ],
+          "parentIds": ["8c0008883c1611f163167b0e5322d70ef9df1cbc"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-11T13:14:19.000Z",
           "commitDate": "2019-09-11T13:14:19.000Z",
@@ -32731,7 +28003,7 @@
         "implicitBranchNo": 2690,
         "seq": 15983,
         "isMergeCommit": false,
-        "taskId": 2506
+        "clusterId": 2506
       },
       {
         "nodeTypeName": "COMMIT",
@@ -32742,20 +28014,12 @@
             "e84f281962840e119b5f10f83a080ea58a91c406"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-11T13:20:49.000Z",
           "commitDate": "2019-09-11T13:20:49.000Z",
@@ -32782,30 +28046,20 @@
         "implicitBranchNo": 2690,
         "seq": 15984,
         "isMergeCommit": true,
-        "taskId": 2506
+        "clusterId": 2506
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "23b34be179ee4fed57e85a127f586caabea495a5",
-          "parentIds": [
-            "3b08fe9bd4d8a05ec235e4618a8889b49044c41b"
-          ],
+          "parentIds": ["3b08fe9bd4d8a05ec235e4618a8889b49044c41b"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-11T13:40:37.000Z",
           "commitDate": "2019-09-11T13:40:37.000Z",
@@ -32824,30 +28078,20 @@
         "implicitBranchNo": 2690,
         "seq": 15985,
         "isMergeCommit": false,
-        "taskId": 2506
+        "clusterId": 2506
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "74ccd7f2fb96d75b1a86cf029d24c9afd43fd7e4",
-          "parentIds": [
-            "23b34be179ee4fed57e85a127f586caabea495a5"
-          ],
+          "parentIds": ["23b34be179ee4fed57e85a127f586caabea495a5"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-11T13:48:19.000Z",
           "commitDate": "2019-09-11T13:48:19.000Z",
@@ -32866,30 +28110,20 @@
         "implicitBranchNo": 2690,
         "seq": 15986,
         "isMergeCommit": false,
-        "taskId": 2506
+        "clusterId": 2506
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "b6645f0c245ad48d6ce1d3cae1e9310c6f2ac0b1",
-          "parentIds": [
-            "74ccd7f2fb96d75b1a86cf029d24c9afd43fd7e4"
-          ],
+          "parentIds": ["74ccd7f2fb96d75b1a86cf029d24c9afd43fd7e4"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-11T14:17:49.000Z",
           "commitDate": "2019-09-11T14:17:49.000Z",
@@ -32908,30 +28142,20 @@
         "implicitBranchNo": 2690,
         "seq": 15987,
         "isMergeCommit": false,
-        "taskId": 2506
+        "clusterId": 2506
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "d2dac454e80b33f151ec65a71a92e6b1840e0515",
-          "parentIds": [
-            "b6645f0c245ad48d6ce1d3cae1e9310c6f2ac0b1"
-          ],
+          "parentIds": ["b6645f0c245ad48d6ce1d3cae1e9310c6f2ac0b1"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-11T15:24:39.000Z",
           "commitDate": "2019-09-11T15:24:39.000Z",
@@ -32958,30 +28182,20 @@
         "implicitBranchNo": 2690,
         "seq": 15988,
         "isMergeCommit": false,
-        "taskId": 2506
+        "clusterId": 2506
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "b87e575e1c95297ad8eb2e3dfbd794f83dadf9cd",
-          "parentIds": [
-            "d2dac454e80b33f151ec65a71a92e6b1840e0515"
-          ],
+          "parentIds": ["d2dac454e80b33f151ec65a71a92e6b1840e0515"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-12T09:09:38.000Z",
           "commitDate": "2019-09-12T09:09:38.000Z",
@@ -33068,30 +28282,20 @@
         "implicitBranchNo": 2690,
         "seq": 15989,
         "isMergeCommit": false,
-        "taskId": 2506
+        "clusterId": 2506
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "8bea9495784ca225ec9a557b19f9d0bf9233f685",
-          "parentIds": [
-            "b87e575e1c95297ad8eb2e3dfbd794f83dadf9cd"
-          ],
+          "parentIds": ["b87e575e1c95297ad8eb2e3dfbd794f83dadf9cd"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-12T09:39:11.000Z",
           "commitDate": "2019-09-12T09:39:11.000Z",
@@ -33138,30 +28342,20 @@
         "implicitBranchNo": 2690,
         "seq": 15990,
         "isMergeCommit": false,
-        "taskId": 2506
+        "clusterId": 2506
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "c11940f3cf0452f2197edc60d75764c5b59221cc",
-          "parentIds": [
-            "8bea9495784ca225ec9a557b19f9d0bf9233f685"
-          ],
+          "parentIds": ["8bea9495784ca225ec9a557b19f9d0bf9233f685"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-12T12:00:18.000Z",
           "commitDate": "2019-09-12T12:00:18.000Z",
@@ -33180,30 +28374,20 @@
         "implicitBranchNo": 2690,
         "seq": 15991,
         "isMergeCommit": false,
-        "taskId": 2506
+        "clusterId": 2506
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "4787fa1f1ae54282d6f0193464f089002011d7d5",
-          "parentIds": [
-            "c11940f3cf0452f2197edc60d75764c5b59221cc"
-          ],
+          "parentIds": ["c11940f3cf0452f2197edc60d75764c5b59221cc"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-09-12T12:02:53.000Z",
           "commitDate": "2019-09-12T12:02:53.000Z",
@@ -33226,30 +28410,20 @@
         "implicitBranchNo": 2690,
         "seq": 15992,
         "isMergeCommit": false,
-        "taskId": 2506
+        "clusterId": 2506
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "c9639fe5db54bf92044cbe8b00ca21f6f07478dd",
-          "parentIds": [
-            "4787fa1f1ae54282d6f0193464f089002011d7d5"
-          ],
+          "parentIds": ["4787fa1f1ae54282d6f0193464f089002011d7d5"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-12T12:06:24.000Z",
           "commitDate": "2019-09-12T12:06:24.000Z",
@@ -33268,30 +28442,20 @@
         "implicitBranchNo": 2690,
         "seq": 15993,
         "isMergeCommit": false,
-        "taskId": 2506
+        "clusterId": 2506
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "7761ab2cd2edf0867b3198d928933706cfa3af23",
-          "parentIds": [
-            "c9639fe5db54bf92044cbe8b00ca21f6f07478dd"
-          ],
+          "parentIds": ["c9639fe5db54bf92044cbe8b00ca21f6f07478dd"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-09-30T10:36:43.000Z",
           "commitDate": "2019-09-30T10:36:43.000Z",
@@ -33310,30 +28474,20 @@
         "implicitBranchNo": 2690,
         "seq": 16010,
         "isMergeCommit": false,
-        "taskId": 2506
+        "clusterId": 2506
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "968b700030e33ed3a99370fde98a9a6adea581d5",
-          "parentIds": [
-            "7761ab2cd2edf0867b3198d928933706cfa3af23"
-          ],
+          "parentIds": ["7761ab2cd2edf0867b3198d928933706cfa3af23"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-09-30T10:36:55.000Z",
           "commitDate": "2019-09-30T10:36:55.000Z",
@@ -33352,7 +28506,7 @@
         "implicitBranchNo": 2690,
         "seq": 16011,
         "isMergeCommit": false,
-        "taskId": 2506
+        "clusterId": 2506
       },
       {
         "nodeTypeName": "COMMIT",
@@ -33363,20 +28517,12 @@
             "968b700030e33ed3a99370fde98a9a6adea581d5"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-09-30T10:37:17.000Z",
           "commitDate": "2019-09-30T10:37:17.000Z",
@@ -33523,7 +28669,7 @@
         "implicitBranchNo": 0,
         "seq": 16012,
         "isMergeCommit": true,
-        "taskId": 2506
+        "clusterId": 2506
       }
     ]
   },
@@ -33534,24 +28680,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "a8d16ed3a7b104d10689aacd15539819c1a861d3",
-          "parentIds": [
-            "521f2fff5b1a8f4278e25ae8fd6ae2f5d442d0c6"
-          ],
+          "parentIds": ["521f2fff5b1a8f4278e25ae8fd6ae2f5d442d0c6"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-18T17:46:03.000Z",
           "commitDate": "2019-09-18T17:46:03.000Z",
@@ -33574,30 +28710,20 @@
         "implicitBranchNo": 2693,
         "seq": 15997,
         "isMergeCommit": false,
-        "taskId": 2507
+        "clusterId": 2507
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "9f839e8dd9fab6e4ca1fbf9aac31c9131ab2fc6f",
-          "parentIds": [
-            "a8d16ed3a7b104d10689aacd15539819c1a861d3"
-          ],
+          "parentIds": ["a8d16ed3a7b104d10689aacd15539819c1a861d3"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-26T09:55:35.000Z",
           "commitDate": "2019-09-26T09:55:35.000Z",
@@ -33632,30 +28758,20 @@
         "implicitBranchNo": 2693,
         "seq": 15998,
         "isMergeCommit": false,
-        "taskId": 2507
+        "clusterId": 2507
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "e1a1043615b90fd239c01675f8edff4fd9d83fc4",
-          "parentIds": [
-            "9f839e8dd9fab6e4ca1fbf9aac31c9131ab2fc6f"
-          ],
+          "parentIds": ["9f839e8dd9fab6e4ca1fbf9aac31c9131ab2fc6f"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-26T10:24:33.000Z",
           "commitDate": "2019-09-26T10:24:33.000Z",
@@ -33674,30 +28790,20 @@
         "implicitBranchNo": 2693,
         "seq": 15999,
         "isMergeCommit": false,
-        "taskId": 2507
+        "clusterId": 2507
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "8d1430d43b5db3fbc0b9e22448077041d78c0770",
-          "parentIds": [
-            "e1a1043615b90fd239c01675f8edff4fd9d83fc4"
-          ],
+          "parentIds": ["e1a1043615b90fd239c01675f8edff4fd9d83fc4"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-26T10:25:59.000Z",
           "commitDate": "2019-09-26T10:25:59.000Z",
@@ -33716,30 +28822,20 @@
         "implicitBranchNo": 2693,
         "seq": 16000,
         "isMergeCommit": false,
-        "taskId": 2507
+        "clusterId": 2507
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "6e4a58505e845fe4ca673f4f7c5ab6ec40973975",
-          "parentIds": [
-            "8d1430d43b5db3fbc0b9e22448077041d78c0770"
-          ],
+          "parentIds": ["8d1430d43b5db3fbc0b9e22448077041d78c0770"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-26T11:08:50.000Z",
           "commitDate": "2019-09-26T11:08:50.000Z",
@@ -33758,30 +28854,20 @@
         "implicitBranchNo": 2693,
         "seq": 16001,
         "isMergeCommit": false,
-        "taskId": 2507
+        "clusterId": 2507
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "3a22a26459cde7179fa60369ab07e29291aa9c28",
-          "parentIds": [
-            "6e4a58505e845fe4ca673f4f7c5ab6ec40973975"
-          ],
+          "parentIds": ["6e4a58505e845fe4ca673f4f7c5ab6ec40973975"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-27T08:08:24.000Z",
           "commitDate": "2019-09-27T08:08:24.000Z",
@@ -33808,30 +28894,20 @@
         "implicitBranchNo": 2693,
         "seq": 16002,
         "isMergeCommit": false,
-        "taskId": 2507
+        "clusterId": 2507
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "9aae086cea2681e8a323eb3774769116d40bfaa4",
-          "parentIds": [
-            "3a22a26459cde7179fa60369ab07e29291aa9c28"
-          ],
+          "parentIds": ["3a22a26459cde7179fa60369ab07e29291aa9c28"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-27T09:23:58.000Z",
           "commitDate": "2019-09-27T09:23:58.000Z",
@@ -33850,30 +28926,20 @@
         "implicitBranchNo": 2693,
         "seq": 16003,
         "isMergeCommit": false,
-        "taskId": 2507
+        "clusterId": 2507
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "afa472499cdc05f2686d9fd4deef637e2bb49b7f",
-          "parentIds": [
-            "9aae086cea2681e8a323eb3774769116d40bfaa4"
-          ],
+          "parentIds": ["9aae086cea2681e8a323eb3774769116d40bfaa4"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-27T13:24:16.000Z",
           "commitDate": "2019-09-27T13:24:16.000Z",
@@ -33896,30 +28962,20 @@
         "implicitBranchNo": 2693,
         "seq": 16004,
         "isMergeCommit": false,
-        "taskId": 2507
+        "clusterId": 2507
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "5ac7a9f4953e28995ac38c063aa79ddc92a8af7d",
-          "parentIds": [
-            "afa472499cdc05f2686d9fd4deef637e2bb49b7f"
-          ],
+          "parentIds": ["afa472499cdc05f2686d9fd4deef637e2bb49b7f"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-30T09:14:21.000Z",
           "commitDate": "2019-09-30T09:14:21.000Z",
@@ -33942,7 +28998,7 @@
         "implicitBranchNo": 2693,
         "seq": 16005,
         "isMergeCommit": false,
-        "taskId": 2507
+        "clusterId": 2507
       },
       {
         "nodeTypeName": "COMMIT",
@@ -33953,20 +29009,12 @@
             "5ac7a9f4953e28995ac38c063aa79ddc92a8af7d"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-09-30T10:20:55.000Z",
           "commitDate": "2019-09-30T10:20:55.000Z",
@@ -34021,30 +29069,20 @@
         "implicitBranchNo": 2691,
         "seq": 16006,
         "isMergeCommit": true,
-        "taskId": 2507
+        "clusterId": 2507
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "8f99c094ad557b054b24ad9affe16002676d02e4",
-          "parentIds": [
-            "ad900696fe02a3f3c3e26151c5bd19e479b3f415"
-          ],
+          "parentIds": ["ad900696fe02a3f3c3e26151c5bd19e479b3f415"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-30T10:23:02.000Z",
           "commitDate": "2019-09-30T10:23:02.000Z",
@@ -34063,30 +29101,20 @@
         "implicitBranchNo": 2691,
         "seq": 16007,
         "isMergeCommit": false,
-        "taskId": 2507
+        "clusterId": 2507
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "7a31cbe8a76c90fb88a67256bfc5e852514c5029",
-          "parentIds": [
-            "8f99c094ad557b054b24ad9affe16002676d02e4"
-          ],
+          "parentIds": ["8f99c094ad557b054b24ad9affe16002676d02e4"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-30T10:23:19.000Z",
           "commitDate": "2019-09-30T10:23:19.000Z",
@@ -34105,30 +29133,20 @@
         "implicitBranchNo": 2691,
         "seq": 16008,
         "isMergeCommit": false,
-        "taskId": 2507
+        "clusterId": 2507
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "8967f6a2aaaa8260c4f14ab8c97c745422ac7cc2",
-          "parentIds": [
-            "7a31cbe8a76c90fb88a67256bfc5e852514c5029"
-          ],
+          "parentIds": ["7a31cbe8a76c90fb88a67256bfc5e852514c5029"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-30T10:23:19.000Z",
           "commitDate": "2019-09-30T10:23:19.000Z",
@@ -34147,7 +29165,7 @@
         "implicitBranchNo": 2691,
         "seq": 16009,
         "isMergeCommit": false,
-        "taskId": 2507
+        "clusterId": 2507
       },
       {
         "nodeTypeName": "COMMIT",
@@ -34158,20 +29176,12 @@
             "8967f6a2aaaa8260c4f14ab8c97c745422ac7cc2"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-30T11:46:57.000Z",
           "commitDate": "2019-09-30T11:46:57.000Z",
@@ -34218,7 +29228,7 @@
         "implicitBranchNo": 0,
         "seq": 16013,
         "isMergeCommit": true,
-        "taskId": 2507
+        "clusterId": 2507
       }
     ]
   },
@@ -34229,24 +29239,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "62325ca5ae668b1e53266a54e0a9ac47c6147b84",
-          "parentIds": [
-            "f8cac3d07c9c14593f1752ce35e0feeb0bcca83a"
-          ],
+          "parentIds": ["f8cac3d07c9c14593f1752ce35e0feeb0bcca83a"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-30T12:34:00.000Z",
           "commitDate": "2019-09-30T12:34:00.000Z",
@@ -34265,7 +29265,7 @@
         "implicitBranchNo": 0,
         "seq": 16015,
         "isMergeCommit": false,
-        "taskId": 2508
+        "clusterId": 2508
       }
     ]
   },
@@ -34276,24 +29276,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "8a022573a5b095c2ec887720bd73098475829766",
-          "parentIds": [
-            "62325ca5ae668b1e53266a54e0a9ac47c6147b84"
-          ],
+          "parentIds": ["62325ca5ae668b1e53266a54e0a9ac47c6147b84"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-30T12:39:25.000Z",
           "commitDate": "2019-09-30T12:39:25.000Z",
@@ -34312,7 +29302,7 @@
         "implicitBranchNo": 0,
         "seq": 16016,
         "isMergeCommit": false,
-        "taskId": 2509
+        "clusterId": 2509
       }
     ]
   },
@@ -34323,24 +29313,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "242bd56a2cdefb987377aa0aa5e61516ed492937",
-          "parentIds": [
-            "8a022573a5b095c2ec887720bd73098475829766"
-          ],
+          "parentIds": ["8a022573a5b095c2ec887720bd73098475829766"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-09-30T12:39:25.000Z",
           "commitDate": "2019-09-30T12:39:25.000Z",
@@ -34359,7 +29339,7 @@
         "implicitBranchNo": 0,
         "seq": 16017,
         "isMergeCommit": false,
-        "taskId": 2510
+        "clusterId": 2510
       }
     ]
   },
@@ -34370,24 +29350,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "b9ba860c4e59f9a4bd1a064edede2f64712be026",
-          "parentIds": [
-            "242bd56a2cdefb987377aa0aa5e61516ed492937"
-          ],
+          "parentIds": ["242bd56a2cdefb987377aa0aa5e61516ed492937"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-10-29T14:34:13.000Z",
           "commitDate": "2019-10-29T14:34:13.000Z",
@@ -34414,30 +29384,20 @@
         "implicitBranchNo": 2695,
         "seq": 16053,
         "isMergeCommit": false,
-        "taskId": 2511
+        "clusterId": 2511
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "fb9f6b53a97969f8c42307a2fd08ef843fcb5f9b",
-          "parentIds": [
-            "b9ba860c4e59f9a4bd1a064edede2f64712be026"
-          ],
+          "parentIds": ["b9ba860c4e59f9a4bd1a064edede2f64712be026"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-10-30T07:16:59.000Z",
           "commitDate": "2019-10-30T07:16:59.000Z",
@@ -34456,30 +29416,20 @@
         "implicitBranchNo": 2695,
         "seq": 16054,
         "isMergeCommit": false,
-        "taskId": 2511
+        "clusterId": 2511
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "28155be62e50d6e2cf36e344185ec0039a76a7ce",
-          "parentIds": [
-            "fb9f6b53a97969f8c42307a2fd08ef843fcb5f9b"
-          ],
+          "parentIds": ["fb9f6b53a97969f8c42307a2fd08ef843fcb5f9b"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-10-30T13:03:06.000Z",
           "commitDate": "2019-10-30T13:03:06.000Z",
@@ -34506,30 +29456,20 @@
         "implicitBranchNo": 2695,
         "seq": 16055,
         "isMergeCommit": false,
-        "taskId": 2511
+        "clusterId": 2511
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "ac9bca7b57710e12a8b68d70984ca1acd37b4b32",
-          "parentIds": [
-            "28155be62e50d6e2cf36e344185ec0039a76a7ce"
-          ],
+          "parentIds": ["28155be62e50d6e2cf36e344185ec0039a76a7ce"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-10-30T13:48:45.000Z",
           "commitDate": "2019-10-30T13:48:45.000Z",
@@ -34548,30 +29488,20 @@
         "implicitBranchNo": 2695,
         "seq": 16056,
         "isMergeCommit": false,
-        "taskId": 2511
+        "clusterId": 2511
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "0fd74be00960261c3009bda3b8b66a79bec6505c",
-          "parentIds": [
-            "ac9bca7b57710e12a8b68d70984ca1acd37b4b32"
-          ],
+          "parentIds": ["ac9bca7b57710e12a8b68d70984ca1acd37b4b32"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-10-30T14:01:20.000Z",
           "commitDate": "2019-10-30T14:01:20.000Z",
@@ -34590,30 +29520,20 @@
         "implicitBranchNo": 2695,
         "seq": 16057,
         "isMergeCommit": false,
-        "taskId": 2511
+        "clusterId": 2511
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "ca3d552730cebee39df84aab90c5953178b74059",
-          "parentIds": [
-            "0fd74be00960261c3009bda3b8b66a79bec6505c"
-          ],
+          "parentIds": ["0fd74be00960261c3009bda3b8b66a79bec6505c"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-10-30T14:06:54.000Z",
           "commitDate": "2019-10-30T14:06:54.000Z",
@@ -34632,7 +29552,7 @@
         "implicitBranchNo": 2695,
         "seq": 16058,
         "isMergeCommit": false,
-        "taskId": 2511
+        "clusterId": 2511
       },
       {
         "nodeTypeName": "COMMIT",
@@ -34643,20 +29563,12 @@
             "ca3d552730cebee39df84aab90c5953178b74059"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-11-05T10:34:52.000Z",
           "commitDate": "2019-11-05T10:34:52.000Z",
@@ -34691,7 +29603,7 @@
         "implicitBranchNo": 0,
         "seq": 16093,
         "isMergeCommit": true,
-        "taskId": 2511
+        "clusterId": 2511
       }
     ]
   },
@@ -34702,24 +29614,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "becb496de8eb293c55317d37bacfbfd7f2b79b79",
-          "parentIds": [
-            "0c80dfc9a467914b845954aee74f7ffbcc13d60d"
-          ],
+          "parentIds": ["0c80dfc9a467914b845954aee74f7ffbcc13d60d"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-11-11T08:02:41.000Z",
           "commitDate": "2019-11-11T08:02:41.000Z",
@@ -34738,7 +29640,7 @@
         "implicitBranchNo": 0,
         "seq": 16096,
         "isMergeCommit": false,
-        "taskId": 2512
+        "clusterId": 2512
       }
     ]
   },
@@ -34749,24 +29651,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "ee3c88c6d53c2795f4d41206dc8fab47b6f411b0",
-          "parentIds": [
-            "becb496de8eb293c55317d37bacfbfd7f2b79b79"
-          ],
+          "parentIds": ["becb496de8eb293c55317d37bacfbfd7f2b79b79"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-11-11T08:03:49.000Z",
           "commitDate": "2019-11-11T08:03:49.000Z",
@@ -34785,7 +29677,7 @@
         "implicitBranchNo": 0,
         "seq": 16097,
         "isMergeCommit": false,
-        "taskId": 2513
+        "clusterId": 2513
       }
     ]
   },
@@ -34796,24 +29688,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "121f96576209faec5e923ee9c6489e65ab499865",
-          "parentIds": [
-            "ee3c88c6d53c2795f4d41206dc8fab47b6f411b0"
-          ],
+          "parentIds": ["ee3c88c6d53c2795f4d41206dc8fab47b6f411b0"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-11-11T08:03:49.000Z",
           "commitDate": "2019-11-11T08:03:49.000Z",
@@ -34832,7 +29714,7 @@
         "implicitBranchNo": 0,
         "seq": 16098,
         "isMergeCommit": false,
-        "taskId": 2514
+        "clusterId": 2514
       }
     ]
   },
@@ -34843,24 +29725,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "3383237cd83990c667788d6e95283d0ff85d914b",
-          "parentIds": [
-            "242bd56a2cdefb987377aa0aa5e61516ed492937"
-          ],
+          "parentIds": ["242bd56a2cdefb987377aa0aa5e61516ed492937"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-10-01T07:01:45.000Z",
           "commitDate": "2019-10-01T07:01:45.000Z",
@@ -34879,30 +29751,20 @@
         "implicitBranchNo": 2696,
         "seq": 16021,
         "isMergeCommit": false,
-        "taskId": 2515
+        "clusterId": 2515
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "c860d75274ac394ba23f6dd057a12e90c8277a28",
-          "parentIds": [
-            "3383237cd83990c667788d6e95283d0ff85d914b"
-          ],
+          "parentIds": ["3383237cd83990c667788d6e95283d0ff85d914b"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-11-01T08:12:57.000Z",
           "commitDate": "2019-11-01T08:12:57.000Z",
@@ -34961,7 +29823,7 @@
         "implicitBranchNo": 2697,
         "seq": 16069,
         "isMergeCommit": false,
-        "taskId": 2515
+        "clusterId": 2515
       },
       {
         "nodeTypeName": "COMMIT",
@@ -34972,20 +29834,12 @@
             "c860d75274ac394ba23f6dd057a12e90c8277a28"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-11-01T08:14:43.000Z",
           "commitDate": "2019-11-01T08:14:43.000Z",
@@ -35044,30 +29898,20 @@
         "implicitBranchNo": 2696,
         "seq": 16070,
         "isMergeCommit": true,
-        "taskId": 2515
+        "clusterId": 2515
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "4d5874a57fd1cc6734be53f948d4cd9d7e343dbe",
-          "parentIds": [
-            "b96e28a0fcaa9f795b02efbc1a795ba750c797af"
-          ],
+          "parentIds": ["b96e28a0fcaa9f795b02efbc1a795ba750c797af"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-11-13T09:47:22.000Z",
           "commitDate": "2019-11-13T09:47:22.000Z",
@@ -35118,7 +29962,7 @@
         "implicitBranchNo": 2696,
         "seq": 16100,
         "isMergeCommit": false,
-        "taskId": 2515
+        "clusterId": 2515
       },
       {
         "nodeTypeName": "COMMIT",
@@ -35129,20 +29973,12 @@
             "121f96576209faec5e923ee9c6489e65ab499865"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-11-13T09:48:20.000Z",
           "commitDate": "2019-11-13T09:48:20.000Z",
@@ -35181,30 +30017,20 @@
         "implicitBranchNo": 2696,
         "seq": 16101,
         "isMergeCommit": true,
-        "taskId": 2515
+        "clusterId": 2515
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "e01a7e34e45214ce80b72af026efea2b130d9189",
-          "parentIds": [
-            "27ca59be0d267b646a68c4fa4b29764f2a459d47"
-          ],
+          "parentIds": ["27ca59be0d267b646a68c4fa4b29764f2a459d47"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-11-13T09:50:47.000Z",
           "commitDate": "2019-11-13T09:50:47.000Z",
@@ -35223,30 +30049,20 @@
         "implicitBranchNo": 2696,
         "seq": 16102,
         "isMergeCommit": false,
-        "taskId": 2515
+        "clusterId": 2515
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "49be669da12e68ed806cebd8e8fded7aa1390f1b",
-          "parentIds": [
-            "e01a7e34e45214ce80b72af026efea2b130d9189"
-          ],
+          "parentIds": ["e01a7e34e45214ce80b72af026efea2b130d9189"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-11-13T12:40:55.000Z",
           "commitDate": "2019-11-13T12:40:55.000Z",
@@ -35269,30 +30085,20 @@
         "implicitBranchNo": 2696,
         "seq": 16103,
         "isMergeCommit": false,
-        "taskId": 2515
+        "clusterId": 2515
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "0392c52e376a013f1a98cfd629e889bc2df02a81",
-          "parentIds": [
-            "49be669da12e68ed806cebd8e8fded7aa1390f1b"
-          ],
+          "parentIds": ["49be669da12e68ed806cebd8e8fded7aa1390f1b"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-11-20T19:21:29.000Z",
           "commitDate": "2019-11-20T19:21:29.000Z",
@@ -35311,7 +30117,7 @@
         "implicitBranchNo": 2696,
         "seq": 16128,
         "isMergeCommit": false,
-        "taskId": 2515
+        "clusterId": 2515
       },
       {
         "nodeTypeName": "COMMIT",
@@ -35322,20 +30128,12 @@
             "0392c52e376a013f1a98cfd629e889bc2df02a81"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-11-20T19:21:56.000Z",
           "commitDate": "2019-11-20T19:21:56.000Z",
@@ -35434,7 +30232,7 @@
         "implicitBranchNo": 0,
         "seq": 16129,
         "isMergeCommit": true,
-        "taskId": 2515
+        "clusterId": 2515
       }
     ]
   },
@@ -35445,24 +30243,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "3e764de90f1c8fb70e7b3280b85a8537bc9461c6",
-          "parentIds": [
-            "121f96576209faec5e923ee9c6489e65ab499865"
-          ],
+          "parentIds": ["121f96576209faec5e923ee9c6489e65ab499865"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-11-20T13:25:10.000Z",
           "commitDate": "2019-11-20T13:25:10.000Z",
@@ -35485,7 +30273,7 @@
         "implicitBranchNo": 2702,
         "seq": 16125,
         "isMergeCommit": false,
-        "taskId": 2516
+        "clusterId": 2516
       },
       {
         "nodeTypeName": "COMMIT",
@@ -35496,20 +30284,12 @@
             "92202120a59716c6e2053fdb26cdb6fd34765553"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-11-20T19:24:53.000Z",
           "commitDate": "2019-11-20T19:24:53.000Z",
@@ -35608,7 +30388,7 @@
         "implicitBranchNo": 2702,
         "seq": 16130,
         "isMergeCommit": true,
-        "taskId": 2516
+        "clusterId": 2516
       },
       {
         "nodeTypeName": "COMMIT",
@@ -35619,20 +30399,12 @@
             "ceb14a0602484f1c21fcbeb3fb8beeb337e57058"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-11-20T19:31:29.000Z",
           "commitDate": "2019-11-20T19:31:29.000Z",
@@ -35655,7 +30427,7 @@
         "implicitBranchNo": 0,
         "seq": 16131,
         "isMergeCommit": true,
-        "taskId": 2516
+        "clusterId": 2516
       }
     ]
   },
@@ -35666,24 +30438,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "df5e31c5930a9c875bb078a4a794bfd26a918c6d",
-          "parentIds": [
-            "9fb012b0d3e9a553b60363ff028ccf91de3bb33f"
-          ],
+          "parentIds": ["9fb012b0d3e9a553b60363ff028ccf91de3bb33f"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-11-20T19:49:10.000Z",
           "commitDate": "2019-11-20T19:49:10.000Z",
@@ -35706,7 +30468,7 @@
         "implicitBranchNo": 2706,
         "seq": 16132,
         "isMergeCommit": false,
-        "taskId": 2517
+        "clusterId": 2517
       },
       {
         "nodeTypeName": "COMMIT",
@@ -35717,20 +30479,12 @@
             "df5e31c5930a9c875bb078a4a794bfd26a918c6d"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-11-21T12:22:28.000Z",
           "commitDate": "2019-11-21T12:22:28.000Z",
@@ -35753,7 +30507,7 @@
         "implicitBranchNo": 0,
         "seq": 16133,
         "isMergeCommit": true,
-        "taskId": 2517
+        "clusterId": 2517
       }
     ]
   },
@@ -35764,24 +30518,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "8cf6fe95c01a80f4df3853af70f7c0b92a807487",
-          "parentIds": [
-            "1c9bb7da7080ed4f3ed728266b3934565131dbb0"
-          ],
+          "parentIds": ["1c9bb7da7080ed4f3ed728266b3934565131dbb0"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-11-21T12:25:48.000Z",
           "commitDate": "2019-11-21T12:25:48.000Z",
@@ -35800,7 +30544,7 @@
         "implicitBranchNo": 0,
         "seq": 16134,
         "isMergeCommit": false,
-        "taskId": 2518
+        "clusterId": 2518
       }
     ]
   },
@@ -35811,24 +30555,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "72b82f50077fa34e76163c194342064fb4c83232",
-          "parentIds": [
-            "8cf6fe95c01a80f4df3853af70f7c0b92a807487"
-          ],
+          "parentIds": ["8cf6fe95c01a80f4df3853af70f7c0b92a807487"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-11-21T12:26:07.000Z",
           "commitDate": "2019-11-21T12:26:07.000Z",
@@ -35847,7 +30581,7 @@
         "implicitBranchNo": 0,
         "seq": 16135,
         "isMergeCommit": false,
-        "taskId": 2519
+        "clusterId": 2519
       }
     ]
   },
@@ -35858,24 +30592,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "32a80d6f6f2c4a5273bef53e3860a0f61f716640",
-          "parentIds": [
-            "72b82f50077fa34e76163c194342064fb4c83232"
-          ],
+          "parentIds": ["72b82f50077fa34e76163c194342064fb4c83232"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-11-21T12:26:07.000Z",
           "commitDate": "2019-11-21T12:26:07.000Z",
@@ -35894,7 +30618,7 @@
         "implicitBranchNo": 0,
         "seq": 16136,
         "isMergeCommit": false,
-        "taskId": 2520
+        "clusterId": 2520
       }
     ]
   },
@@ -35905,24 +30629,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "cb9949cccd4a2d7f64b386d8426be39ce372a687",
-          "parentIds": [
-            "32a80d6f6f2c4a5273bef53e3860a0f61f716640"
-          ],
+          "parentIds": ["32a80d6f6f2c4a5273bef53e3860a0f61f716640"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-12-06T10:29:22.000Z",
           "commitDate": "2019-12-06T10:29:22.000Z",
@@ -35973,30 +30687,20 @@
         "implicitBranchNo": 2707,
         "seq": 16167,
         "isMergeCommit": false,
-        "taskId": 2521
+        "clusterId": 2521
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "d5baf59f8430ea19228633920db27cb1e90b3372",
-          "parentIds": [
-            "cb9949cccd4a2d7f64b386d8426be39ce372a687"
-          ],
+          "parentIds": ["cb9949cccd4a2d7f64b386d8426be39ce372a687"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-12-16T12:50:12.000Z",
           "commitDate": "2019-12-16T12:50:12.000Z",
@@ -36031,7 +30735,7 @@
         "implicitBranchNo": 2707,
         "seq": 16183,
         "isMergeCommit": false,
-        "taskId": 2521
+        "clusterId": 2521
       },
       {
         "nodeTypeName": "COMMIT",
@@ -36042,20 +30746,12 @@
             "d5baf59f8430ea19228633920db27cb1e90b3372"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-12-16T13:36:41.000Z",
           "commitDate": "2019-12-16T13:36:41.000Z",
@@ -36102,7 +30798,7 @@
         "implicitBranchNo": 0,
         "seq": 16184,
         "isMergeCommit": true,
-        "taskId": 2521
+        "clusterId": 2521
       }
     ]
   },
@@ -36113,24 +30809,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "057a5caf4cfa93286a15007bef9cf4d7618b03f3",
-          "parentIds": [
-            "779ea50dc7d40f9fb9228eea6fee0a6588de7ad6"
-          ],
+          "parentIds": ["779ea50dc7d40f9fb9228eea6fee0a6588de7ad6"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-12-16T13:40:53.000Z",
           "commitDate": "2019-12-16T13:40:53.000Z",
@@ -36153,7 +30839,7 @@
         "implicitBranchNo": 2714,
         "seq": 16185,
         "isMergeCommit": false,
-        "taskId": 2522
+        "clusterId": 2522
       },
       {
         "nodeTypeName": "COMMIT",
@@ -36164,20 +30850,12 @@
             "057a5caf4cfa93286a15007bef9cf4d7618b03f3"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-12-16T17:22:02.000Z",
           "commitDate": "2019-12-16T17:22:02.000Z",
@@ -36200,7 +30878,7 @@
         "implicitBranchNo": 0,
         "seq": 16187,
         "isMergeCommit": true,
-        "taskId": 2522
+        "clusterId": 2522
       }
     ]
   },
@@ -36211,24 +30889,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "f7e747988b3e49458eec07febc1a7db727457e39",
-          "parentIds": [
-            "b96e28a0fcaa9f795b02efbc1a795ba750c797af"
-          ],
+          "parentIds": ["b96e28a0fcaa9f795b02efbc1a795ba750c797af"],
           "author": {
-            "names": [
-              "sellmair "
-            ],
-            "emails": [
-              "sebastiansellmair@gmail.com"
-            ]
+            "names": ["sellmair "],
+            "emails": ["sebastiansellmair@gmail.com"]
           },
           "committer": {
-            "names": [
-              "sellmair "
-            ],
-            "emails": [
-              "sebastiansellmair@gmail.com"
-            ]
+            "names": ["sellmair "],
+            "emails": ["sebastiansellmair@gmail.com"]
           },
           "authorDate": "2019-11-01T22:08:36.000Z",
           "commitDate": "2019-11-02T01:53:49.000Z",
@@ -36247,7 +30915,7 @@
         "implicitBranchNo": 2701,
         "seq": 16076,
         "isMergeCommit": false,
-        "taskId": 2523
+        "clusterId": 2523
       },
       {
         "nodeTypeName": "COMMIT",
@@ -36258,20 +30926,12 @@
             "121f96576209faec5e923ee9c6489e65ab499865"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-11-11T09:00:55.000Z",
           "commitDate": "2019-11-11T09:00:55.000Z",
@@ -36310,30 +30970,20 @@
         "implicitBranchNo": 2700,
         "seq": 16099,
         "isMergeCommit": true,
-        "taskId": 2523
+        "clusterId": 2523
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "4832e2d2160d0ab6b623ddddd24e6afb1422db8f",
-          "parentIds": [
-            "dc67440f62fee3637f1e308f6d55b4dc41fce8d5"
-          ],
+          "parentIds": ["dc67440f62fee3637f1e308f6d55b4dc41fce8d5"],
           "author": {
-            "names": [
-              "Anoop S S "
-            ],
-            "emails": [
-              "anoopvvs@gmail.com"
-            ]
+            "names": ["Anoop S S "],
+            "emails": ["anoopvvs@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-11-20T10:43:31.000Z",
           "commitDate": "2019-11-20T10:43:31.000Z",
@@ -36352,7 +31002,7 @@
         "implicitBranchNo": 2703,
         "seq": 16124,
         "isMergeCommit": false,
-        "taskId": 2523
+        "clusterId": 2523
       },
       {
         "nodeTypeName": "COMMIT",
@@ -36363,20 +31013,12 @@
             "4832e2d2160d0ab6b623ddddd24e6afb1422db8f"
           ],
           "author": {
-            "names": [
-              "Anoop S S "
-            ],
-            "emails": [
-              "anoopvvs@gmail.com"
-            ]
+            "names": ["Anoop S S "],
+            "emails": ["anoopvvs@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-11-20T16:28:16.000Z",
           "commitDate": "2019-11-20T16:28:16.000Z",
@@ -36395,7 +31037,7 @@
         "implicitBranchNo": 2700,
         "seq": 16127,
         "isMergeCommit": true,
-        "taskId": 2523
+        "clusterId": 2523
       },
       {
         "nodeTypeName": "COMMIT",
@@ -36406,20 +31048,12 @@
             "32a80d6f6f2c4a5273bef53e3860a0f61f716640"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-11-21T14:10:44.000Z",
           "commitDate": "2019-11-21T14:10:44.000Z",
@@ -36482,7 +31116,7 @@
         "implicitBranchNo": 2700,
         "seq": 16137,
         "isMergeCommit": true,
-        "taskId": 2523
+        "clusterId": 2523
       },
       {
         "nodeTypeName": "COMMIT",
@@ -36493,20 +31127,12 @@
             "f7e747988b3e49458eec07febc1a7db727457e39"
           ],
           "author": {
-            "names": [
-              "Sebastian Sellmair "
-            ],
-            "emails": [
-              "34319766+sellmair@users.noreply.github.com"
-            ]
+            "names": ["Sebastian Sellmair "],
+            "emails": ["34319766+sellmair@users.noreply.github.com"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-11-26T15:04:20.000Z",
           "commitDate": "2019-11-26T15:04:20.000Z",
@@ -36525,30 +31151,20 @@
         "implicitBranchNo": 2700,
         "seq": 16154,
         "isMergeCommit": true,
-        "taskId": 2523
+        "clusterId": 2523
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "4e82766ba451acd79fe91bcb2485f9ce5c82d2ac",
-          "parentIds": [
-            "291eab42c41a4c0ce7e175e00b25b8543de547d1"
-          ],
+          "parentIds": ["291eab42c41a4c0ce7e175e00b25b8543de547d1"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-11-26T15:10:34.000Z",
           "commitDate": "2019-11-26T15:10:34.000Z",
@@ -36567,30 +31183,20 @@
         "implicitBranchNo": 2700,
         "seq": 16155,
         "isMergeCommit": false,
-        "taskId": 2523
+        "clusterId": 2523
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "aa9f046f23cbc1c8e589bbcf5fc2f202f37f4bee",
-          "parentIds": [
-            "4e82766ba451acd79fe91bcb2485f9ce5c82d2ac"
-          ],
+          "parentIds": ["4e82766ba451acd79fe91bcb2485f9ce5c82d2ac"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-12-03T13:32:37.000Z",
           "commitDate": "2019-12-03T13:32:37.000Z",
@@ -36609,30 +31215,20 @@
         "implicitBranchNo": 2708,
         "seq": 16166,
         "isMergeCommit": false,
-        "taskId": 2523
+        "clusterId": 2523
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "3d6fb2f41f39eab602bd7e5ac80b893d647a6a77",
-          "parentIds": [
-            "aa9f046f23cbc1c8e589bbcf5fc2f202f37f4bee"
-          ],
+          "parentIds": ["aa9f046f23cbc1c8e589bbcf5fc2f202f37f4bee"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2019-12-16T12:19:53.000Z",
           "commitDate": "2019-12-16T12:19:53.000Z",
@@ -36651,7 +31247,7 @@
         "implicitBranchNo": 2708,
         "seq": 16182,
         "isMergeCommit": false,
-        "taskId": 2523
+        "clusterId": 2523
       },
       {
         "nodeTypeName": "COMMIT",
@@ -36662,20 +31258,12 @@
             "3d6fb2f41f39eab602bd7e5ac80b893d647a6a77"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2019-12-16T17:21:39.000Z",
           "commitDate": "2019-12-16T17:21:39.000Z",
@@ -36694,30 +31282,20 @@
         "implicitBranchNo": 2700,
         "seq": 16186,
         "isMergeCommit": true,
-        "taskId": 2523
+        "clusterId": 2523
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "a18a3448c4272c56435e5ee46ec61513b3d2d668",
-          "parentIds": [
-            "5a1a25c764bdb4eef71d04103b0b3c75006fa9d7"
-          ],
+          "parentIds": ["5a1a25c764bdb4eef71d04103b0b3c75006fa9d7"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2020-01-07T12:00:15.000Z",
           "commitDate": "2020-01-07T12:00:15.000Z",
@@ -36740,30 +31318,20 @@
         "implicitBranchNo": 2715,
         "seq": 16199,
         "isMergeCommit": false,
-        "taskId": 2523
+        "clusterId": 2523
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "1ecb476714353160ef51a1d2ddd0214e0260cd4a",
-          "parentIds": [
-            "a18a3448c4272c56435e5ee46ec61513b3d2d668"
-          ],
+          "parentIds": ["a18a3448c4272c56435e5ee46ec61513b3d2d668"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2020-01-07T14:55:00.000Z",
           "commitDate": "2020-01-07T14:55:00.000Z",
@@ -36782,7 +31350,7 @@
         "implicitBranchNo": 2715,
         "seq": 16200,
         "isMergeCommit": false,
-        "taskId": 2523
+        "clusterId": 2523
       },
       {
         "nodeTypeName": "COMMIT",
@@ -36793,20 +31361,12 @@
             "1ecb476714353160ef51a1d2ddd0214e0260cd4a"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2020-01-07T15:47:55.000Z",
           "commitDate": "2020-01-07T15:47:55.000Z",
@@ -36833,30 +31393,20 @@
         "implicitBranchNo": 2700,
         "seq": 16201,
         "isMergeCommit": true,
-        "taskId": 2523
+        "clusterId": 2523
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "6e449593da4cea0be7a38fb1c19177130fd69ba1",
-          "parentIds": [
-            "d4a5db37c1b6254af17c7367a5f937c6f2de5443"
-          ],
+          "parentIds": ["d4a5db37c1b6254af17c7367a5f937c6f2de5443"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2020-01-16T10:26:44.000Z",
           "commitDate": "2020-01-16T10:26:44.000Z",
@@ -36907,30 +31457,20 @@
         "implicitBranchNo": 2717,
         "seq": 16212,
         "isMergeCommit": false,
-        "taskId": 2523
+        "clusterId": 2523
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "ee5777dffa6a29451866d5697a6693e5b86b1a7e",
-          "parentIds": [
-            "6e449593da4cea0be7a38fb1c19177130fd69ba1"
-          ],
+          "parentIds": ["6e449593da4cea0be7a38fb1c19177130fd69ba1"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2020-01-16T14:42:45.000Z",
           "commitDate": "2020-01-16T14:42:45.000Z",
@@ -36957,30 +31497,20 @@
         "implicitBranchNo": 2717,
         "seq": 16214,
         "isMergeCommit": false,
-        "taskId": 2523
+        "clusterId": 2523
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "8f4e8ac5691ae297a5f1955a079ef208e33c6d8f",
-          "parentIds": [
-            "ee5777dffa6a29451866d5697a6693e5b86b1a7e"
-          ],
+          "parentIds": ["ee5777dffa6a29451866d5697a6693e5b86b1a7e"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2020-01-17T11:09:32.000Z",
           "commitDate": "2020-01-17T11:09:32.000Z",
@@ -36999,30 +31529,20 @@
         "implicitBranchNo": 2717,
         "seq": 16217,
         "isMergeCommit": false,
-        "taskId": 2523
+        "clusterId": 2523
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "ccc70f39c35a74fb56661fae0f5224e7d5fdecb2",
-          "parentIds": [
-            "8f4e8ac5691ae297a5f1955a079ef208e33c6d8f"
-          ],
+          "parentIds": ["8f4e8ac5691ae297a5f1955a079ef208e33c6d8f"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2020-01-17T11:22:37.000Z",
           "commitDate": "2020-01-17T11:22:37.000Z",
@@ -37045,7 +31565,7 @@
         "implicitBranchNo": 2717,
         "seq": 16218,
         "isMergeCommit": false,
-        "taskId": 2523
+        "clusterId": 2523
       },
       {
         "nodeTypeName": "COMMIT",
@@ -37056,20 +31576,12 @@
             "ccc70f39c35a74fb56661fae0f5224e7d5fdecb2"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2020-01-17T12:20:08.000Z",
           "commitDate": "2020-01-17T12:20:08.000Z",
@@ -37124,7 +31636,7 @@
         "implicitBranchNo": 2700,
         "seq": 16219,
         "isMergeCommit": true,
-        "taskId": 2523
+        "clusterId": 2523
       },
       {
         "nodeTypeName": "COMMIT",
@@ -37135,20 +31647,12 @@
             "ea772b530d1006407a7eff46bffb0049c91a3c43"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2020-01-17T12:32:40.000Z",
           "commitDate": "2020-01-17T12:32:40.000Z",
@@ -37223,7 +31727,7 @@
         "implicitBranchNo": 0,
         "seq": 16220,
         "isMergeCommit": true,
-        "taskId": 2523
+        "clusterId": 2523
       }
     ]
   },
@@ -37234,24 +31738,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "2354e27c862fae1105cb886166767d1d6a6c3acc",
-          "parentIds": [
-            "4dc7352b2c7ea38c3f1f62986d8005378c7ea098"
-          ],
+          "parentIds": ["4dc7352b2c7ea38c3f1f62986d8005378c7ea098"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2020-01-17T12:39:39.000Z",
           "commitDate": "2020-01-17T12:39:39.000Z",
@@ -37270,7 +31764,7 @@
         "implicitBranchNo": 0,
         "seq": 16221,
         "isMergeCommit": false,
-        "taskId": 2524
+        "clusterId": 2524
       }
     ]
   },
@@ -37281,24 +31775,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "23b6ede794592b047b507d6fd8f2536005cca147",
-          "parentIds": [
-            "2354e27c862fae1105cb886166767d1d6a6c3acc"
-          ],
+          "parentIds": ["2354e27c862fae1105cb886166767d1d6a6c3acc"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2020-01-17T12:39:39.000Z",
           "commitDate": "2020-01-17T12:39:39.000Z",
@@ -37317,7 +31801,7 @@
         "implicitBranchNo": 0,
         "seq": 16222,
         "isMergeCommit": false,
-        "taskId": 2525
+        "clusterId": 2525
       }
     ]
   },
@@ -37328,24 +31812,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "3bb822bc96f69c3388ed09be291ce9f59593208b",
-          "parentIds": [
-            "23b6ede794592b047b507d6fd8f2536005cca147"
-          ],
+          "parentIds": ["23b6ede794592b047b507d6fd8f2536005cca147"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2020-01-17T14:17:21.000Z",
           "commitDate": "2020-01-17T14:17:21.000Z",
@@ -37364,7 +31838,7 @@
         "implicitBranchNo": 0,
         "seq": 16223,
         "isMergeCommit": false,
-        "taskId": 2526
+        "clusterId": 2526
       }
     ]
   },
@@ -37375,24 +31849,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "5ef857bcb80d1db33c32ce5b7297977f47bfd46e",
-          "parentIds": [
-            "3bb822bc96f69c3388ed09be291ce9f59593208b"
-          ],
+          "parentIds": ["3bb822bc96f69c3388ed09be291ce9f59593208b"],
           "author": {
-            "names": [
-              "Jonathan Leitschuh "
-            ],
-            "emails": [
-              "jonathan.leitschuh@gmail.com"
-            ]
+            "names": ["Jonathan Leitschuh "],
+            "emails": ["jonathan.leitschuh@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2020-02-04T17:12:09.000Z",
           "commitDate": "2020-02-04T17:12:09.000Z",
@@ -37411,7 +31875,7 @@
         "implicitBranchNo": 2722,
         "seq": 16249,
         "isMergeCommit": false,
-        "taskId": 2527
+        "clusterId": 2527
       },
       {
         "nodeTypeName": "COMMIT",
@@ -37422,20 +31886,12 @@
             "5ef857bcb80d1db33c32ce5b7297977f47bfd46e"
           ],
           "author": {
-            "names": [
-              "Jonathan Leitschuh "
-            ],
-            "emails": [
-              "jonathan.leitschuh@gmail.com"
-            ]
+            "names": ["Jonathan Leitschuh "],
+            "emails": ["jonathan.leitschuh@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2020-02-05T13:54:15.000Z",
           "commitDate": "2020-02-05T13:54:15.000Z",
@@ -37454,7 +31910,7 @@
         "implicitBranchNo": 0,
         "seq": 16251,
         "isMergeCommit": true,
-        "taskId": 2527
+        "clusterId": 2527
       }
     ]
   },
@@ -37465,24 +31921,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "dbfe924507aa6da95835ffecbdce9d7375e37812",
-          "parentIds": [
-            "c1c45b46a36e9725f9741cce25732c69536be075"
-          ],
+          "parentIds": ["c1c45b46a36e9725f9741cce25732c69536be075"],
           "author": {
-            "names": [
-              "Joxon "
-            ],
-            "emails": [
-              "cijophxon@gmail.com"
-            ]
+            "names": ["Joxon "],
+            "emails": ["cijophxon@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Joxon "
-            ],
-            "emails": [
-              "cijophxon@gmail.com"
-            ]
+            "names": ["Joxon "],
+            "emails": ["cijophxon@gmail.com"]
           },
           "authorDate": "2020-03-05T04:05:27.000Z",
           "commitDate": "2020-03-05T04:05:27.000Z",
@@ -37501,30 +31947,20 @@
         "implicitBranchNo": 2726,
         "seq": 16310,
         "isMergeCommit": false,
-        "taskId": 2528
+        "clusterId": 2528
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "3b61103bbd848f7219aaee815e11e8f1d70ff967",
-          "parentIds": [
-            "dbfe924507aa6da95835ffecbdce9d7375e37812"
-          ],
+          "parentIds": ["dbfe924507aa6da95835ffecbdce9d7375e37812"],
           "author": {
-            "names": [
-              "Joxon "
-            ],
-            "emails": [
-              "cijophxon@gmail.com"
-            ]
+            "names": ["Joxon "],
+            "emails": ["cijophxon@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Joxon "
-            ],
-            "emails": [
-              "cijophxon@gmail.com"
-            ]
+            "names": ["Joxon "],
+            "emails": ["cijophxon@gmail.com"]
           },
           "authorDate": "2020-03-06T09:14:29.000Z",
           "commitDate": "2020-03-06T09:14:29.000Z",
@@ -37543,30 +31979,20 @@
         "implicitBranchNo": 2726,
         "seq": 16312,
         "isMergeCommit": false,
-        "taskId": 2528
+        "clusterId": 2528
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "603efeb53c8c4709d6b79d7c5cc7e89f5db4c9a0",
-          "parentIds": [
-            "3b61103bbd848f7219aaee815e11e8f1d70ff967"
-          ],
+          "parentIds": ["3b61103bbd848f7219aaee815e11e8f1d70ff967"],
           "author": {
-            "names": [
-              "Joxon "
-            ],
-            "emails": [
-              "cijophxon@gmail.com"
-            ]
+            "names": ["Joxon "],
+            "emails": ["cijophxon@gmail.com"]
           },
           "committer": {
-            "names": [
-              "Joxon "
-            ],
-            "emails": [
-              "cijophxon@gmail.com"
-            ]
+            "names": ["Joxon "],
+            "emails": ["cijophxon@gmail.com"]
           },
           "authorDate": "2020-03-06T09:33:54.000Z",
           "commitDate": "2020-03-06T09:33:54.000Z",
@@ -37585,7 +32011,7 @@
         "implicitBranchNo": 2726,
         "seq": 16313,
         "isMergeCommit": false,
-        "taskId": 2528
+        "clusterId": 2528
       },
       {
         "nodeTypeName": "COMMIT",
@@ -37596,20 +32022,12 @@
             "603efeb53c8c4709d6b79d7c5cc7e89f5db4c9a0"
           ],
           "author": {
-            "names": [
-              "Junxian "
-            ],
-            "emails": [
-              "cijophxon@gmail.com"
-            ]
+            "names": ["Junxian "],
+            "emails": ["cijophxon@gmail.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2020-03-16T19:50:59.000Z",
           "commitDate": "2020-03-16T19:50:59.000Z",
@@ -37636,7 +32054,7 @@
         "implicitBranchNo": 0,
         "seq": 16403,
         "isMergeCommit": true,
-        "taskId": 2528
+        "clusterId": 2528
       }
     ]
   },
@@ -37647,24 +32065,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "fb352e7025700f001e77cd2fcfd61b4accfbe898",
-          "parentIds": [
-            "6b7b85cf4d2c8d88afdb9f7bc85e63e05b2f55d1"
-          ],
+          "parentIds": ["6b7b85cf4d2c8d88afdb9f7bc85e63e05b2f55d1"],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "authorDate": "2020-03-16T19:55:59.000Z",
           "commitDate": "2020-03-16T19:55:59.000Z",
@@ -37683,7 +32091,7 @@
         "implicitBranchNo": 0,
         "seq": 16404,
         "isMergeCommit": false,
-        "taskId": 2529
+        "clusterId": 2529
       }
     ]
   },
@@ -37694,24 +32102,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "af46e4c5232780f8bdea4e91c3866c1d1b928923",
-          "parentIds": [
-            "c1c45b46a36e9725f9741cce25732c69536be075"
-          ],
+          "parentIds": ["c1c45b46a36e9725f9741cce25732c69536be075"],
           "author": {
-            "names": [
-              "zihuaweng "
-            ],
-            "emails": [
-              "wengzihua123@126.com"
-            ]
+            "names": ["zihuaweng "],
+            "emails": ["wengzihua123@126.com"]
           },
           "committer": {
-            "names": [
-              "zihuaweng "
-            ],
-            "emails": [
-              "wengzihua123@126.com"
-            ]
+            "names": ["zihuaweng "],
+            "emails": ["wengzihua123@126.com"]
           },
           "authorDate": "2020-03-16T07:02:42.000Z",
           "commitDate": "2020-03-16T07:02:42.000Z",
@@ -37738,30 +32136,20 @@
         "implicitBranchNo": 2725,
         "seq": 16401,
         "isMergeCommit": false,
-        "taskId": 2530
+        "clusterId": 2530
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "08cd7181a5b60e7feeca6ae82846792d6db4456d",
-          "parentIds": [
-            "af46e4c5232780f8bdea4e91c3866c1d1b928923"
-          ],
+          "parentIds": ["af46e4c5232780f8bdea4e91c3866c1d1b928923"],
           "author": {
-            "names": [
-              "zihuaweng "
-            ],
-            "emails": [
-              "wengzihua123@126.com"
-            ]
+            "names": ["zihuaweng "],
+            "emails": ["wengzihua123@126.com"]
           },
           "committer": {
-            "names": [
-              "zihuaweng "
-            ],
-            "emails": [
-              "wengzihua123@126.com"
-            ]
+            "names": ["zihuaweng "],
+            "emails": ["wengzihua123@126.com"]
           },
           "authorDate": "2020-03-16T19:31:07.000Z",
           "commitDate": "2020-03-16T19:31:07.000Z",
@@ -37780,30 +32168,20 @@
         "implicitBranchNo": 2725,
         "seq": 16402,
         "isMergeCommit": false,
-        "taskId": 2530
+        "clusterId": 2530
       },
       {
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "8090121a66e245734cd8e728734b34d4fd37a042",
-          "parentIds": [
-            "08cd7181a5b60e7feeca6ae82846792d6db4456d"
-          ],
+          "parentIds": ["08cd7181a5b60e7feeca6ae82846792d6db4456d"],
           "author": {
-            "names": [
-              "Junxian "
-            ],
-            "emails": [
-              "junxian.chen@uci.edu"
-            ]
+            "names": ["Junxian "],
+            "emails": ["junxian.chen@uci.edu"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2020-03-16T20:15:16.000Z",
           "commitDate": "2020-03-16T20:15:16.000Z",
@@ -37822,7 +32200,7 @@
         "implicitBranchNo": 2725,
         "seq": 16405,
         "isMergeCommit": false,
-        "taskId": 2530
+        "clusterId": 2530
       },
       {
         "nodeTypeName": "COMMIT",
@@ -37833,20 +32211,12 @@
             "8090121a66e245734cd8e728734b34d4fd37a042"
           ],
           "author": {
-            "names": [
-              "Junxian "
-            ],
-            "emails": [
-              "junxian.chen@uci.edu"
-            ]
+            "names": ["Junxian "],
+            "emails": ["junxian.chen@uci.edu"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2020-03-17T09:04:42.000Z",
           "commitDate": "2020-03-17T09:04:42.000Z",
@@ -37873,7 +32243,7 @@
         "implicitBranchNo": 0,
         "seq": 16410,
         "isMergeCommit": true,
-        "taskId": 2530
+        "clusterId": 2530
       }
     ]
   },
@@ -37884,24 +32254,14 @@
         "nodeTypeName": "COMMIT",
         "commit": {
           "id": "df9fbc96a4d84982f5a7f1598e2277c4fc5b25fa",
-          "parentIds": [
-            "b6d8033d542392bd9ea74353316a183417f0579c"
-          ],
+          "parentIds": ["b6d8033d542392bd9ea74353316a183417f0579c"],
           "author": {
-            "names": [
-              "Eduardo López "
-            ],
-            "emails": [
-              "eduardo.lopezgutierrez@mongodb.com"
-            ]
+            "names": ["Eduardo López "],
+            "emails": ["eduardo.lopezgutierrez@mongodb.com"]
           },
           "committer": {
-            "names": [
-              "Eduardo López "
-            ],
-            "emails": [
-              "eduardo.lopezgutierrez@mongodb.com"
-            ]
+            "names": ["Eduardo López "],
+            "emails": ["eduardo.lopezgutierrez@mongodb.com"]
           },
           "authorDate": "2020-03-31T21:14:44.000Z",
           "commitDate": "2020-03-31T21:14:44.000Z",
@@ -37920,7 +32280,7 @@
         "implicitBranchNo": 2738,
         "seq": 16475,
         "isMergeCommit": false,
-        "taskId": 2531
+        "clusterId": 2531
       },
       {
         "nodeTypeName": "COMMIT",
@@ -37931,20 +32291,12 @@
             "df9fbc96a4d84982f5a7f1598e2277c4fc5b25fa"
           ],
           "author": {
-            "names": [
-              "Eduardo López "
-            ],
-            "emails": [
-              "1874445+edualonso@users.noreply.github.com"
-            ]
+            "names": ["Eduardo López "],
+            "emails": ["1874445+edualonso@users.noreply.github.com"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2020-04-01T19:41:23.000Z",
           "commitDate": "2020-04-01T19:41:23.000Z",
@@ -37963,7 +32315,7 @@
         "implicitBranchNo": 0,
         "seq": 16485,
         "isMergeCommit": true,
-        "taskId": 2531
+        "clusterId": 2531
       }
     ]
   },
@@ -37979,20 +32331,12 @@
             "8539eb178d4c6c8ed6e85d4d1101a4008b93483e"
           ],
           "author": {
-            "names": [
-              "Christian Melchior "
-            ],
-            "emails": [
-              "christian@ilios.dk"
-            ]
+            "names": ["Christian Melchior "],
+            "emails": ["christian@ilios.dk"]
           },
           "committer": {
-            "names": [
-              "GitHub "
-            ],
-            "emails": [
-              "noreply@github.com"
-            ]
+            "names": ["GitHub "],
+            "emails": ["noreply@github.com"]
           },
           "authorDate": "2020-04-01T19:43:30.000Z",
           "commitDate": "2020-04-01T19:43:30.000Z",
@@ -38027,7 +32371,7 @@
         "implicitBranchNo": 0,
         "seq": 16486,
         "isMergeCommit": true,
-        "taskId": 2532
+        "clusterId": 2532
       }
     ]
   }

--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -1,33 +1,29 @@
-/* eslint-disable react/no-array-index-key */
-import type { GlobalProps } from "types";
+import type { GlobalProps } from "types/global";
 
-import { getTargetCommit, getTime } from "./Detail.util";
+import { getCommitListDetail, getCommitListInCluster } from "./Detail.util";
 
-const TARGET_ID = "2a7a93cde9c9f74d5f05c1d0fb1da8e96da7057b";
+const TARGET_CLUSTER_ID = 2433;
 
 const Detail = ({ data }: GlobalProps) => {
-  const commit = getTargetCommit({ data, id: TARGET_ID });
-  if (!commit) return null;
-  const { authorDate, message, committer } = commit;
-  const time = getTime(authorDate);
+  const commitNodeListInCluster = getCommitListInCluster({
+    data,
+    clusterId: TARGET_CLUSTER_ID,
+  });
+  const { authorLength, fileLength, commitLength, insertions, deletions } =
+    getCommitListDetail({ commitNodeListInCluster });
+
   return (
-    <div className="detail">
-      <div>작성 날짜</div>
-      <p>{time}</p>
-
-      <div>메세지</div>
-      <p>{message}</p>
-
-      <div>Committer Name</div>
-      {committer.names.map((name: string, i: number) => (
-        <p key={i}>{name}</p>
+    <>
+      {commitNodeListInCluster.map((commitNode) => (
+        <div key={commitNode.commit.id}>{commitNode.commit.message}</div>
       ))}
-
-      <div>Committer Email</div>
-      {committer.emails.map((email: string, i: number) => (
-        <p key={i}>{email}</p>
-      ))}
-    </div>
+      <div>
+        Excluding merges, {authorLength} authors have pushed {commitLength}
+        commits to main. On main, {fileLength} files have changed and there have
+        been
+        {insertions} additions and {deletions} deletions.
+      </div>
+    </>
   );
 };
 

--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -2,7 +2,7 @@ import type { GlobalProps } from "types/global";
 
 import { getCommitListDetail, getCommitListInCluster } from "./Detail.util";
 
-const TARGET_CLUSTER_ID = 2433;
+const TARGET_CLUSTER_ID = 2435;
 
 const Detail = ({ data }: GlobalProps) => {
   const commitNodeListInCluster = getCommitListInCluster({

--- a/packages/view/src/components/Detail/Detail.util.ts
+++ b/packages/view/src/components/Detail/Detail.util.ts
@@ -28,7 +28,7 @@ const getCommitListAuthorLength = ({
   commitNodeListInCluster,
 }: GetCommitListAuthorLength) => {
   const fn =
-    (set: Set<unknown>) =>
+    (set: Set<string>) =>
     ({
       commit: {
         author: { names },
@@ -43,7 +43,7 @@ const getChangeFileLength = ({
   commitNodeListInCluster,
 }: GetChangeFileLength) => {
   const fn =
-    (set: Set<unknown>) =>
+    (set: Set<string>) =>
     ({
       commit: {
         diffStatistics: { files },

--- a/packages/view/src/components/Detail/Detail.util.ts
+++ b/packages/view/src/components/Detail/Detail.util.ts
@@ -53,9 +53,6 @@ const getChangeFileLength = ({
   return getDataSetSize(commitNodeListInCluster, fn);
 };
 
-const numAddCommar = (num: number) =>
-  num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-
 type ObjAddCommarProps = {
   authorLength: number;
   fileLength: number;
@@ -68,7 +65,7 @@ const objAddCommar = (obj: ObjAddCommarProps): ObjAddCommarReturn =>
   Object.entries(obj).reduce((acc, [k, v]) => {
     return {
       ...acc,
-      [k]: numAddCommar(v),
+      [k]: v.toLocaleString("en"),
     };
   }, {}) as ObjAddCommarReturn;
 

--- a/packages/view/src/components/Detail/Detail.util.ts
+++ b/packages/view/src/components/Detail/Detail.util.ts
@@ -1,32 +1,97 @@
 import type { GlobalProps, CommitNode } from "types/";
 
-type GetTargetCommit = GlobalProps & { id: string };
-
-export const getTargetCommit = ({ data, id }: GetTargetCommit) => {
-  if (data?.length === 0) return undefined;
-  const flatCommitNode: CommitNode[] = data
+type GetCommitListInCluster = GlobalProps & { clusterId: number };
+export const getCommitListInCluster = ({
+  data,
+  clusterId,
+}: GetCommitListInCluster) => {
+  const flatCommitNodeList: CommitNode[] = data
     .map((clusterNode) => clusterNode.commitNodeList)
     .flat();
-  const [target] = flatCommitNode.filter(
-    (commitNode) => commitNode.commit.id === id
+
+  const commitNodeListInCluster = flatCommitNodeList.filter(
+    (commitNode) => commitNode.clusterId === clusterId
   );
-
-  // parent Commit 추출하기
-  // const parentCommitId = target.commit.parentIds;
-  // console.log(parentCommitId);
-  // const parentCommits = parentCommitId.map((parentId) =>
-  //   flatCommitNode.filter(commitNode => commitNode.commit.id === parentId)
-  // );
-  // console.log(parentCommits);
-
-  // 동일한 Cluster Commit 추출하기
-  // const { taskId: ClusterId } = target;
-  // const clusterCommits = flatCommitNode.filter(
-  //   (commitNode) => commitNode.taskId === ClusterId
-  // );
-  // console.log(clusterCommits);
-  return target?.commit;
+  return commitNodeListInCluster;
 };
 
-export const getTime = (date: Date) =>
-  String(date).split(".")[0].replace("T", " ");
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getDataSetSize = <T extends any[]>(arr: T, callback: Function) => {
+  const set = new Set();
+  const fn = callback(set);
+  arr.forEach(fn);
+  return set.size;
+};
+
+type GetCommitListAuthorLength = GetCommitListDetail;
+const getCommitListAuthorLength = ({
+  commitNodeListInCluster,
+}: GetCommitListAuthorLength) => {
+  const fn =
+    (set: Set<unknown>) =>
+    ({
+      commit: {
+        author: { names },
+      },
+    }: CommitNode) =>
+      names.forEach((name) => set.add(name));
+  return getDataSetSize(commitNodeListInCluster, fn);
+};
+
+type GetChangeFileLength = GetCommitListDetail;
+const getChangeFileLength = ({
+  commitNodeListInCluster,
+}: GetChangeFileLength) => {
+  const fn =
+    (set: Set<unknown>) =>
+    ({
+      commit: {
+        diffStatistics: { files },
+      },
+    }: CommitNode) =>
+      Object.keys(files).forEach((file) => set.add(file));
+  return getDataSetSize(commitNodeListInCluster, fn);
+};
+
+const numAddCommar = (num: number) =>
+  num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+
+type ObjAddCommarProps = {
+  authorLength: number;
+  fileLength: number;
+  commitLength: number;
+  insertions: number;
+  deletions: number;
+};
+type ObjAddCommarReturn = { [key in keyof ObjAddCommarProps]: string };
+const objAddCommar = (obj: ObjAddCommarProps): ObjAddCommarReturn =>
+  Object.entries(obj).reduce((acc, [k, v]) => {
+    return {
+      ...acc,
+      [k]: numAddCommar(v),
+    };
+  }, {}) as ObjAddCommarReturn;
+
+type GetCommitListDetail = { commitNodeListInCluster: CommitNode[] };
+export const getCommitListDetail = ({
+  commitNodeListInCluster,
+}: GetCommitListDetail) => {
+  const authorLength = getCommitListAuthorLength({ commitNodeListInCluster });
+  const fileLength = getChangeFileLength({ commitNodeListInCluster });
+  const diffStatistics = commitNodeListInCluster.reduce(
+    (acc, { commit: { diffStatistics: cur } }) => ({
+      insertions: acc.insertions + cur.insertions,
+      deletions: acc.deletions + cur.deletions,
+    }),
+    {
+      insertions: 0,
+      deletions: 0,
+    }
+  );
+  return objAddCommar({
+    authorLength,
+    fileLength,
+    commitLength: commitNodeListInCluster.length,
+    ...diffStatistics,
+  });
+};

--- a/packages/view/src/types/NodeTypes.temp.ts
+++ b/packages/view/src/types/NodeTypes.temp.ts
@@ -63,7 +63,7 @@ export type CommitNode = NodeBase & {
   nodeTypeName: "COMMIT";
   commit: Commit;
   seq: number;
-  taskId: number; // 동일한 Cluster 내부 commit 참조 id
+  clusterId: number; // 동일한 Cluster 내부 commit 참조 id
   hasMajorTag: boolean;
   hasMinorTag: boolean;
   isMergeCommit: boolean;


### PR DESCRIPTION
# WorkList

Before this commit, Detail Components contents showed the contents of one target commit, but after this commit, it shows the commit list in cluster

- Target_ID => TARGET_TASK_ID 변경
- getTime Func Delete

# Result

<img width="522" alt="스크린샷 2022-09-05 오후 2 38 32" src="https://user-images.githubusercontent.com/70205497/188368188-0d42ca00-c597-4d07-a8ad-fa405cfc0d03.png">

# Todo

- scss
- Commit 상세 내용 추가

---

# Add WorkList

[ fix(view): fix value naming taskId => ClusterId ]
- taskId 대신 ClusterId 적용

[ enhance(view): add Cluster Detail Data in Detail Component ]
- add Detail Data 
  - authors
  - commits
  - files
  - insertions
  - deletions