### PR TITLE
feat(engine): implement csm

### DIFF
--- a/packages/analysis-engine/src/csm.spec.ts
+++ b/packages/analysis-engine/src/csm.spec.ts
@@ -1,4 +1,4 @@
-import { buildCSM } from "./csm";
+import { buildCSMDict } from "./csm";
 
 import type { CommitRaw } from "./types/CommitRaw";
 import type { CommitNode } from "./types/CommitNode";
@@ -76,7 +76,7 @@ describe("csm", () => {
     let csmDict: CSMDictionary;
 
     beforeAll(() => {
-      csmDict = buildCSM(fakeCommitNodeDict, fakeStemDict);
+      csmDict = buildCSMDict(fakeCommitNodeDict, fakeStemDict);
     });
 
     it("should return csm-dictionary", () => {

--- a/packages/analysis-engine/src/csm.spec.ts
+++ b/packages/analysis-engine/src/csm.spec.ts
@@ -1,0 +1,143 @@
+import { buildCSM } from "./csm";
+
+import type { CommitRaw } from "./types/CommitRaw";
+import type { CommitNode } from "./types/CommitNode";
+import type { Stem } from "./types/Stem";
+import type { CSMDictionary } from "./types/CSM";
+
+describe("csm", () => {
+  // master = [0, 1,              2,                 3, 4, 5]
+  // sub1 =         [6,7,       8,  9,10,         11]
+  // sub2 =              [12,13,         14,15,16]
+
+  const fakeCommitDict: Map<string, CommitRaw> = new Map<
+    string,
+    Pick<CommitRaw, "id" | "parents" | "branches" | "sequence">
+  >([
+    // master
+    ["0", { id: "0", parents: [], branches: [], sequence: 0 }],
+    ["1", { id: "1", parents: ["0"], branches: [], sequence: 1 }],
+    ["2", { id: "2", parents: ["1", "8"], branches: [], sequence: 7 }],
+    ["3", { id: "3", parents: ["2", "11"], branches: [], sequence: 14 }],
+    ["4", { id: "4", parents: ["3"], branches: [], sequence: 15 }],
+    ["5", { id: "5", parents: ["4"], branches: ["master"], sequence: 16 }],
+    // sub1
+    ["6", { id: "6", parents: ["1"], branches: [], sequence: 2 }],
+    ["7", { id: "7", parents: ["6"], branches: [], sequence: 3 }],
+    ["8", { id: "8", parents: ["7", "13"], branches: [], sequence: 6 }],
+    ["9", { id: "9", parents: ["8" /* "2" */], branches: [], sequence: 8 }],
+    ["10", { id: "10", parents: ["9"], branches: [], sequence: 9 }],
+    [
+      "11",
+      { id: "11", parents: ["10", "16"], branches: ["sub1"], sequence: 13 },
+    ],
+    // sub2
+    ["12", { id: "12", parents: ["7"], branches: [], sequence: 4 }],
+    ["13", { id: "13", parents: ["12"], branches: [], sequence: 5 }],
+    [
+      "14",
+      { id: "14", parents: ["13" /* "10" */], branches: [], sequence: 10 },
+    ],
+    ["15", { id: "15", parents: ["14"], branches: [], sequence: 11 }],
+    ["16", { id: "16", parents: ["15"], branches: ["sub2"], sequence: 12 }],
+  ]) as Map<string, CommitRaw>;
+
+  function makeFakeStemTuple(
+    stemId: string,
+    commitIds: string[]
+  ): [string, Stem] {
+    return [
+      stemId,
+      {
+        nodes: commitIds
+          .map((id) => fakeCommitDict.get(`${id}`))
+          .filter((commit): commit is CommitRaw => Boolean(commit))
+          .map((commit) => ({ stemId, commit })),
+      },
+    ];
+  }
+
+  const fakeStemDict: Map<string, Stem> = new Map([
+    makeFakeStemTuple("master", [0, 1, 2, 3, 4, 5].map(String)),
+    makeFakeStemTuple("sub1", [6, 7, 8, 9, 10, 11].map(String)),
+    makeFakeStemTuple("sub2", [12, 13, 14, 15, 16].map(String)),
+  ]);
+
+  const fakeCommitNodeDict: Map<string, CommitNode> = Array.from(
+    fakeStemDict.entries()
+  ).reduce((dict, [, stem]) => {
+    stem.nodes.forEach((commitNode) => {
+      dict.set(commitNode.commit.id, commitNode);
+    });
+    return dict;
+  }, new Map<string, CommitNode>());
+
+  describe("buildCSM", () => {
+    let csmDict: CSMDictionary;
+
+    beforeAll(() => {
+      csmDict = buildCSM(fakeCommitNodeDict, fakeStemDict);
+    });
+
+    it("should return csm-dictionary", () => {
+      expect(csmDict).toBeDefined();
+      expect(csmDict.master).toBeDefined();
+      expect(csmDict.master.length).toBeGreaterThan(0);
+    });
+
+    describe("csm-dictionary", () => {
+      // master = [0, 1,              2,                 3, 4, 5]
+      // sub1 =         [6,7,       8,  9,10,         11]
+      // sub2 =              [12,13,         14,15,16]
+
+      it("has empty-squash-commits", () => {
+        const nonMergeCSMNodes = csmDict.master.filter(
+          (csmNode) => csmNode.source.length === 0
+        );
+        expect(nonMergeCSMNodes).toBeDefined();
+        expect(nonMergeCSMNodes.length).toBeGreaterThan(0);
+
+        // 0,1,4,5 commits have no-squash-commits
+        const expectedNonMergeCommitIds = ["0", "1", "4", "5"];
+        const nonMergeCommitIds = nonMergeCSMNodes.map(
+          (csmNode) => csmNode.base.commit.id
+        );
+        nonMergeCommitIds.forEach((commitId) => {
+          expect(expectedNonMergeCommitIds.includes(commitId)).toBe(true);
+        });
+      });
+
+      it("has squash-commits", () => {
+        const mergeCSMNodes = csmDict.master.filter(
+          (csmNode) => csmNode.source.length > 0
+        );
+        expect(mergeCSMNodes).toBeDefined();
+        expect(mergeCSMNodes.length).toBeGreaterThan(0);
+
+        // 2,3 commits have sqaush-commits
+        const expectedMergeCommitIds = ["2", "3"];
+        const mergeCommitIds = mergeCSMNodes.map(
+          (csmNode) => csmNode.base.commit.id
+        );
+        mergeCommitIds.forEach((commitId) => {
+          expect(expectedMergeCommitIds.includes(commitId)).toBe(true);
+        });
+
+        // 2 commit has squash-commits(6,7,12,13,8)
+        // 3 commit has squash-commits(9,10,14,15,16,11)
+        const expectedSquashCommitIds = {
+          "2": ["6", "7", "12", "13", "8"],
+          "3": ["9", "10", "14", "15", "16", "11"],
+        };
+        mergeCSMNodes.forEach((csmNode) => {
+          const squashCommitIds = csmNode.source.map(
+            (commitNode) => commitNode.commit.id
+          );
+          expect(squashCommitIds).toEqual(
+            expectedSquashCommitIds[csmNode.base.commit.id]
+          );
+        });
+      });
+    });
+  });
+});

--- a/packages/analysis-engine/src/csm.spec.ts
+++ b/packages/analysis-engine/src/csm.spec.ts
@@ -15,31 +15,28 @@ describe("csm", () => {
     Pick<CommitRaw, "id" | "parents" | "branches" | "sequence">
   >([
     // master
-    ["0", { id: "0", parents: [], branches: [], sequence: 0 }],
-    ["1", { id: "1", parents: ["0"], branches: [], sequence: 1 }],
-    ["2", { id: "2", parents: ["1", "8"], branches: [], sequence: 7 }],
-    ["3", { id: "3", parents: ["2", "11"], branches: [], sequence: 14 }],
-    ["4", { id: "4", parents: ["3"], branches: [], sequence: 15 }],
-    ["5", { id: "5", parents: ["4"], branches: ["master"], sequence: 16 }],
+    ["0", { id: "0", parents: [], branches: [], sequence: 16 }],
+    ["1", { id: "1", parents: ["0"], branches: [], sequence: 15 }],
+    ["2", { id: "2", parents: ["1", "8"], branches: [], sequence: 9 }],
+    ["3", { id: "3", parents: ["2", "11"], branches: [], sequence: 2 }],
+    ["4", { id: "4", parents: ["3"], branches: [], sequence: 1 }],
+    ["5", { id: "5", parents: ["4"], branches: ["master"], sequence: 0 }],
     // sub1
-    ["6", { id: "6", parents: ["1"], branches: [], sequence: 2 }],
-    ["7", { id: "7", parents: ["6"], branches: [], sequence: 3 }],
-    ["8", { id: "8", parents: ["7", "13"], branches: [], sequence: 6 }],
+    ["6", { id: "6", parents: ["1"], branches: [], sequence: 14 }],
+    ["7", { id: "7", parents: ["6"], branches: [], sequence: 13 }],
+    ["8", { id: "8", parents: ["7", "13"], branches: [], sequence: 10 }],
     ["9", { id: "9", parents: ["8" /* "2" */], branches: [], sequence: 8 }],
-    ["10", { id: "10", parents: ["9"], branches: [], sequence: 9 }],
+    ["10", { id: "10", parents: ["9"], branches: [], sequence: 7 }],
     [
       "11",
-      { id: "11", parents: ["10", "16"], branches: ["sub1"], sequence: 13 },
+      { id: "11", parents: ["10", "16"], branches: ["sub1"], sequence: 3 },
     ],
     // sub2
-    ["12", { id: "12", parents: ["7"], branches: [], sequence: 4 }],
-    ["13", { id: "13", parents: ["12"], branches: [], sequence: 5 }],
-    [
-      "14",
-      { id: "14", parents: ["13" /* "10" */], branches: [], sequence: 10 },
-    ],
-    ["15", { id: "15", parents: ["14"], branches: [], sequence: 11 }],
-    ["16", { id: "16", parents: ["15"], branches: ["sub2"], sequence: 12 }],
+    ["12", { id: "12", parents: ["7"], branches: [], sequence: 12 }],
+    ["13", { id: "13", parents: ["12"], branches: [], sequence: 11 }],
+    ["14", { id: "14", parents: ["13" /* "10" */], branches: [], sequence: 6 }],
+    ["15", { id: "15", parents: ["14"], branches: [], sequence: 5 }],
+    ["16", { id: "16", parents: ["15"], branches: ["sub2"], sequence: 4 }],
   ]) as Map<string, CommitRaw>;
 
   function makeFakeStemTuple(
@@ -57,10 +54,13 @@ describe("csm", () => {
     ];
   }
 
+  // master = [0, 1,              2,                 3, 4, 5]
+  // sub1 =         [6,7,       8,  9,10,         11]
+  // sub2 =              [12,13,         14,15,16]
   const fakeStemDict: Map<string, Stem> = new Map([
-    makeFakeStemTuple("master", [0, 1, 2, 3, 4, 5].map(String)),
-    makeFakeStemTuple("sub1", [6, 7, 8, 9, 10, 11].map(String)),
-    makeFakeStemTuple("sub2", [12, 13, 14, 15, 16].map(String)),
+    makeFakeStemTuple("master", [0, 1, 2, 3, 4, 5].reverse().map(String)),
+    makeFakeStemTuple("sub1", [6, 7, 8, 9, 10, 11].reverse().map(String)),
+    makeFakeStemTuple("sub2", [12, 13, 14, 15, 16].reverse().map(String)),
   ]);
 
   const fakeCommitNodeDict: Map<string, CommitNode> = Array.from(
@@ -123,11 +123,11 @@ describe("csm", () => {
           expect(expectedMergeCommitIds.includes(commitId)).toBe(true);
         });
 
-        // 2 commit has squash-commits(6,7,12,13,8)
-        // 3 commit has squash-commits(9,10,14,15,16,11)
+        // 2 commit has squash-commits(8,13,12,7,6)
+        // 3 commit has squash-commits(11,16,15,14,10,9)
         const expectedSquashCommitIds = {
-          "2": ["6", "7", "12", "13", "8"],
-          "3": ["9", "10", "14", "15", "16", "11"],
+          "2": ["8", "13", "12", "7", "6"],
+          "3": ["11", "16", "15", "14", "10", "9"],
         };
         mergeCSMNodes.forEach((csmNode) => {
           const squashCommitIds = csmNode.source.map(

--- a/packages/analysis-engine/src/csm.ts
+++ b/packages/analysis-engine/src/csm.ts
@@ -46,9 +46,11 @@ export const buildCSM = (
       const squashTaskQueue: CommitNode[] = [mergeParentCommit];
       while (squashTaskQueue.length > 0) {
         // get target
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const mergeCommitNode = squashTaskQueue.shift()!;
 
         // get target's stem
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const mergeCommitStemId = mergeCommitNode.stemId!;
         const mergeCommitStem = stemDict.get(mergeCommitStemId);
         if (!mergeCommitStem) {

--- a/packages/analysis-engine/src/csm.ts
+++ b/packages/analysis-engine/src/csm.ts
@@ -32,10 +32,16 @@ export const buildCSM = (
   const stemNodes = masterStem.nodes;
 
   const csmNodes: CSMNode[] = [];
+
   stemNodes.forEach((commitNode) => {
+    const csmNode: CSMNode = {
+      base: commitNode,
+      source: [],
+    };
+
     const mergeParentCommit = commitDict.get(commitNode.commit.parents[1]);
     if (mergeParentCommit) {
-      const squashCommitNodes: CommitNode[] = [commitNode];
+      const squashCommitNodes: CommitNode[] = [];
 
       const squashTaskQueue: CommitNode[] = [mergeParentCommit];
       while (squashTaskQueue.length > 0) {
@@ -70,10 +76,10 @@ export const buildCSM = (
 
       squashCommitNodes.sort((a, b) => a.commit.sequence - b.commit.sequence);
 
-      csmNodes.push({ commits: squashCommitNodes });
-    } else {
-      csmNodes.push({ commits: [commitNode] });
+      csmNode.source = squashCommitNodes;
     }
+
+    csmNodes.push(csmNode);
   });
 
   csmDict[branch] = csmNodes;

--- a/packages/analysis-engine/src/csm.ts
+++ b/packages/analysis-engine/src/csm.ts
@@ -68,6 +68,8 @@ export const buildCSM = (
         squashTaskQueue.push(...nestedMergeCommits);
       }
 
+      squashCommitNodes.sort((a, b) => a.commit.sequence - b.commit.sequence);
+
       csmNodes.push({ commits: squashCommitNodes });
     } else {
       csmNodes.push({ commits: [commitNode] });

--- a/packages/analysis-engine/src/csm.ts
+++ b/packages/analysis-engine/src/csm.ts
@@ -1,0 +1,123 @@
+import type { CommitRaw } from "./types/CommitRaw";
+import type { CSMDictionary, CSMNode } from "./types/CSM";
+
+// todo: import type { StemDictionary } from "./types/STEM";
+interface StemDictionary {
+  [branch: string]: CommitRaw[];
+}
+
+/**
+ * extract root-commits
+ */
+const getRootCommitStems = (stemDict: StemDictionary) =>
+  Object.keys(stemDict)
+    .filter((branch) => {
+      const stem = stemDict[branch];
+      return stem[stem.length - 1].parents.length === 0;
+    })
+    .map((branch) => ({ branch, stem: stemDict[branch] }));
+
+/**
+ * CSM 생성
+ *
+ * @param commits
+ * @returns Array<Stem>
+ */
+export const buildCSM = (
+  commitDict: Map<string, CommitRaw>,
+  stemDict: StemDictionary
+): CSMDictionary => {
+  if (Object.values(stemDict).length === 0) {
+    // throw new Error("no stem");
+    return {};
+  }
+
+  /*
+  const commit = {} // root-commit
+  const mergedCommit = commit.parent[0]
+  const stemId = mergedCommit.stemId
+  const stem = stemDict[stemId]
+
+  stem
+  => head부터~ merged커밋노드까지 splice 하고
+  => 이걸 CSM의 노드에 넣어줌
+  => 
+  */
+
+  const csmDict: CSMDictionary = {};
+
+  /*
+    commits[0] : 가장 최근 커밋
+    commits[-1] : 가장 오래된 커밋
+
+    루트노드가 N개일수있음
+    => stem 의 가장첫번째 커밋을 확인하여 parent 여부 확인
+    => parent 없는 커밋을 루트노드로 취급
+
+    루트노드부터 순회 시작 
+    => if 머지커밋발견하면, 머지parent로 올라가서 해당stem 가져오기
+    => 아니면 통과
+
+    머지parent로 어떻게 찾아 올라가나..?
+    => commitDict 로 찾아옴..!
+
+    머지parent 부터 시작해서 해당 stem 어떻게 가져오나..??
+    => 머지커밋id로 그에 속한 stem을 찾을수있어야함..!
+   */
+
+  const rootCommitStems = getRootCommitStems(stemDict);
+  // 마스터브랜치루트 → HEAD브랜치 루트 → 서브브랜치 루트 순서대로 CSM 생성
+
+  rootCommitStems.forEach(({ branch, stem }) => {
+    const csm: CSMNode[] = [];
+
+    stem.forEach((commit) => {
+      if (commit.parents[1]) {
+        const squashCommits: CommitRaw[] = [];
+
+        // stem1 = [5, 4,           3,               2, 1, 0]
+        // stem2 =       [5,4,   3,    2,1,        0]
+        // stem3 =       [    4,3,          2,1,0]
+
+        const taskQueue = [commitDict[commit.parents[1]]];
+        while (taskQueue.length > 0) {
+          const mergingCommit = taskQueue.shift()!;
+
+          // prepare sqush
+          const branchStem = stemDict[(mergingCommit as any).stemId];
+          const branchStemLastIndex = branchStem.length - 1;
+          const branchStemMergedCommitIndex = branchStem.findIndex(
+            ({ id }) => id === mergingCommit.id
+          );
+          const commitCount =
+            branchStemLastIndex - branchStemMergedCommitIndex + 1;
+
+          // sqush
+          const spliceCommits = branchStem.splice(
+            branchStemLastIndex,
+            commitCount
+          );
+          squashCommits.push(...spliceCommits);
+
+          // nested merge
+          const nestedMergingCommits = spliceCommits.filter(
+            ({ parents }) => parents.length > 1
+          );
+          taskQueue.push(...nestedMergingCommits);
+        }
+
+        csm.push({ commits: squashCommits });
+      } else {
+        csm.push({ commits: [commit] });
+      }
+    });
+
+    csmDict[branch] = csm;
+  });
+
+  return csmDict;
+};
+
+export const csm = () => "csm";
+
+export default csm;

--- a/packages/analysis-engine/src/csm.ts
+++ b/packages/analysis-engine/src/csm.ts
@@ -11,7 +11,7 @@ import type { CSMDictionary, CSMNode } from "./types/CSM";
  * @param {Map<string, Stem>} stemDict
  * @returns {CSMDictionary}
  */
-export const buildCSM = (
+export const buildCSMDict = (
   commitDict: Map<string, CommitNode>,
   stemDict: Map<string, Stem>
 ): CSMDictionary => {

--- a/packages/analysis-engine/src/csm.ts
+++ b/packages/analysis-engine/src/csm.ts
@@ -29,7 +29,7 @@ export const buildCSM = (
     // return {};
   }
   const branch = "master";
-  const stemNodes = masterStem.nodes;
+  const stemNodes = masterStem.nodes.reverse(); // start on root-node
 
   const csmNodes: CSMNode[] = [];
 
@@ -56,13 +56,17 @@ export const buildCSM = (
           continue;
         }
 
-        // squash
+        // prepare squash
+        const mergeCommitStemLastIndex = mergeCommitStem.nodes.length - 1;
         const spliceIndex = mergeCommitStem.nodes.findIndex(
           ({ commit: { id } }) => id === mergeCommitNode.commit.id
         );
+        const spliceCount = mergeCommitStemLastIndex - spliceIndex + 1;
+
+        // squash
         const spliceCommitNodes = mergeCommitStem.nodes.splice(
-          0,
-          spliceIndex + 1
+          spliceIndex,
+          spliceCount
         );
         squashCommitNodes.push(...spliceCommitNodes);
 

--- a/packages/analysis-engine/src/types/CSM.ts
+++ b/packages/analysis-engine/src/types/CSM.ts
@@ -1,18 +1,10 @@
-import type { CommitRaw } from "./CommitRaw";
+import type { CommitNode } from "./CommitNode";
 
 export interface CSMNode {
-  commits: CommitRaw[];
+  commits: CommitNode[];
+  no?: number;
 }
 
 export interface CSMDictionary {
   [branch: string]: CSMNode[];
-
-  // [branch: string]: Array<{
-  //   nodeTypeName: "CLUSTER";
-  //   commitNodeList: Array<{
-  //     nodeTypeName: "COMMIT";
-  //     commit: CommitRaw;
-  //     seq: string;
-  //   }>;
-  // }>;
 }

--- a/packages/analysis-engine/src/types/CSM.ts
+++ b/packages/analysis-engine/src/types/CSM.ts
@@ -3,7 +3,6 @@ import type { CommitNode } from "./CommitNode";
 export interface CSMNode {
   base: CommitNode;
   source: CommitNode[];
-  no?: number;
 }
 
 export interface CSMDictionary {

--- a/packages/analysis-engine/src/types/CSM.ts
+++ b/packages/analysis-engine/src/types/CSM.ts
@@ -1,7 +1,8 @@
 import type { CommitNode } from "./CommitNode";
 
 export interface CSMNode {
-  commits: CommitNode[];
+  base: CommitNode;
+  source: CommitNode[];
   no?: number;
 }
 

--- a/packages/analysis-engine/src/types/CSM.ts
+++ b/packages/analysis-engine/src/types/CSM.ts
@@ -1,0 +1,18 @@
+import type { CommitRaw } from "./CommitRaw";
+
+export interface CSMNode {
+  commits: CommitRaw[];
+}
+
+export interface CSMDictionary {
+  [branch: string]: CSMNode[];
+
+  // [branch: string]: Array<{
+  //   nodeTypeName: "CLUSTER";
+  //   commitNodeList: Array<{
+  //     nodeTypeName: "COMMIT";
+  //     commit: CommitRaw;
+  //     seq: string;
+  //   }>;
+  // }>;
+}


### PR DESCRIPTION
CSM 생성에 대한 구현입니다.

master STEM 을 기준으로 루트노트부터 순회하여 머지커밋에 연결된 커밋들을 squash 합니다.

CSM 생성 인터페이스는 아래와 같습니다. 

input : `Map<string, CommitNode>`, `Map<string, Stem>` 
output : `CSMDictionary`


---

example commit log : 
```
master = [0, 1,              2,                 3, 4, 5]
sub1 =         [6,7,       8,  9,10,         11]
sub2 =              [12,13,         14,15,16]
```

example output (CSMDictionary) :
```typescript
{
  master: [
        {
          base: { commit: { id: '0', parents: [], branches: [] }},
          source: []
        },
        {
          base: { commit: { id: '1', parents: [ '0' ], branches: [] }},
          source: []
        },
        {
          base: { commit: { id: '2', parents: [ '1', '8' ], branches: [] }},
          source: [
            { commit: { id: '6', parents: [ '1' ], branches: [] } },
            { commit: { id: '7', parents: [ '6' ], branches: [] } },
            { commit: { id: '12', parents: [ '7' ], branches: [] } },
            { commit: { id: '13', parents: [ '12' ], branches: [] } },
            { commit: { id: '8', parents: [ '7', '13' ], branches: [] } }
          ]
        },
  // ...
  ]
}
```
