### PR TITLE
feat(view): add ClusterGraph Component v2 in VerticalClusterGraph

### DIFF
--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.const.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.const.ts
@@ -1,4 +1,4 @@
 export const NODE_GAP = 20;
 export const COMMIT_HEIGHT = 50;
-export const GRAPH_WIDTH = 20;
-export const SVG_WIDTH = 24;
+export const GRAPH_WIDTH = 100;
+export const SVG_WIDTH = GRAPH_WIDTH + 4;

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.const.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.const.ts
@@ -2,3 +2,9 @@ export const NODE_GAP = 20;
 export const COMMIT_HEIGHT = 50;
 export const GRAPH_WIDTH = 100;
 export const SVG_WIDTH = GRAPH_WIDTH + 4;
+export const SVG_MARGIN = {
+  right: 2,
+  left: 2,
+  top: 10,
+  bottom: 10,
+};

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
@@ -1,15 +1,13 @@
 .cluster-container {
   .cluster-box {
-    rx: 10;
-    ry: 10;
+    rx: 5;
     stroke-width: 1;
     stroke: rgb(13, 71, 161, 0.4);
     fill: transparent;
   }
 
   .degree-box {
-    rx: 10;
-    ry: 10;
+    rx: 5;
     fill: rgb(13, 71, 161, 0.4);
   }
 

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
@@ -1,13 +1,23 @@
-.cluster-graph-container {
-  rx: 10;
-  ry: 10;
-  stroke-width: 1;
-  stroke: black;
-  fill: transparent;
-}
+.cluster-container {
+  .cluster-box {
+    rx: 10;
+    ry: 10;
+    stroke-width: 1;
+    stroke: rgb(13, 71, 161, 0.4);
+    fill: transparent;
+  }
 
-.degree-box {
-  rx: 10;
-  ry: 10;
-  fill: rgba(0, 0, 0, 0.2);
+  .degree-box {
+    rx: 10;
+    ry: 10;
+    fill: rgb(13, 71, 161, 0.4);
+  }
+
+  &:hover {
+    .cluster-box {
+      stroke-width: 3;
+    }
+  }
+
+  cursor: pointer;
 }

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
@@ -1,0 +1,13 @@
+.cluster-graph-container {
+  rx: 10;
+  ry: 10;
+  stroke-width: 1;
+  stroke: black;
+  fill: transparent;
+}
+
+.degree-box {
+  rx: 10;
+  ry: 10;
+  fill: rgba(0, 0, 0, 0.2);
+}

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -1,4 +1,6 @@
+import type { RefObject } from "react";
 import { useEffect, useRef } from "react";
+import type { Selection } from "d3";
 import { select } from "d3";
 
 import type { ClusterNode } from "types";
@@ -14,44 +16,72 @@ import {
   SVG_WIDTH,
 } from "./ClusterGraph.const";
 
+const drawClusterBox = (
+  container: Selection<SVGGElement, number, SVGSVGElement | null, unknown>
+) => {
+  container
+    .append("rect")
+    .attr("class", "cluster-box")
+    .attr("width", GRAPH_WIDTH)
+    .attr("height", COMMIT_HEIGHT)
+    .attr("x", SVG_MARGIN.left)
+    .attr("y", (_, i) => SVG_MARGIN.bottom + i * (NODE_GAP + COMMIT_HEIGHT));
+};
+
+const drawDegreeBox = (
+  container: Selection<SVGGElement, number, SVGSVGElement | null, unknown>,
+  maxOfClusterSize: number
+) => {
+  container
+    .append("rect")
+    .attr("class", "degree-box")
+    .attr("width", (d) => GRAPH_WIDTH * (d / maxOfClusterSize))
+    .attr("height", COMMIT_HEIGHT)
+    .attr(
+      "x",
+      (d) => (GRAPH_WIDTH * (1 - d / maxOfClusterSize)) / 2 + SVG_MARGIN.left
+    )
+    .attr("y", (_, i) => SVG_MARGIN.bottom + i * (NODE_GAP + COMMIT_HEIGHT));
+};
+
+const drawClusterGraph = (
+  svgRef: RefObject<SVGSVGElement>,
+  data: ClusterNode[]
+) => {
+  const clusterSizes = getClusterSizes(data);
+  const maxOfClusterSize = Math.max(...clusterSizes);
+
+  const group = select(svgRef.current)
+    .selectAll("g")
+    .data(clusterSizes)
+    .enter()
+    .append("g")
+    .attr("class", "cluster-container");
+
+  drawClusterBox(group);
+  drawDegreeBox(group, maxOfClusterSize);
+};
+
+const destroyClusterGraph = (target: RefObject<SVGElement>) => {
+  select(target.current).selectAll("svg").remove();
+};
+
 type ClusterGraphProps = {
   data: ClusterNode[];
 };
 
 const ClusterGraph = ({ data }: ClusterGraphProps) => {
-  const svgRef = useRef(null);
-
+  const svgRef = useRef<SVGSVGElement>(null);
   const clusterSizes = getClusterSizes(data);
   const graphHeight = getGraphHeight(clusterSizes);
-  const maxOfClusterSize = Math.max(...clusterSizes);
 
   useEffect(() => {
-    const group = select(svgRef.current)
-      .selectAll("g")
-      .data(clusterSizes)
-      .enter()
-      .append("g")
-      .attr("class", "cluster-container");
+    drawClusterGraph(svgRef, data);
 
-    group
-      .append("rect")
-      .attr("class", "cluster-box")
-      .attr("width", GRAPH_WIDTH)
-      .attr("height", COMMIT_HEIGHT)
-      .attr("x", SVG_MARGIN.left)
-      .attr("y", (_, i) => SVG_MARGIN.bottom + i * (NODE_GAP + COMMIT_HEIGHT));
-
-    group
-      .append("rect")
-      .attr("class", "degree-box")
-      .attr("width", (d) => GRAPH_WIDTH * (d / maxOfClusterSize))
-      .attr("height", COMMIT_HEIGHT)
-      .attr(
-        "x",
-        (d) => (GRAPH_WIDTH * (1 - d / maxOfClusterSize)) / 2 + SVG_MARGIN.left
-      )
-      .attr("y", (_, i) => SVG_MARGIN.bottom + i * (NODE_GAP + COMMIT_HEIGHT));
-  }, [clusterSizes, maxOfClusterSize]);
+    return () => {
+      destroyClusterGraph(svgRef);
+    };
+  }, [data]);
 
   return <svg ref={svgRef} width={SVG_WIDTH} height={graphHeight} />;
 };

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -26,21 +26,22 @@ const ClusterGraph = ({ data }: ClusterGraphProps) => {
   const maxOfClusterSize = Math.max(...clusterSizes);
 
   useEffect(() => {
-    select(svgRef.current)
-      .selectAll(".cluster-graph-container")
+    const group = select(svgRef.current)
+      .selectAll("g")
       .data(clusterSizes)
       .enter()
+      .append("g")
+      .attr("class", "cluster-container");
+
+    group
       .append("rect")
-      .attr("class", "cluster-graph-container")
+      .attr("class", "cluster-box")
       .attr("width", GRAPH_WIDTH)
       .attr("height", COMMIT_HEIGHT)
       .attr("x", SVG_MARGIN.left)
       .attr("y", (_, i) => SVG_MARGIN.bottom + i * (NODE_GAP + COMMIT_HEIGHT));
 
-    select(svgRef.current)
-      .selectAll(".degree-box")
-      .data(clusterSizes)
-      .enter()
+    group
       .append("rect")
       .attr("class", "degree-box")
       .attr("width", (d) => GRAPH_WIDTH * (d / maxOfClusterSize))

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -46,17 +46,19 @@ const drawDegreeBox = (
 
 const drawClusterGraph = (
   svgRef: RefObject<SVGSVGElement>,
-  data: ClusterNode[]
+  data: ClusterNode[],
+  onClickCluster: (this: SVGGElement, event: any, d: number) => void
 ) => {
   const clusterSizes = getClusterSizes(data);
   const maxOfClusterSize = Math.max(...clusterSizes);
 
   const group = select(svgRef.current)
-    .selectAll("g")
+    .selectAll(".cluster-container")
     .data(clusterSizes)
     .enter()
     .append("g")
-    .attr("class", "cluster-container");
+    .attr("class", "cluster-container")
+    .on("click", onClickCluster);
 
   drawClusterBox(group);
   drawDegreeBox(group, maxOfClusterSize);
@@ -75,8 +77,13 @@ const ClusterGraph = ({ data }: ClusterGraphProps) => {
   const clusterSizes = getClusterSizes(data);
   const graphHeight = getGraphHeight(clusterSizes);
 
+  const handleClickCluster = () => {
+    // for solving lint error (@typescript-eslint/no-empty-function)
+    console.log("cluster click");
+  };
+
   useEffect(() => {
-    drawClusterGraph(svgRef, data);
+    drawClusterGraph(svgRef, data, handleClickCluster);
 
     return () => {
       destroyClusterGraph(svgRef);

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -3,11 +3,14 @@ import { select } from "d3";
 
 import type { ClusterNode } from "types";
 
+import "./ClusterGraph.scss";
+
 import { getGraphHeight, getClusterSizes } from "./ClusterGraph.util";
 import {
   COMMIT_HEIGHT,
   GRAPH_WIDTH,
   NODE_GAP,
+  SVG_MARGIN,
   SVG_WIDTH,
 } from "./ClusterGraph.const";
 
@@ -31,13 +34,8 @@ const ClusterGraph = ({ data }: ClusterGraphProps) => {
       .attr("class", "cluster-graph-container")
       .attr("width", GRAPH_WIDTH)
       .attr("height", COMMIT_HEIGHT)
-      .attr("x", 2)
-      .attr("y", (_, i) => 10 + i * (NODE_GAP + COMMIT_HEIGHT))
-      .attr("rx", 10)
-      .attr("ry", 10)
-      .attr("stroke-width", 1)
-      .attr("stroke", "black")
-      .attr("fill", "transparent");
+      .attr("x", SVG_MARGIN.left)
+      .attr("y", (_, i) => SVG_MARGIN.bottom + i * (NODE_GAP + COMMIT_HEIGHT));
 
     select(svgRef.current)
       .selectAll(".degree-box")
@@ -47,11 +45,11 @@ const ClusterGraph = ({ data }: ClusterGraphProps) => {
       .attr("class", "degree-box")
       .attr("width", (d) => GRAPH_WIDTH * (d / maxOfClusterSize))
       .attr("height", COMMIT_HEIGHT)
-      .attr("x", (d) => (GRAPH_WIDTH * (1 - d / maxOfClusterSize)) / 2 + 2)
-      .attr("y", (_, i) => 10 + i * (NODE_GAP + COMMIT_HEIGHT))
-      .attr("rx", 10)
-      .attr("ry", 10)
-      .attr("fill", "rgba(0,0,0,0.2)");
+      .attr(
+        "x",
+        (d) => (GRAPH_WIDTH * (1 - d / maxOfClusterSize)) / 2 + SVG_MARGIN.left
+      )
+      .attr("y", (_, i) => SVG_MARGIN.bottom + i * (NODE_GAP + COMMIT_HEIGHT));
   }, [clusterSizes, maxOfClusterSize]);
 
   return <svg ref={svgRef} width={SVG_WIDTH} height={graphHeight} />;

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -31,22 +31,16 @@ const drawClusterBox = (
 const drawDegreeBox = (
   container: Selection<SVGGElement, number, SVGSVGElement | null, unknown>
 ) => {
-  const blockHeightScale = d3
-    .scaleLinear()
-    .range([0, GRAPH_WIDTH])
-    .domain([0, 10]);
+  const widthScale = d3.scaleLinear().range([0, GRAPH_WIDTH]).domain([0, 10]);
 
   container
     .append("rect")
     .attr("class", "degree-box")
-    .attr("width", (d) => blockHeightScale(Math.min(d, 10)))
+    .attr("width", (d) => widthScale(Math.min(d, 10)))
     .attr("height", COMMIT_HEIGHT)
     .attr(
       "x",
-      (d) =>
-        SVG_MARGIN.left +
-        GRAPH_WIDTH / 2 -
-        blockHeightScale(Math.min(d, 10)) / 2
+      (d) => SVG_MARGIN.left + GRAPH_WIDTH / 2 - widthScale(Math.min(d, 10)) / 2
     )
     .attr("y", (_, i) => SVG_MARGIN.bottom + i * (NODE_GAP + COMMIT_HEIGHT));
 };
@@ -56,12 +50,10 @@ const drawClusterGraph = (
   data: ClusterNode[],
   onClickCluster: (this: SVGGElement, event: any, d: number) => void
 ) => {
-  const clusterSizes = getClusterSizes(data);
-
   const group = d3
     .select(svgRef.current)
     .selectAll(".cluster-container")
-    .data(clusterSizes)
+    .data(getClusterSizes(data))
     .enter()
     .append("g")
     .attr("class", "cluster-container")

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -3,7 +3,7 @@ import { select } from "d3";
 
 import type { ClusterNode } from "types";
 
-import { getGraphHeight, getCommitCounts } from "./ClusterGraph.util";
+import { getGraphHeight, getClusterSizes } from "./ClusterGraph.util";
 import {
   COMMIT_HEIGHT,
   GRAPH_WIDTH,
@@ -18,31 +18,41 @@ type ClusterGraphProps = {
 const ClusterGraph = ({ data }: ClusterGraphProps) => {
   const svgRef = useRef(null);
 
-  const commitCounts = getCommitCounts(data);
-  const graphHeight = getGraphHeight(commitCounts);
+  const clusterSizes = getClusterSizes(data);
+  const graphHeight = getGraphHeight(clusterSizes);
+  const maxOfClusterSize = Math.max(...clusterSizes);
 
   useEffect(() => {
     select(svgRef.current)
-      .selectAll("rect")
-      .data(commitCounts)
+      .selectAll(".cluster-graph-container")
+      .data(clusterSizes)
       .enter()
       .append("rect")
-      .attr("width", () => GRAPH_WIDTH)
-      .attr("height", (d) => (d as number) * COMMIT_HEIGHT)
+      .attr("class", "cluster-graph-container")
+      .attr("width", GRAPH_WIDTH)
+      .attr("height", COMMIT_HEIGHT)
       .attr("x", 2)
-      .attr("y", (_, i, prev) =>
-        i > 0
-          ? prev[i - 1].y.baseVal.value +
-            prev[i - 1].height.baseVal.value +
-            NODE_GAP
-          : 10
-      )
+      .attr("y", (_, i) => 10 + i * (NODE_GAP + COMMIT_HEIGHT))
       .attr("rx", 10)
       .attr("ry", 10)
       .attr("stroke-width", 1)
       .attr("stroke", "black")
       .attr("fill", "transparent");
-  }, [commitCounts, data]);
+
+    select(svgRef.current)
+      .selectAll(".degree-box")
+      .data(clusterSizes)
+      .enter()
+      .append("rect")
+      .attr("class", "degree-box")
+      .attr("width", (d) => GRAPH_WIDTH * (d / maxOfClusterSize))
+      .attr("height", COMMIT_HEIGHT)
+      .attr("x", (d) => (GRAPH_WIDTH * (1 - d / maxOfClusterSize)) / 2 + 2)
+      .attr("y", (_, i) => 10 + i * (NODE_GAP + COMMIT_HEIGHT))
+      .attr("rx", 10)
+      .attr("ry", 10)
+      .attr("fill", "rgba(0,0,0,0.2)");
+  }, [clusterSizes, maxOfClusterSize]);
 
   return <svg ref={svgRef} width={SVG_WIDTH} height={graphHeight} />;
 };

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -1,6 +1,5 @@
-import type { RefObject } from "react";
+import type { MouseEvent, RefObject } from "react";
 import { useEffect, useRef } from "react";
-import type { Selection } from "d3";
 import * as d3 from "d3";
 
 import type { ClusterNode } from "types";
@@ -15,10 +14,9 @@ import {
   SVG_MARGIN,
   SVG_WIDTH,
 } from "./ClusterGraph.const";
+import type { SVGElementSelection } from "./ClusterGraph.type";
 
-const drawClusterBox = (
-  container: Selection<SVGGElement, number, SVGSVGElement | null, unknown>
-) => {
+const drawClusterBox = (container: SVGElementSelection<SVGGElement>) => {
   container
     .append("rect")
     .attr("class", "cluster-box")
@@ -28,9 +26,7 @@ const drawClusterBox = (
     .attr("y", (_, i) => SVG_MARGIN.bottom + i * (NODE_GAP + COMMIT_HEIGHT));
 };
 
-const drawDegreeBox = (
-  container: Selection<SVGGElement, number, SVGSVGElement | null, unknown>
-) => {
+const drawDegreeBox = (container: SVGElementSelection<SVGGElement>) => {
   const widthScale = d3.scaleLinear().range([0, GRAPH_WIDTH]).domain([0, 10]);
 
   container
@@ -48,7 +44,7 @@ const drawDegreeBox = (
 const drawClusterGraph = (
   svgRef: RefObject<SVGSVGElement>,
   data: ClusterNode[],
-  onClickCluster: (this: SVGGElement, event: any, d: number) => void
+  onClickCluster: (this: SVGGElement, event: MouseEvent, d: number) => void
 ) => {
   const group = d3
     .select(svgRef.current)

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.type.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.type.ts
@@ -1,0 +1,8 @@
+import type { BaseType, Selection } from "d3";
+
+export type SVGElementSelection<T extends BaseType> = Selection<
+  T,
+  number,
+  SVGSVGElement | null,
+  unknown
+>;

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.util.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.util.ts
@@ -2,14 +2,14 @@ import type { ClusterNode } from "types";
 
 import { COMMIT_HEIGHT, NODE_GAP } from "./ClusterGraph.const";
 
-export function getCommitCounts(data: ClusterNode[]) {
+export function getClusterSizes(data: ClusterNode[]) {
   return data.map((node) => node.commitNodeList.length);
 }
 
-export function getGraphHeight(commitCounts: number[]) {
-  const totalCommit = commitCounts.reduce(
-    (sum: number, commit: number) => sum + commit,
-    0
+export function getGraphHeight(clusterSizes: number[]) {
+  return (
+    clusterSizes.length * COMMIT_HEIGHT +
+    clusterSizes.length * NODE_GAP +
+    NODE_GAP
   );
-  return totalCommit * COMMIT_HEIGHT + commitCounts.length * NODE_GAP;
 }

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -26,7 +26,7 @@
 .cluster {
   align-items: center;
   width: 85%;
-  padding-top: 10px;
+  padding: 10px 0;
 }
 
 .summary {
@@ -49,11 +49,11 @@
   display: flex;
   width: 30px;
   height: 30px;
+  line-height: 30px;
   font-weight: bold;
-  
+
   color: $white;
   justify-content: center;
-  align-items: center;
   text-align: center;
   font-size: 15pt;
   margin-left: -5px;
@@ -66,7 +66,7 @@
     z-index: 9999;
   }
 
-  &:nth-child(2n){
+  &:nth-child(2n) {
     &:hover {
       @include animation();
       z-index: 9999;
@@ -135,6 +135,7 @@
   &.large {
     font-size: 18pt;
     font-weight: 900;
+    line-height: 28px;
 
     &:hover {
       @include animation();
@@ -145,7 +146,8 @@
   &.medium {
     font-size: 16pt;
     font-weight: 700;
-    
+    line-height: 28px;
+
     &:hover {
       @include animation();
       cursor: pointer;


### PR DESCRIPTION
## WorkList

5fcc7dc60d734860fd6a54bd04bfb1661ae8b22a
- ClusterSize에 따라 height를 다르게 했던 ClusterGraph v1을 삭제하고, height는 고정시키고 내부에 rect를 추가하여 내부 rect의 width를 통해 ClusterSize를 표현하는 v2를 추가했습니다.

c816fc53e7fc75f98a8819e9f2f41d3d4d4861d0
- d3의 style attributes를 scss 파일로 분리하는 작업을 수행했습니다.

e93f8eab3c57a068f3df365b9be2aec7f4efbded
- ClusterGraph에서, 하나의 ClusterElement를 hover 했을 때 stroke-width가 증가하는 액션을 추가했습니다.

ef8d7a300795151ef1bbf959b76b10b7e476ed66
- useEffect 내부에 존재하던 d3 graph draw 로직을 컴포넌트 외부로 분리했습니다.
- graph destroy 로직을 추가하여, 데이터 변경 시 기존 View를 삭제하도록 구현했습니다.

6ac0f1a17410da5aa301d56d21a750abc5ef70ab
- Cluster Click 이벤트 핸들러를 등록했습니다.

ba26cb5dd7dc570c8365ae0d8163fb10c8a9d81b
- githru를 참고하여 ClusterSize에 대한 시각화 scale을 수정했습니다.
- githru에서 ClusterGraph의 scale을 나타낼 때, ClusterSize (cluster에 포함된 commit 개수) 가 10이상이면 Container를 모두 채우도록 되어있어서, 동일한 방법으로 구현했습니다.

## 

## Result

(v1)
![image](https://user-images.githubusercontent.com/49841765/188868246-d5acb23e-aae4-433c-99ee-a379f3ab73b8.png)

(v2)
![image](https://user-images.githubusercontent.com/49841765/188866048-49f16bef-3e2f-476d-bd68-112855c902b1.png)
