### PR TITLE
feat(view): add opening Detail Component action of selected cluster event

### DIFF
--- a/packages/view/src/App.tsx
+++ b/packages/view/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 
 import {
-  Detail,
+  // Detail,
   Statistics,
   TemporalFilter,
   VerticalClusterList,
@@ -34,11 +34,12 @@ const App = () => {
       <div className="middle-container">
         <VerticalClusterList
           data={filteredData}
+          selectedData={selectedData}
           setSelectedData={setSelectedData}
         />
         <Statistics data={selectedData ? [selectedData] : filteredData} />
       </div>
-      <Detail selectedData={selectedData} />
+      {/* <Detail selectedData={selectedData} /> */}
     </div>
   );
 };

--- a/packages/view/src/App.tsx
+++ b/packages/view/src/App.tsx
@@ -38,7 +38,7 @@ const App = () => {
         />
         <Statistics data={selectedData ? [selectedData] : filteredData} />
       </div>
-      <Detail data={data} />
+      <Detail selectedData={selectedData} />
     </div>
   );
 };

--- a/packages/view/src/App.tsx
+++ b/packages/view/src/App.tsx
@@ -36,7 +36,7 @@ const App = () => {
           data={filteredData}
           setSelectedData={setSelectedData}
         />
-        <Statistics data={selectedData ?? filteredData} />
+        <Statistics data={selectedData ? [selectedData] : filteredData} />
       </div>
       <Detail data={data} />
     </div>

--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -1,14 +1,10 @@
-import type { GlobalProps } from "types/global";
+import type { SelectedDataProps } from "types/global";
 
-import { getCommitListDetail, getCommitListInCluster } from "./Detail.util";
+import { getCommitListDetail } from "./Detail.util";
 
-const TARGET_CLUSTER_ID = 2435;
-
-const Detail = ({ data }: GlobalProps) => {
-  const commitNodeListInCluster = getCommitListInCluster({
-    data,
-    clusterId: TARGET_CLUSTER_ID,
-  });
+const Detail = ({ selectedData }: { selectedData: SelectedDataProps }) => {
+  if (!selectedData) return null;
+  const commitNodeListInCluster = selectedData.commitNodeList;
   const { authorLength, fileLength, commitLength, insertions, deletions } =
     getCommitListDetail({ commitNodeListInCluster });
 

--- a/packages/view/src/components/Detail/Detail.util.ts
+++ b/packages/view/src/components/Detail/Detail.util.ts
@@ -1,19 +1,4 @@
-import type { GlobalProps, CommitNode } from "types/";
-
-type GetCommitListInCluster = GlobalProps & { clusterId: number };
-export const getCommitListInCluster = ({
-  data,
-  clusterId,
-}: GetCommitListInCluster) => {
-  const flatCommitNodeList: CommitNode[] = data
-    .map((clusterNode) => clusterNode.commitNodeList)
-    .flat();
-
-  const commitNodeListInCluster = flatCommitNodeList.filter(
-    (commitNode) => commitNode.clusterId === clusterId
-  );
-  return commitNodeListInCluster;
-};
+import type { CommitNode } from "types/";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getDataSetSize = <T extends any[]>(arr: T, callback: Function) => {

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -2,7 +2,7 @@ import type { ChangeEvent } from "react";
 import { useRef, useEffect, useState } from "react";
 import * as d3 from "d3";
 
-import type { ClusterNode, StatisticsProps } from "types";
+import type { StatisticsProps } from "types";
 
 import type { AuthorDataType, MetricType } from "./AuthorBarChart.type";
 import { getDataByAuthor, sortDataByName } from "./AuthorBarChart.util";
@@ -17,8 +17,7 @@ const AuthorBarChart = ({ data: rawData }: AuthorBarChartProps) => {
   const [metric, setMetric] = useState<MetricType>(METRIC_TYPE[0]);
 
   useEffect(() => {
-    // type as
-    const authorData = getDataByAuthor(rawData as ClusterNode[]);
+    const authorData = getDataByAuthor(rawData);
     const data = authorData.sort((a, b) => {
       if (a[metric] === b[metric]) {
         return sortDataByName(a.name, b.name);

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
@@ -2,15 +2,17 @@ import type { ClusterNode } from "types";
 
 import type { AuthorDataType } from "./AuthorBarChart.type";
 
-export const getDataByAuthor = (data: ClusterNode[]): AuthorDataType[] => {
+export const getDataByAuthor = (
+  selectedData: ClusterNode[]
+): AuthorDataType[] => {
   // Sample Selected Data
   // 0: {name: 'Brian Munkholm ', commit: 2, insertion: 24, deletion: 78}
   // 1: {name: 'Christian Melchior ', commit: 4, insertion: 56, deletion: 60}
   // 2: {name: 'Nabil Hachicha ', commit: 2, insertion: 2, deletion: 2}
 
   // delete
-  if (!data.length) return [];
-  const selectedData: ClusterNode[] = [data[0], data[11], data[43]];
+  if (!selectedData.length) return [];
+  // const selectedData: ClusterNode[] = [data[0], data[11], data[43]];
 
   const authorDataObj = {};
 

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.const.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.const.ts
@@ -2,6 +2,7 @@ export const NODE_GAP = 20;
 export const COMMIT_HEIGHT = 50;
 export const GRAPH_WIDTH = 100;
 export const SVG_WIDTH = GRAPH_WIDTH + 4;
+export const DETAIL_HEIGHT = 300;
 export const SVG_MARGIN = {
   right: 2,
   left: 2,

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -124,16 +124,16 @@ const ClusterGraph = ({
     selected: selectedNextId,
   }));
 
-  const handleClickCluster = (_: MouseEvent, d: ClusterGraphElement) =>
-    setSelectedData(
-      selectedDataUpdater(d.cluster, d.cluster.commitNodeList[0].clusterId)
-    );
   useEffect(() => {
+    const handleClickCluster = (_: MouseEvent, d: ClusterGraphElement) =>
+      setSelectedData(
+        selectedDataUpdater(d.cluster, d.cluster.commitNodeList[0].clusterId)
+      );
     drawClusterGraph(svgRef, clusterGraphElements, handleClickCluster);
     return () => {
       destroyClusterGraph(svgRef);
     };
-  }, [clusterGraphElements]);
+  }, [clusterGraphElements, setSelectedData]);
 
   return <svg ref={svgRef} width={SVG_WIDTH} height={graphHeight} />;
 };

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -1,8 +1,8 @@
 import type { MouseEvent, RefObject } from "react";
-import { useEffect, useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import * as d3 from "d3";
 
-import type { ClusterNode } from "types";
+import type { ClusterNode, SelectedDataProps } from "types";
 
 import "./ClusterGraph.scss";
 
@@ -65,16 +65,16 @@ const destroyClusterGraph = (target: RefObject<SVGElement>) => {
 
 type ClusterGraphProps = {
   data: ClusterNode[];
+  setSelectedData: React.Dispatch<React.SetStateAction<SelectedDataProps>>;
 };
 
-const ClusterGraph = ({ data }: ClusterGraphProps) => {
+const ClusterGraph = ({ data, setSelectedData }: ClusterGraphProps) => {
   const svgRef = useRef<SVGSVGElement>(null);
   const clusterSizes = getClusterSizes(data);
   const graphHeight = getGraphHeight(clusterSizes);
 
   const handleClickCluster = () => {
-    // for solving lint error (@typescript-eslint/no-empty-function)
-    console.log("cluster click");
+    console.log(setSelectedData);
   };
 
   useEffect(() => {

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.type.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.type.ts
@@ -1,8 +1,15 @@
 import type { BaseType, Selection } from "d3";
 
+import type { ClusterNode } from "types";
+
+export type ClusterGraphElement = {
+  cluster: ClusterNode;
+  clusterSize: number;
+};
+
 export type SVGElementSelection<T extends BaseType> = Selection<
   T,
-  number,
+  ClusterGraphElement,
   SVGSVGElement | null,
   unknown
 >;

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.type.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.type.ts
@@ -5,6 +5,7 @@ import type { ClusterNode } from "types";
 export type ClusterGraphElement = {
   cluster: ClusterNode;
   clusterSize: number;
+  selected?: number;
 };
 
 export type SVGElementSelection<T extends BaseType> = Selection<

--- a/packages/view/src/components/VerticalClusterList/Summary/AuthorName/AuthorName.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/AuthorName/AuthorName.tsx
@@ -1,0 +1,17 @@
+import { getColorValue } from "../Summary.util";
+
+const AuthorName = ({ authorName }: { authorName: string }) => {
+  const colorValue = getColorValue(authorName);
+  return (
+    <span
+      key={authorName}
+      className={["name"].join(" ")}
+      data-tooltip-text={authorName}
+      style={{ backgroundColor: colorValue }}
+    >
+      {authorName.slice(0, 1)}
+    </span>
+  );
+};
+
+export default AuthorName;

--- a/packages/view/src/components/VerticalClusterList/Summary/AuthorName/index.ts
+++ b/packages/view/src/components/VerticalClusterList/Summary/AuthorName/index.ts
@@ -1,0 +1,1 @@
+export { default as AuthorName } from "./AuthorName";

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -1,18 +1,40 @@
-import type { GlobalProps } from "types";
+import React from "react";
+
+import type { ClusterNode, SelectedDataProps } from "types";
 
 import type { Cluster, Keyword } from "./Summary.type";
-import { getColorValue, getInitData } from "./Summary.util";
+import { getClusterById, getColorValue, getInitData } from "./Summary.util";
 
 import "./Summary.scss";
 
-const Summary = ({ data }: GlobalProps) => {
+type SummaryProps = {
+  data: ClusterNode[];
+  setSelectedData: React.Dispatch<React.SetStateAction<SelectedDataProps>>;
+};
+
+const Summary = ({ data, setSelectedData }: SummaryProps) => {
   const clusters = getInitData({ data });
+
+  const onClickClusterSummary = (clusterId: number) => () => {
+    const selected = getClusterById(data, clusterId);
+    setSelectedData((prev: ClusterNode | null) => {
+      if (prev === null) return selected;
+      const { clusterId: prevClusterId } = prev.commitNodeList[0];
+      if (prevClusterId === clusterId) return null;
+      return selected;
+    });
+  };
 
   return (
     <div className="entire">
       {clusters.map((cluster: Cluster) => {
         return (
-          <div className="cluster" key={cluster.clusterId}>
+          <div
+            role="presentation"
+            className="cluster"
+            key={cluster.clusterId}
+            onClick={onClickClusterSummary(cluster.clusterId)}
+          >
             <p className="summary">
               <span className="nameBox">
                 {cluster.summary.authorNames.map(

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -2,6 +2,8 @@ import React from "react";
 
 import type { ClusterNode, SelectedDataProps } from "types";
 
+import { selectedDataUpdater } from "../VerticalClusterList.util";
+
 import type { Cluster, Keyword } from "./Summary.type";
 import { getClusterById, getColorValue, getInitData } from "./Summary.util";
 
@@ -17,12 +19,7 @@ const Summary = ({ data, setSelectedData }: SummaryProps) => {
 
   const onClickClusterSummary = (clusterId: number) => () => {
     const selected = getClusterById(data, clusterId);
-    setSelectedData((prev: ClusterNode | null) => {
-      if (prev === null) return selected;
-      const { clusterId: prevClusterId } = prev.commitNodeList[0];
-      if (prevClusterId === clusterId) return null;
-      return selected;
-    });
+    setSelectedData(selectedDataUpdater(selected, clusterId));
   };
 
   return (

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -1,22 +1,31 @@
 import React from "react";
 
 import type { ClusterNode, SelectedDataProps } from "types";
+import { Detail } from "components";
 
 import { selectedDataUpdater } from "../VerticalClusterList.util";
 
+import { AuthorName } from "./AuthorName";
 import type { Cluster, Keyword } from "./Summary.type";
-import { getClusterById, getColorValue, getInitData } from "./Summary.util";
+import { getClusterById, getInitData } from "./Summary.util";
 
 import "./Summary.scss";
 
 type SummaryProps = {
   data: ClusterNode[];
   setSelectedData: React.Dispatch<React.SetStateAction<SelectedDataProps>>;
+  selectedData: SelectedDataProps;
 };
 
-const Summary = ({ data, setSelectedData }: SummaryProps) => {
+const Summary = ({ data, selectedData, setSelectedData }: SummaryProps) => {
   const clusters = getInitData({ data });
 
+  const getClusterIds = (_selectedData: SelectedDataProps) => {
+    if (!_selectedData) return null;
+    return _selectedData.commitNodeList[0].clusterId;
+  };
+
+  const clusterIds = getClusterIds(selectedData);
   const onClickClusterSummary = (clusterId: number) => () => {
     const selected = getClusterById(data, clusterId);
     setSelectedData(selectedDataUpdater(selected, clusterId));
@@ -26,52 +35,59 @@ const Summary = ({ data, setSelectedData }: SummaryProps) => {
     <div className="entire">
       {clusters.map((cluster: Cluster) => {
         return (
-          <div
-            role="presentation"
-            className="cluster"
-            key={cluster.clusterId}
-            onClick={onClickClusterSummary(cluster.clusterId)}
-          >
-            <p className="summary">
-              <span className="nameBox">
-                {cluster.summary.authorNames.map(
-                  (authorArray: Array<string>) => {
-                    return authorArray.map((authorName: string) => {
-                      const colorValue = getColorValue(authorName);
-                      return (
-                        <span
-                          key={authorName}
-                          className={["name"].join(" ")}
-                          data-tooltip-text={authorName}
-                          style={{ backgroundColor: colorValue }}
-                        >
-                          {authorName.slice(0, 1)}
-                        </span>
-                      );
-                    });
-                  }
-                )}
-              </span>
-              <span className="keywords">
-                {cluster.summary.keywords.map((keywordObj: Keyword) => {
-                  let size = "";
+          <React.Fragment key={cluster.clusterId}>
+            <div
+              role="presentation"
+              className="cluster"
+              onClick={onClickClusterSummary(cluster.clusterId)}
+            >
+              <p className="summary">
+                <span className="nameBox">
+                  {cluster.summary.authorNames.map(
+                    (authorArray: Array<string>) => {
+                      return authorArray.map((authorName: string) => (
+                        <AuthorName authorName={authorName} />
+                      ));
+                      // const colorValue = getColorValue(authorName);
+                      // return (
+                      //   <span
+                      //     key={authorName}
+                      //     className={["name"].join(" ")}
+                      //     data-tooltip-text={authorName}
+                      //     style={{ backgroundColor: colorValue }}
+                      //   >
+                      //     {authorName.slice(0, 1)}
+                      //   </span>
+                      // );
+                    }
+                  )}
+                </span>
+                <span className="keywords">
+                  {cluster.summary.keywords.map((keywordObj: Keyword) => {
+                    let size = "small";
+                    if (keywordObj.count > 3) size = "medium";
+                    if (keywordObj.count > 6) size = "large";
 
-                  if (keywordObj.count > 6) size = "large";
-                  else if (keywordObj.count > 3) size = "medium";
-                  else size = "small";
-
-                  return (
-                    <span
-                      className={["keyword", size].join(" ")}
-                      key={keywordObj.keyword}
-                    >
-                      {keywordObj.keyword}
-                    </span>
-                  );
-                })}
-              </span>
-            </p>
-          </div>
+                    return (
+                      <span
+                        className={["keyword", size].join(" ")}
+                        key={keywordObj.keyword}
+                      >
+                        {keywordObj.keyword}
+                      </span>
+                    );
+                  })}
+                </span>
+              </p>
+            </div>
+            {cluster.clusterId === clusterIds && (
+              <div
+                style={{ height: "280px", marginTop: "20px", overflow: "auto" }}
+              >
+                <Detail selectedData={selectedData} />
+              </div>
+            )}
+          </React.Fragment>
         );
       })}
     </div>

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.util.ts
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.util.ts
@@ -1,4 +1,4 @@
-import type { GlobalProps, CommitNode } from "types";
+import type { GlobalProps, CommitNode, ClusterNode } from "types";
 
 import { authorBgColorArray } from "./Summary.const";
 import type { Cluster } from "./Summary.type";
@@ -79,4 +79,10 @@ export function getColorValue(name: string) {
   colorName.slice(0 + index, index + 1);
 
   return result;
+}
+
+export function getClusterById(clusters: ClusterNode[], clusterId: number) {
+  return clusters.filter(
+    (cluster) => cluster.commitNodeList[0].clusterId === clusterId
+  )[0];
 }

--- a/packages/view/src/components/VerticalClusterList/VerticalClusterList.tsx
+++ b/packages/view/src/components/VerticalClusterList/VerticalClusterList.tsx
@@ -14,8 +14,8 @@ const VerticalClusterList = ({ data, setSelectedData }: Props) => {
   console.log(setSelectedData);
   return (
     <div className="vertical-cluster-list">
-      <ClusterGraph data={data} />
-      <Summary data={data} />
+      <ClusterGraph data={data} setSelectedData={setSelectedData} />
+      <Summary data={data} setSelectedData={setSelectedData} />
     </div>
   );
 };

--- a/packages/view/src/components/VerticalClusterList/VerticalClusterList.tsx
+++ b/packages/view/src/components/VerticalClusterList/VerticalClusterList.tsx
@@ -8,14 +8,26 @@ import { Summary } from "./Summary";
 
 type Props = GlobalProps & {
   setSelectedData: React.Dispatch<React.SetStateAction<SelectedDataProps>>;
+  selectedData: SelectedDataProps;
 };
 
-const VerticalClusterList = ({ data, setSelectedData }: Props) => {
-  console.log(setSelectedData);
+const VerticalClusterList = ({
+  data,
+  setSelectedData,
+  selectedData,
+}: Props) => {
   return (
     <div className="vertical-cluster-list">
-      <ClusterGraph data={data} setSelectedData={setSelectedData} />
-      <Summary data={data} setSelectedData={setSelectedData} />
+      <ClusterGraph
+        data={data}
+        selectedData={selectedData}
+        setSelectedData={setSelectedData}
+      />
+      <Summary
+        data={data}
+        selectedData={selectedData}
+        setSelectedData={setSelectedData}
+      />
     </div>
   );
 };

--- a/packages/view/src/components/VerticalClusterList/VerticalClusterList.util.ts
+++ b/packages/view/src/components/VerticalClusterList/VerticalClusterList.util.ts
@@ -1,0 +1,9 @@
+import type { ClusterNode } from "types";
+
+export const selectedDataUpdater =
+  (selected: ClusterNode, clusterId: number) => (prev: ClusterNode | null) => {
+    if (prev === null) return selected;
+    const { clusterId: prevClusterId } = prev.commitNodeList[0];
+    if (prevClusterId === clusterId) return null;
+    return selected;
+  };

--- a/packages/view/src/types/global.ts
+++ b/packages/view/src/types/global.ts
@@ -2,4 +2,4 @@ import type { ClusterNode } from "./NodeTypes.temp";
 
 export type GlobalProps = { data: ClusterNode[] };
 export type SelectedDataProps = ClusterNode | null;
-export type StatisticsProps = { data: ClusterNode | ClusterNode[] };
+export type StatisticsProps = { data: ClusterNode[] };


### PR DESCRIPTION
## WorkList

6b99c2188254e6d05fcc4d0b3fff3dbe74990b05
- Summary 클릭 시 setSelectedData 상태 변경 함수를 통해 selectedData 상태를 변경합니다.
- clusterId를 통해 해당하는 Cluster를 필터링하는 유틸 함수를 추가했습니다.

67670e10a4297a1db85d5dee4b6327ef44a40e82
- selected cluter ID로 2435를 고정으로 사용하던 Detail에서, 상위 컴포넌트로부터 selectedData props를 전달받아 적용했습니다.

a5168220b81765fb0d87cb7a8e7f3ef5772b0ad2
- ClusterGraph의 Cluster element 클릭 시 selectedData 상태 변경이 일어나도록 구현했습니다.

8cd0955dc1daa57e97db18c79cde94fde199f612
- Detail 컴포넌트의 위치를 View 하단에서 Summary 컴포넌트 하위로 이동시켰습니다.

## Result

![image](https://user-images.githubusercontent.com/49841765/189191375-46626de7-881b-4408-a270-5c6866570359.png)

