### PR TITLE
feat(view): add FileIcicleSummary

### DIFF
--- a/packages/view/public/fileChanges.json
+++ b/packages/view/public/fileChanges.json
@@ -1,0 +1,1036 @@
+{
+  "name": "project",
+  "children": [
+    {
+      "name": "packages",
+      "children": [
+        {
+          "name": "vue-server-renderer",
+          "children": [
+            {
+              "name": "build.dev.js",
+              "value": 4,
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 226,
+                  "deletions": 142,
+                  "count": 4
+                }
+              }
+            },
+            {
+              "name": "basic.js",
+              "value": 2,
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 155,
+                  "deletions": 71,
+                  "count": 2
+                }
+              }
+            },
+            {
+              "name": "build.prod.js",
+              "value": 2,
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 2,
+                  "deletions": 2,
+                  "count": 2
+                }
+              }
+            },
+            {
+              "name": "package.json",
+              "value": 2,
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 2,
+                  "deletions": 2,
+                  "count": 2
+                }
+              }
+            }
+          ],
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 385,
+              "deletions": 217,
+              "count": 10
+            }
+          }
+        },
+        {
+          "name": "weex-vue-framework/factory.js",
+          "value": 2
+        },
+        {
+          "name": "vue-template-compiler",
+          "children": [
+            {
+              "name": "README.md",
+              "value": 1,
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 3,
+                  "deletions": 3,
+                  "count": 1
+                }
+              }
+            },
+            {
+              "name": "browser.js",
+              "value": 2,
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 49,
+                  "deletions": 19,
+                  "count": 2
+                }
+              }
+            },
+            {
+              "name": "build.js",
+              "value": 2,
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 49,
+                  "deletions": 19,
+                  "count": 2
+                }
+              }
+            },
+            {
+              "name": "package.json",
+              "value": 2,
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 2,
+                  "deletions": 2,
+                  "count": 2
+                }
+              }
+            },
+            {
+              "name": "index.js",
+              "value": 1,
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 4,
+                  "deletions": 2,
+                  "count": 1
+                }
+              }
+            }
+          ],
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 107,
+              "deletions": 45,
+              "count": 8
+            }
+          }
+        }
+      ],
+      "authors": {
+        "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+          "insertions": 492,
+          "deletions": 262,
+          "count": 18
+        }
+      }
+    },
+    {
+      "name": "src",
+      "children": [
+        {
+          "name": "shared/util.js",
+          "value": 3
+        },
+        {
+          "name": "compiler",
+          "children": [
+            {
+              "name": "codeframe.js",
+              "value": 1,
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 7,
+                  "deletions": 5,
+                  "count": 1
+                }
+              }
+            },
+            {
+              "name": "codegen",
+              "children": [
+                {
+                  "name": "index.js",
+                  "value": 1,
+                  "authors": {
+                    "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                      "insertions": 29,
+                      "deletions": 6,
+                      "count": 1
+                    }
+                  }
+                },
+                {
+                  "name": "events.js",
+                  "value": 1,
+                  "authors": {
+                    "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                      "insertions": 1,
+                      "deletions": 1,
+                      "count": 1
+                    }
+                  }
+                }
+              ],
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 30,
+                  "deletions": 7,
+                  "count": 2
+                }
+              }
+            },
+            {
+              "name": "parser",
+              "children": [
+                {
+                  "name": "html-parser.js",
+                  "value": 1,
+                  "authors": {
+                    "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                      "insertions": 3,
+                      "deletions": 3,
+                      "count": 1
+                    }
+                  }
+                },
+                {
+                  "name": "index.js",
+                  "value": 2,
+                  "authors": {
+                    "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                      "insertions": 4,
+                      "deletions": 3,
+                      "count": 2
+                    }
+                  }
+                }
+              ],
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 7,
+                  "deletions": 6,
+                  "count": 3
+                }
+              }
+            }
+          ],
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 44,
+              "deletions": 18,
+              "count": 6
+            }
+          }
+        },
+        {
+          "name": "core",
+          "children": [
+            {
+              "name": "instance",
+              "children": [
+                {
+                  "name": "lifecycle.js",
+                  "value": 1,
+                  "authors": {
+                    "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                      "insertions": 5,
+                      "deletions": 2,
+                      "count": 1
+                    }
+                  }
+                },
+                {
+                  "name": "render-helpers",
+                  "children": [
+                    {
+                      "name": "bind-object-props.js",
+                      "value": 1,
+                      "authors": {
+                        "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                          "insertions": 5,
+                          "deletions": 3,
+                          "count": 1
+                        }
+                      }
+                    },
+                    {
+                      "name": "resolve-scoped-slots.js",
+                      "value": 1,
+                      "authors": {
+                        "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                          "insertions": 7,
+                          "deletions": 2,
+                          "count": 1
+                        }
+                      }
+                    }
+                  ],
+                  "authors": {
+                    "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                      "insertions": 12,
+                      "deletions": 5,
+                      "count": 2
+                    }
+                  }
+                }
+              ],
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 17,
+                  "deletions": 7,
+                  "count": 3
+                }
+              }
+            },
+            {
+              "name": "observer/scheduler.js",
+              "value": 2
+            },
+            {
+              "name": "util",
+              "children": [
+                {
+                  "name": "error.js",
+                  "value": 2,
+                  "authors": {
+                    "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                      "insertions": 7,
+                      "deletions": 4,
+                      "count": 2
+                    }
+                  }
+                },
+                {
+                  "name": "lang.js",
+                  "value": 1,
+                  "authors": {
+                    "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                      "insertions": 2,
+                      "deletions": 2,
+                      "count": 1
+                    }
+                  }
+                },
+                {
+                  "name": "options.js",
+                  "value": 1,
+                  "authors": {
+                    "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                      "insertions": 2,
+                      "deletions": 2,
+                      "count": 1
+                    }
+                  }
+                }
+              ],
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 11,
+                  "deletions": 8,
+                  "count": 4
+                }
+              }
+            },
+            {
+              "name": "vdom/helpers",
+              "children": [
+                {
+                  "name": "normalize-scoped-slots.js",
+                  "value": 2,
+                  "authors": {
+                    "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                      "insertions": 15,
+                      "deletions": 6,
+                      "count": 2
+                    }
+                  }
+                },
+                {
+                  "name": "resolve-async-component.js",
+                  "value": 2,
+                  "authors": {
+                    "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                      "insertions": 27,
+                      "deletions": 10,
+                      "count": 2
+                    }
+                  }
+                }
+              ],
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 42,
+                  "deletions": 16,
+                  "count": 4
+                }
+              }
+            }
+          ],
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 70,
+              "deletions": 31,
+              "count": 11
+            }
+          }
+        },
+        {
+          "name": "platforms",
+          "children": [
+            {
+              "name": "dom-props.js",
+              "value": 2,
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 15,
+                  "deletions": 12,
+                  "count": 2
+                }
+              }
+            },
+            {
+              "name": "events.js",
+              "value": 1,
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 4,
+                  "deletions": 2,
+                  "count": 1
+                }
+              }
+            },
+            {
+              "name": "transition.js",
+              "value": 1,
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 1,
+                  "deletions": 1,
+                  "count": 1
+                }
+              }
+            }
+          ],
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 20,
+              "deletions": 15,
+              "count": 4
+            }
+          }
+        },
+        {
+          "name": "server",
+          "children": [
+            {
+              "name": "write.js",
+              "value": 1,
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 1,
+                  "deletions": 1,
+                  "count": 1
+                }
+              }
+            },
+            {
+              "name": "template-renderer/create-async-file-mapper.js",
+              "value": 1
+            }
+          ],
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 1,
+              "deletions": 1,
+              "count": 1
+            }
+          }
+        }
+      ],
+      "authors": {
+        "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+          "insertions": 135,
+          "deletions": 65,
+          "count": 22
+        }
+      }
+    },
+    {
+      "name": "test",
+      "children": [
+        {
+          "name": "unit",
+          "children": [
+            {
+              "name": "util/loose-equal.spec.js",
+              "value": 3
+            },
+            {
+              "name": "features",
+              "children": [
+                {
+                  "name": "component",
+                  "children": [
+                    {
+                      "name": "component-scoped-slot.spec.js",
+                      "value": 2,
+                      "authors": {
+                        "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                          "insertions": 112,
+                          "deletions": 0,
+                          "count": 2
+                        }
+                      }
+                    },
+                    {
+                      "name": "component-async.spec.js",
+                      "value": 1,
+                      "authors": {
+                        "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                          "insertions": 64,
+                          "deletions": 0,
+                          "count": 1
+                        }
+                      }
+                    }
+                  ],
+                  "authors": {
+                    "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                      "insertions": 176,
+                      "deletions": 0,
+                      "count": 3
+                    }
+                  }
+                },
+                {
+                  "name": "directives/bind.spec.js",
+                  "value": 1
+                },
+                {
+                  "name": "instance/methods-events.spec.js",
+                  "value": 1
+                },
+                {
+                  "name": "options/directives.spec.js",
+                  "value": 1
+                },
+                {
+                  "name": "transition/transition.spec.js",
+                  "value": 1
+                }
+              ],
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 176,
+                  "deletions": 0,
+                  "count": 3
+                }
+              }
+            },
+            {
+              "name": "modules",
+              "children": [
+                {
+                  "name": "compiler",
+                  "children": [
+                    {
+                      "name": "codegen.spec.js",
+                      "value": 2,
+                      "authors": {
+                        "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                          "insertions": 9,
+                          "deletions": 4,
+                          "count": 2
+                        }
+                      }
+                    },
+                    {
+                      "name": "compiler-options.spec.js",
+                      "value": 1,
+                      "authors": {
+                        "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                          "insertions": 5,
+                          "deletions": 0,
+                          "count": 1
+                        }
+                      }
+                    },
+                    {
+                      "name": "parser.spec.js",
+                      "value": 1,
+                      "authors": {
+                        "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                          "insertions": 44,
+                          "deletions": 5,
+                          "count": 1
+                        }
+                      }
+                    }
+                  ],
+                  "authors": {
+                    "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                      "insertions": 58,
+                      "deletions": 9,
+                      "count": 4
+                    }
+                  }
+                },
+                {
+                  "name": "util",
+                  "children": [
+                    {
+                      "name": "invoke-with-error-handling.spec.js",
+                      "value": 1,
+                      "authors": {
+                        "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                          "insertions": 21,
+                          "deletions": 0,
+                          "count": 1
+                        }
+                      }
+                    },
+                    {
+                      "name": "{invoke-with-error-handling.spec.js => error.spec.js}",
+                      "value": 1,
+                      "authors": {
+                        "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                          "insertions": 5,
+                          "deletions": 2,
+                          "count": 1
+                        }
+                      }
+                    }
+                  ],
+                  "authors": {
+                    "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                      "insertions": 26,
+                      "deletions": 2,
+                      "count": 2
+                    }
+                  }
+                },
+                {
+                  "name": "vdom",
+                  "children": [
+                    {
+                      "name": "create-component.spec.js",
+                      "value": 1,
+                      "authors": {
+                        "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                          "insertions": 6,
+                          "deletions": 0,
+                          "count": 1
+                        }
+                      }
+                    },
+                    {
+                      "name": "patch/edge-cases.spec.js",
+                      "value": 1
+                    }
+                  ],
+                  "authors": {
+                    "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                      "insertions": 6,
+                      "deletions": 0,
+                      "count": 1
+                    }
+                  }
+                },
+                {
+                  "name": "observer/observer.spec.js",
+                  "value": 1
+                }
+              ],
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 90,
+                  "deletions": 11,
+                  "count": 7
+                }
+              }
+            }
+          ],
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 266,
+              "deletions": 11,
+              "count": 10
+            }
+          }
+        },
+        {
+          "name": "ssr/ssr-string.spec.js",
+          "value": 2
+        }
+      ],
+      "authors": {
+        "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+          "insertions": 266,
+          "deletions": 11,
+          "count": 10
+        }
+      }
+    },
+    {
+      "name": ".github",
+      "children": [
+        {
+          "name": "CODE_OF_CONDUCT.md",
+          "value": 1,
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 1,
+              "deletions": 1,
+              "count": 1
+            }
+          }
+        },
+        {
+          "name": "COMMIT_CONVENTION.md",
+          "value": 1,
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 5,
+              "deletions": 5,
+              "count": 1
+            }
+          }
+        },
+        {
+          "name": "CONTRIBUTING.md",
+          "value": 1,
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 5,
+              "deletions": 5,
+              "count": 1
+            }
+          }
+        }
+      ],
+      "authors": {
+        "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+          "insertions": 11,
+          "deletions": 11,
+          "count": 3
+        }
+      }
+    },
+    {
+      "name": "BACKERS.md",
+      "value": 2,
+      "authors": {
+        "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+          "insertions": 77,
+          "deletions": 83,
+          "count": 2
+        }
+      }
+    },
+    {
+      "name": "README.md",
+      "value": 2,
+      "authors": {
+        "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+          "insertions": 24,
+          "deletions": 19,
+          "count": 2
+        }
+      }
+    },
+    {
+      "name": "benchmarks",
+      "children": [
+        {
+          "name": "ssr/README.md",
+          "value": 1
+        },
+        {
+          "name": "uptime/index.html",
+          "value": 1
+        }
+      ],
+      "authors": {}
+    },
+    {
+      "name": "dist",
+      "children": [
+        {
+          "name": "README.md",
+          "value": 1,
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 1,
+              "deletions": 1,
+              "count": 1
+            }
+          }
+        },
+        {
+          "name": "vue.common.dev.js",
+          "value": 2,
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 179,
+              "deletions": 90,
+              "count": 2
+            }
+          }
+        },
+        {
+          "name": "vue.common.prod.js",
+          "value": 2,
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 4,
+              "deletions": 4,
+              "count": 2
+            }
+          }
+        },
+        {
+          "name": "vue.esm.browser.js",
+          "value": 2,
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 177,
+              "deletions": 86,
+              "count": 2
+            }
+          }
+        },
+        {
+          "name": "vue.esm.browser.min.js",
+          "value": 2,
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 4,
+              "deletions": 4,
+              "count": 2
+            }
+          }
+        },
+        {
+          "name": "vue.esm.js",
+          "value": 2,
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 179,
+              "deletions": 90,
+              "count": 2
+            }
+          }
+        },
+        {
+          "name": "vue.js",
+          "value": 2,
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 179,
+              "deletions": 90,
+              "count": 2
+            }
+          }
+        },
+        {
+          "name": "vue.min.js",
+          "value": 2,
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 4,
+              "deletions": 4,
+              "count": 2
+            }
+          }
+        },
+        {
+          "name": "vue.runtime.common.dev.js",
+          "value": 2,
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 131,
+              "deletions": 72,
+              "count": 2
+            }
+          }
+        },
+        {
+          "name": "vue.runtime.common.prod.js",
+          "value": 2,
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 4,
+              "deletions": 4,
+              "count": 2
+            }
+          }
+        },
+        {
+          "name": "vue.runtime.esm.js",
+          "value": 2,
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 131,
+              "deletions": 72,
+              "count": 2
+            }
+          }
+        },
+        {
+          "name": "vue.runtime.js",
+          "value": 2,
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 131,
+              "deletions": 72,
+              "count": 2
+            }
+          }
+        },
+        {
+          "name": "vue.runtime.min.js",
+          "value": 2,
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 4,
+              "deletions": 4,
+              "count": 2
+            }
+          }
+        }
+      ],
+      "authors": {
+        "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+          "insertions": 1128,
+          "deletions": 593,
+          "count": 25
+        }
+      }
+    },
+    {
+      "name": "package.json",
+      "value": 2,
+      "authors": {
+        "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+          "insertions": 2,
+          "deletions": 2,
+          "count": 2
+        }
+      }
+    },
+    {
+      "name": "types",
+      "children": [
+        {
+          "name": "options.d.ts",
+          "value": 2,
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 3,
+              "deletions": 3,
+              "count": 2
+            }
+          }
+        },
+        {
+          "name": "test",
+          "children": [
+            {
+              "name": "options-test.ts",
+              "value": 2,
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 19,
+                  "deletions": 0,
+                  "count": 2
+                }
+              }
+            },
+            {
+              "name": "vue-test.ts",
+              "value": 2,
+              "authors": {
+                "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                  "insertions": 35,
+                  "deletions": 0,
+                  "count": 2
+                }
+              }
+            }
+          ],
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 54,
+              "deletions": 0,
+              "count": 4
+            }
+          }
+        },
+        {
+          "name": "vnode.d.ts",
+          "value": 2,
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 6,
+              "deletions": 2,
+              "count": 2
+            }
+          }
+        },
+        {
+          "name": "vue.d.ts",
+          "value": 1,
+          "authors": {
+            "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+              "insertions": 3,
+              "deletions": 3,
+              "count": 1
+            }
+          }
+        }
+      ],
+      "authors": {
+        "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+          "insertions": 66,
+          "deletions": 8,
+          "count": 9
+        }
+      }
+    },
+    {
+      "name": "examples/modal/index.html",
+      "value": 1
+    },
+    {
+      "name": "flow/vnode.js",
+      "value": 1
+    },
+    {
+      "name": "scripts/alias.js",
+      "value": 1
+    }
+  ],
+  "authors": {
+    "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+      "insertions": 2201,
+      "deletions": 1054,
+      "count": 93
+    }
+  }
+}

--- a/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
+++ b/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
@@ -1,5 +1,135 @@
+import * as d3 from "d3";
+import type { HierarchyRectangularNode } from "d3";
+import type { RefObject } from "react";
+import { useEffect, useRef, useState } from "react";
+
+const FILE_PATH = "/fileChanges.json";
+const WIDTH = 600;
+const HEIGHT = 400;
+const FONT_SIZE = 10;
+const MAX_DEPTH = 4;
+const LABEL_VISIBLE_HEIGHT = 16;
+const COLOR_CODE = {
+  dir: "#ffcc80",
+  file: "#ffe082",
+};
+
+type TFileData = {
+  name: string; // Name of file/directory.
+  value?: number; // Count of changed lines.
+  authors: Record<
+    string,
+    {
+      insertion: number;
+      deletions: number;
+      count: number;
+    }
+  >;
+  children: TFileData[];
+};
+
+const partition = (data: TFileData) => {
+  const root = d3
+    .hierarchy(data)
+    // Initialize data - mutating before draw file icicle tree
+    // https://github.com/d3/d3-hierarchy/blob/v3.1.2/README.md#hierarchy
+    // https://observablehq.com/@d3/visiting-a-d3-hierarchy#count
+    .sum((d) => d?.value ?? 0)
+    .sort((a, b) => b.height - a.height || (b.value ?? 0) - (a.value ?? 0));
+  return d3
+    .partition<TFileData>()
+    .size([HEIGHT, ((root.height + 1) * WIDTH) / MAX_DEPTH])(root);
+};
+
+const labelVisible = (d: HierarchyRectangularNode<TFileData>) =>
+  d.y1 <= WIDTH && d.y0 >= 0 && d.x1 - d.x0 > LABEL_VISIBLE_HEIGHT;
+
+const rectHeight = (d: HierarchyRectangularNode<TFileData>) =>
+  d.x1 - d.x0 - Math.min(1, (d.x1 - d.x0) / 2);
+
+// Refer https://observablehq.com/@d3/zoomable-icicle
+const drawIcicleTree = async (
+  $target: RefObject<SVGSVGElement>,
+  data: TFileData
+) => {
+  const root = partition(data);
+
+  const svg = d3
+    .select($target.current)
+    .attr("viewBox", [0, 0, WIDTH, HEIGHT])
+    .style("font", `${FONT_SIZE}px sans-serif`);
+
+  // Position each partitions
+  const cell = svg
+    .selectAll("g")
+    .data(root.descendants())
+    .join("g")
+    // Hide root node
+    .attr("transform", (d) => `translate(${d.y0},${d.x0})`);
+
+  // Draw rect of partition
+  cell
+    .append("rect")
+    .attr("width", (d) => d.y1 - d.y0 - 1)
+    .attr("height", (d) => rectHeight(d))
+    // directory don't have value field
+    .style(
+      "fill",
+      (d) => COLOR_CODE[d.data.value !== undefined ? "file" : "dir"]
+    )
+    .style("cursor", "pointer");
+
+  // Append labels
+  const text = cell
+    .append("text")
+    .style("user-select", "none")
+    .attr("pointer-events", "none")
+    .attr("x", 4)
+    .attr("y", 13)
+    .attr("fill-opacity", (d) => +labelVisible(d));
+
+  text.append("tspan").text((d) => d.data.name);
+
+  text
+    .append("tspan")
+    .attr("fill-opacity", (d) => +labelVisible(d) * 0.7)
+    .text((d) => ` ${d.value?.toLocaleString()}`);
+};
+
+const destroyIcicleTree = ($target: RefObject<SVGSVGElement>) => {
+  d3.select($target.current).selectAll("svg").remove();
+};
+
 const FileIcicleSummary = () => {
-  return <div>FileIcicleSummary</div>;
+  const [data, setData] = useState<TFileData>();
+  const $summary = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    const getFileData = async () => {
+      const response = await d3.json<TFileData>(FILE_PATH);
+      setData(response);
+    };
+
+    getFileData();
+  }, []);
+
+  useEffect(() => {
+    if (data) {
+      drawIcicleTree($summary, data);
+    }
+
+    // cleanup
+    return () => {
+      destroyIcicleTree($summary);
+    };
+  }, [data]);
+
+  return (
+    <div>
+      FileIcicleSummary
+      <svg ref={$summary} />
+    </div>
+  );
 };
 
 export default FileIcicleSummary;

--- a/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
+++ b/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
@@ -8,6 +8,7 @@ const WIDTH = 600;
 const HEIGHT = 400;
 const FONT_SIZE = 10;
 const MAX_DEPTH = 4;
+const SINGLE_RECT_WIDTH = WIDTH / MAX_DEPTH;
 const LABEL_VISIBLE_HEIGHT = 16;
 const COLOR_CODE = {
   dir: "#ffcc80",
@@ -66,7 +67,7 @@ const drawIcicleTree = async (
     .data(root.descendants())
     .join("g")
     // Hide root node
-    .attr("transform", (d) => `translate(${d.y0},${d.x0})`);
+    .attr("transform", (d) => `translate(${d.y0 - SINGLE_RECT_WIDTH},${d.x0})`);
 
   // Draw rect of partition
   const rect = cell
@@ -106,13 +107,14 @@ const drawIcicleTree = async (
     }
 
     focus = targetNode;
+    const isRootFocused = focus.depth === 0;
 
     root.each((d) => {
       positionMap.set(d, {
         x0: ((d.x0 - targetNode.x0) / (targetNode.x1 - targetNode.x0)) * HEIGHT,
         x1: ((d.x1 - targetNode.x0) / (targetNode.x1 - targetNode.x0)) * HEIGHT,
-        y0: d.y0 - targetNode.y0,
-        y1: d.y1 - targetNode.y0,
+        y0: d.y0 - targetNode.y0 - (isRootFocused ? SINGLE_RECT_WIDTH : 0),
+        y1: d.y1 - targetNode.y0 - (isRootFocused ? SINGLE_RECT_WIDTH : 0),
       });
     });
 

--- a/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
+++ b/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
@@ -1,0 +1,5 @@
+const FileIcicleSummary = () => {
+  return <div>FileIcicleSummary</div>;
+};
+
+export default FileIcicleSummary;

--- a/packages/view/src/components/Statistics/FileIcicleSummary/index.ts
+++ b/packages/view/src/components/Statistics/FileIcicleSummary/index.ts
@@ -1,0 +1,1 @@
+export { default as FileIcicleSummary } from "./FileIcicleSummary";

--- a/packages/view/src/components/Statistics/Statistics.tsx
+++ b/packages/view/src/components/Statistics/Statistics.tsx
@@ -1,12 +1,14 @@
 import type { GlobalProps } from "types";
 
 import { AuthorBarChart } from "./AuthorBarChart";
+import { FileIcicleSummary } from "./FileIcicleSummary";
 import "./Statistics.scss";
 
 const Statistics = ({ data }: GlobalProps) => {
   return (
     <div className="statistics">
       <AuthorBarChart data={data} />
+      <FileIcicleSummary />
     </div>
   );
 };


### PR DESCRIPTION
# https://github.com/githru/githru-vscode-ext/issues/37 [view] Statistics - FileIcicleSummary 구현

FileIcicleSummary는 커밋 클러스터별 변경된 파일을 icicle tree 형식으로 제공하는 컴포넌트입니다.

## Description
### chore(view): copy fake data from githru FileIcicleSummary.tsx

데이터 가공쪽은 다른 컴포넌트 작업되면 진행하는것이 효율적일거서 같아서 미리 작업하지는 않았고 임시 데이터를 fileChanges.json이라는 파일로 추가하여 사용했습니다.

fileChanges.json은 githuru - FileIcicleSummary.js >line 57의 fileAnalyzer.getFileStructure() 결과값을 복사한 값입니다. [코드 링크](https://github.com/githru/githru/blob/b479984a3081e4e6e389179b86a6997db984d5a3/frontend/src/components/FileIcicleSummary.js#L57)
 
### chore(view): create FileIcicleSummary component

코드가 들어갈 파일을 생성했습니다.
파일 위치는 같은 Statistics 컴포넌트인 AuthorBarChart 위치와 동일하게 Statistics 하위에 만들었습니다.

### feature(view): draw icicle tree in <FileIcicleSummary/>

데이터 기반으로 IcicleTree를 그립니다.
https://observablehq.com/@d3/zoomable-icicle 를 참고했습니다.
width, height는 각각 600, 400으로 임의로 정했습니다.

차트 그리는 부분은 githru-tutorial에서 진행한 내용과 크게 다르지 않아서 영어 주석이 부족하신 경우 https://github.com/githru/githru-feature-practices/pull/18#issue-1315908433 PR 내용도 함께 봐주시면 좋을것 같습니다.


### feature(view): make <FileIcicleSummary/> to be zoomable
FileIcicleSummary의 인터랙션을 구현했습니다.
각 노드를 클릭했을때 해당 노드가 포커싱되고, 포커싱된 노드를 한번더 클릭하면 상위 노드로 포커싱됩니다.
이 부분 깔끔하게 개발하는 방법을 고민하다가 PR이 늦어졌네요 

로직자체는 https://observablehq.com/@d3/zoomable-icicle 의 function clicked를 참고했습니다.

해당 예제에서는 각 node에 target이라는 필드를 추가해 변경된 위치정보를 저장하여 node를 mutable하게 사용하고 있습니다.
```tsx
    root.each(d => d.target = {
      x0: (d.x0 - p.x0) / (p.x1 - p.x0) * height,
      x1: (d.x1 - p.x0) / (p.x1 - p.x0) * height,
      y0: d.y0 - p.y0,
      y1: d.y1 - p.y0
    });
```

각 node는 HierarchyRectangularNode 타입으로 추론되어 여기에 필드를 임의로 추가할경우 타입 오류가 발생하기도하고.. 해당 값은 인터랙션 발생시에만 사용하게 되기때문에 다른 방법을 찾아야했습니다.

positionMap이라는 WeakMap을 만들어 해당 노드를 key, 변경된 좌표값을 value로 설정하고 cell, rect, text, tspan쪽 값 변경할때는 positionMap의 value를 사용하도록 수정했습니다.

이렇게 변경하면 하위 노드들을 변경하지않고도 인터랙션을 구현할 수 있습니다.


### feature(view): hide root node of partitions - FileIcicleSummary
githru에도 적용이 되어있는 내용으로 root node(레포지토리 최상위 디렉토리)는 노출하지 않도록 개발했습니다.

첫번째 변경사항인 transform쪽은 초기렌더링 x좌표를 설정하는 부분입니다.
root node가 보이지 않도록 SINGLE_RECT_WIDTH(각 노드 너비)만큼 제해줍니다.

두번째 변경사항은 인터랙션 발생 부분입니다. 위에도 설명했듯이 포커싱된 노드를 한번더 클릭하면 상위 노드로 포커싱되는 기능이 있습니다.

이부분때문에 depth가 2인 노드들을 한번더 클릭하면 root node로 포커싱이 되는데 이를 막기 위해서 isRootFocused가 true인 경우 x좌표를 SINGLE_RECT_WIDTH(각 노드 너비)만큼 제해서 root node가 보이지 않도록 개발했습니다.


---

실제 구현 화면
<img width="507" alt="image" src="https://user-images.githubusercontent.com/41318449/188762463-19d081f8-d6cb-4f98-ab18-18dc835255e0.png">


참고한 githru 화면 https://githru.github.io/vuejs-demo/
https://github.com/githru/githru/blob/b479984a3081e4e6e389179b86a6997db984d5a3/frontend/src/components/FileIcicleSummary.js#L8
<img width="421" alt="image" src="https://user-images.githubusercontent.com/41318449/188762434-9f8aa7d0-098f-4cd6-a084-2c3e520bcb7b.png">
