### PR TITLE
feat(view): global state management using context API

### DIFF
--- a/packages/view/src/App.tsx
+++ b/packages/view/src/App.tsx
@@ -5,12 +5,12 @@ import {
   VerticalClusterList,
 } from "components";
 
-import { useGetTotalData } from "./App.hook";
+import { useGlobalData } from "./hooks/useGlobalData";
 import "./App.scss";
 
 const App = () => {
-  const { data } = useGetTotalData();
-  if (!data.length) return null;
+  const { data } = useGlobalData();
+  if (!data?.length) return null;
 
   return (
     <div>

--- a/packages/view/src/hooks/useGlobalData.tsx
+++ b/packages/view/src/hooks/useGlobalData.tsx
@@ -1,0 +1,45 @@
+import type { Dispatch, ReactNode } from "react";
+import { createContext, useContext, useMemo, useState } from "react";
+
+import type { ClusterNode } from "../types";
+import { useGetTotalData } from "../App.hook";
+
+type GlobalDataState = Partial<{
+  data: ClusterNode[];
+  filteredData: ClusterNode[];
+  setFilteredData: Dispatch<ClusterNode[]>;
+  selectedData: ClusterNode[];
+  setSelectedData: Dispatch<ClusterNode[]>;
+}>;
+
+export const GlobalDataContext = createContext<GlobalDataState>(
+  {} as GlobalDataState
+);
+
+export const GlobalDataProvider = ({ children }: { children: ReactNode }) => {
+  const { data } = useGetTotalData();
+  const [filteredData, setFilteredData] = useState<ClusterNode[]>(data);
+  const [selectedData, setSelectedData] = useState<ClusterNode[]>([]);
+
+  const value = useMemo(
+    () => ({
+      data,
+      filteredData,
+      setFilteredData,
+      selectedData,
+      setSelectedData,
+    }),
+    [data, filteredData, selectedData]
+  );
+
+  return (
+    <GlobalDataContext.Provider value={value}>
+      {children}
+    </GlobalDataContext.Provider>
+  );
+};
+
+export const useGlobalData = () => {
+  const globalData = useContext<GlobalDataState>(GlobalDataContext);
+  return globalData;
+};

--- a/packages/view/src/hooks/useGlobalData.tsx
+++ b/packages/view/src/hooks/useGlobalData.tsx
@@ -1,5 +1,5 @@
 import type { Dispatch, ReactNode } from "react";
-import { createContext, useContext, useMemo, useState } from "react";
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
 
 import type { ClusterNode } from "../types";
 import { useGetTotalData } from "../App.hook";
@@ -20,6 +20,10 @@ export const GlobalDataProvider = ({ children }: { children: ReactNode }) => {
   const { data } = useGetTotalData();
   const [filteredData, setFilteredData] = useState<ClusterNode[]>(data);
   const [selectedData, setSelectedData] = useState<ClusterNode[]>([]);
+
+  useEffect(() => {
+    setSelectedData([]);
+  }, [filteredData]);
 
   const value = useMemo(
     () => ({

--- a/packages/view/src/index.tsx
+++ b/packages/view/src/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 
 import App from "./App";
 import "styles/app.scss";
+import { GlobalDataProvider } from "./hooks/useGlobalData";
 
 declare global {
   interface Window {
@@ -14,6 +15,8 @@ const container = document.getElementById("root") as HTMLElement;
 
 ReactDOM.createRoot(container).render(
   <React.StrictMode>
-    <App />
+    <GlobalDataProvider>
+      <App />
+    </GlobalDataProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
https://github.com/githru/githru-vscode-ext/pull/103
영진님이 추가해주신 상태를 context API로 분리해봤습니다 
의견 여쭤보고 적용해도 괜찮으신 경우 이걸로 진행해도 좋을것 같아요 

지금 몇개의 컴포넌트가 하위에 더 추가될지 모르는 상태기도하고 각 컴포넌트마다 어떤 데이터를 사용하는지 파악할 필요가 없도록 contextAPI 사용해서 본인이 구현하는 컴포넌트에서 사용되는것만 가져다쓰는 형태로 개발해봤습니다.

실제로 사용하실때는 
 ```typescript
const { selectedData } = useGlobalData();
```
형태로 사용하시면됩니다


----

타입 같은 경우에는 처음에 아래와 같은 형태로(nullable) 개발하려고 했는데 destructuring이 안되어서 불편하더라구요
```typescript
type GlobalDataState = {
  data: ClusterNode[];
  filteredData: ClusterNode[];
  setFilteredData: Dispatch<ClusterNode[]>;
  selectedData: ClusterNode[];
  setSelectedData: Dispatch<ClusterNode[]>;
}| null
```
그래서 타입정의시에는 Partial<>을 사용하고 기본 데이터는 빈 object로 설정해서 destructuring할 수 있게 구현했습니다.

----



useMemo는 아래 eslint 룰에 걸려서 추가했습니다.
```
The object passed as the value prop to the Context provider (at line 30) changes every render. To fix this consider wrapping it in a useMemo hook.(react/jsx-no-constructed-context-values)
```
