### PR TITLE
feat(view): add tooltip and transition to AuthorBarChart

### DIFF
--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -1,4 +1,4 @@
-import type { SelectedDataProps } from "types/global";
+import type { SelectedDataProps } from "types";
 
 import { getCommitListDetail } from "./Detail.util";
 

--- a/packages/view/src/components/Detail/Detail.util.ts
+++ b/packages/view/src/components/Detail/Detail.util.ts
@@ -1,4 +1,4 @@
-import type { CommitNode } from "types/";
+import type { CommitNode } from "types";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getDataSetSize = <T extends any[]>(arr: T, callback: Function) => {
@@ -38,21 +38,21 @@ const getChangeFileLength = ({
   return getDataSetSize(commitNodeListInCluster, fn);
 };
 
-type ObjAddCommarProps = {
+type ObjAddCommaProps = {
   authorLength: number;
   fileLength: number;
   commitLength: number;
   insertions: number;
   deletions: number;
 };
-type ObjAddCommarReturn = { [key in keyof ObjAddCommarProps]: string };
-const objAddCommar = (obj: ObjAddCommarProps): ObjAddCommarReturn =>
+type ObjAddCommaReturn = { [key in keyof ObjAddCommaProps]: string };
+const objAddComma = (obj: ObjAddCommaProps): ObjAddCommaReturn =>
   Object.entries(obj).reduce((acc, [k, v]) => {
     return {
       ...acc,
       [k]: v.toLocaleString("en"),
     };
-  }, {}) as ObjAddCommarReturn;
+  }, {}) as ObjAddCommaReturn;
 
 type GetCommitListDetail = { commitNodeListInCluster: CommitNode[] };
 export const getCommitListDetail = ({
@@ -70,7 +70,7 @@ export const getCommitListDetail = ({
       deletions: 0,
     }
   );
-  return objAddCommar({
+  return objAddComma({
     authorLength,
     fileLength,
     commitLength: commitNodeListInCluster.length,

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
@@ -10,12 +10,7 @@
   font-size: 20px;
 }
 
-.author-bar-chart {
-  overflow: visible;
-  margin: 40px;
-}
-
-.select-box {
+.author-bar-chart__select-box {
   background: transparent;
   border: none;
   margin: 50px;
@@ -26,46 +21,66 @@
   text-align: center;
 }
 
-.axis {
-  color: $white;
-  font-weight: bold;
-  font-size: 11px;
-}
+.author-bar-chart {
+  overflow: visible;
+  margin: 40px;
 
-.y-axis {
-  text {
-    display: none;
+  .axis {
+    color: $white;
+    font-weight: bold;
+    font-size: 11px;
+
+    &.y-axis {
+      text {
+        display: none;
+      }
+    }
+
+    &.x-axis {
+      .x-axis-label {
+        fill: $white;
+        font-size: 15px;
+      }
+    }
   }
-}
 
-.x-axis {
-  .x-axis-label {
-    fill: $white;
-    font-size: 15px;
-  }
-}
+  .bars {
+    .bar {
+      fill: #0077aa;
 
-.author-bar-chart__name {
-  fill: $white;
-  stroke: none;
-  font-size: 14px;
-  text-anchor: start;
+      &:hover {
+        fill: $gray-900;
+        stroke: #0077aa;
+        stroke-width: 2;
+      }
+    }
 
-  &:hover {
-    & + rect.bar {
-      fill: $gray-900;
-      stroke: #0077aa;
-      stroke-width: 2;
+    .name {
+      fill: $white;
+      stroke: none;
+      font-size: 14px;
+      text-anchor: start;
+      font-weight: normal;
     }
   }
 }
 
-.bar {
-  fill: #0077aa;
+.author-bar-chart__tooltip {
+  display: none;
+  position: absolute;
+  background: $white;
+  border: 1px solid #0077aa;
+  padding: 8px 16px;
+  text-align: center;
+  font-size: 15px;
+  border-radius: 5px;
+  color: $gray-900;
 
-  &:hover {
-    fill: $gray-900;
-    stroke: #0077aa;
-    stroke-width: 2;
+  .selected {
+    color: #0077aa;
+    font-weight: bold;
+  }
+  .name {
+    font-weight: bold;
   }
 }

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
@@ -46,21 +46,25 @@
 
   .bars {
     .bar {
-      fill: #0077aa;
-
       &:hover {
-        fill: $gray-900;
-        stroke: #0077aa;
-        stroke-width: 2;
+        rect {
+          fill: $gray-900;
+          stroke: #0077aa;
+          stroke-width: 2;
+        }
       }
-    }
 
-    .name {
-      fill: $white;
-      stroke: none;
-      font-size: 14px;
-      text-anchor: start;
-      font-weight: normal;
+      rect {
+        fill: #0077aa;
+      }
+
+      .name {
+        fill: $white;
+        stroke: none;
+        font-size: 14px;
+        text-anchor: start;
+        font-weight: normal;
+      }
     }
   }
 }
@@ -69,10 +73,10 @@
   display: none;
   position: absolute;
   background: $white;
-  border: 1px solid #0077aa;
   padding: 8px 16px;
   text-align: center;
   font-size: 15px;
+  line-height: 1.5;
   border-radius: 5px;
   color: $gray-900;
 

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
@@ -1,6 +1,6 @@
 @import "styles/app.scss";
 
-.AuthorBarChartWrap {
+.author-bar-chart-wrap {
   width: 500px;
   background: $gray-900;
   height: 100%;
@@ -10,12 +10,12 @@
   font-size: 20px;
 }
 
-.authorBarChart {
+.author-bar-chart {
   overflow: visible;
   margin: 40px;
 }
 
-.selectBox {
+.select-box {
   background: transparent;
   border: none;
   margin: 50px;
@@ -32,14 +32,14 @@
   font-size: 11px;
 }
 
-.yAxis {
+.y-axis {
   text {
     display: none;
   }
 }
 
-.xAxis {
-  .xAxisLabel {
+.x-axis {
+  .x-axis-label {
     fill: $white;
     font-size: 15px;
   }

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
@@ -45,32 +45,27 @@
   }
 }
 
-.bar {
-  rect {
-    fill: #0077aa;
-  }
+.author-bar-chart__name {
+  fill: $white;
+  stroke: none;
+  font-size: 14px;
+  text-anchor: start;
 
   &:hover {
-    rect {
+    & + rect.bar {
       fill: $gray-900;
       stroke: #0077aa;
       stroke-width: 2;
     }
   }
-
-  .name {
-    fill: $white;
-    stroke: none;
-    font-size: 14px;
-  }
 }
 
-.hoverValue {
-  height: 30px;
+.bar {
+  fill: #0077aa;
 
-  .focusText {
-    color: $white;
-    font-size: 25px;
-    text-align: center;
+  &:hover {
+    fill: $gray-900;
+    stroke: #0077aa;
+    stroke-width: 2;
   }
 }

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -62,7 +62,11 @@ const AuthorBarChart = ({ data: rawData }: AuthorBarChartProps) => {
     const xAxis = d3.axisBottom(xScale).ticks(5, "%").tickSizeOuter(0);
     xAxisGroup.call(xAxis);
 
-    const yAxis = d3.axisLeft(yScale).ticks(0).tickSizeOuter(0);
+    const yAxis = d3
+      .axisLeft(yScale)
+      .ticks(0)
+      .tickSizeInner(3)
+      .tickSizeOuter(0);
     yAxisGroup.call(yAxis);
 
     xAxisGroup
@@ -87,13 +91,13 @@ const AuthorBarChart = ({ data: rawData }: AuthorBarChartProps) => {
         .style("top", `${e.pageY - 70}px`)
         .html(
           `<p class="name">${d.name}</p>
-        <p>${metric}: 
-          <span class="selected">
-            ${d[metric].toLocaleString()}
-          </span> 
-          / ${totalMetricValues.toLocaleString()} 
-          (${((d[metric] / totalMetricValues) * 100).toFixed(0)}%) 
-        </p>`
+          <p>${metric}: 
+            <span class="selected">
+              ${d[metric].toLocaleString()}
+            </span> 
+            / ${totalMetricValues.toLocaleString()} 
+            (${((d[metric] / totalMetricValues) * 100).toFixed(1)}%) 
+          </p>`
         );
     };
     const handleMouseOut = () => {

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
@@ -3,18 +3,10 @@ import type { ClusterNode } from "types";
 import type { AuthorDataType } from "./AuthorBarChart.type";
 
 export const getDataByAuthor = (data: ClusterNode[]): AuthorDataType[] => {
-  // Sample Selected Data
-  // 0: {name: 'Brian Munkholm ', commit: 2, insertion: 24, deletion: 78}
-  // 1: {name: 'Christian Melchior ', commit: 4, insertion: 56, deletion: 60}
-  // 2: {name: 'Nabil Hachicha ', commit: 2, insertion: 2, deletion: 2}
-
-  // delete
   if (!data.length) return [];
-  // const selectedData: ClusterNode[] = [data[0], data[11], data[43]];
 
   const authorDataObj = {};
 
-  // selectedData.forEach(({ commitNodeList }) => {
   data.forEach(({ commitNodeList }) => {
     commitNodeList.reduce((acc, { commit }) => {
       const author = commit.author.names[0];

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
@@ -2,21 +2,20 @@ import type { ClusterNode } from "types";
 
 import type { AuthorDataType } from "./AuthorBarChart.type";
 
-export const getDataByAuthor = (
-  selectedData: ClusterNode[]
-): AuthorDataType[] => {
+export const getDataByAuthor = (data: ClusterNode[]): AuthorDataType[] => {
   // Sample Selected Data
   // 0: {name: 'Brian Munkholm ', commit: 2, insertion: 24, deletion: 78}
   // 1: {name: 'Christian Melchior ', commit: 4, insertion: 56, deletion: 60}
   // 2: {name: 'Nabil Hachicha ', commit: 2, insertion: 2, deletion: 2}
 
   // delete
-  if (!selectedData.length) return [];
+  if (!data.length) return [];
   // const selectedData: ClusterNode[] = [data[0], data[11], data[43]];
 
   const authorDataObj = {};
 
-  selectedData.forEach(({ commitNodeList }) => {
+  // selectedData.forEach(({ commitNodeList }) => {
+  data.forEach(({ commitNodeList }) => {
     commitNodeList.reduce((acc, { commit }) => {
       const author = commit.author.names[0];
       const { insertions, deletions } = commit.diffStatistics;

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.scss
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.scss
@@ -29,6 +29,6 @@
     display: flex;
     flex-direction: column;
     width: 100%;
-    height: 130px;
+    // height: 130px;
   }
 }

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
@@ -1,8 +1,7 @@
-import * as React from "react";
+import type { Dispatch, SetStateAction } from "react";
 import { useState, useEffect } from "react";
 
-import type { GlobalProps } from "types/global";
-import type { ClusterNode } from "types";
+import type { ClusterNode, GlobalProps } from "types";
 
 import { ClocLineChart } from "./ClocLineChart";
 import { CommitLineChart } from "./CommitLineChart";
@@ -16,7 +15,7 @@ import { ThemeSelector } from "./ThemeSelector";
 import "./TemporalFilter.scss";
 
 type Props = GlobalProps & {
-  setFilteredData: React.Dispatch<React.SetStateAction<ClusterNode[]>>;
+  setFilteredData: Dispatch<SetStateAction<ClusterNode[]>>;
 };
 
 const TemporalFilter = ({ data, setFilteredData }: Props) => {

--- a/packages/view/src/components/VerticalClusterList/Summary/AuthorName/AuthorName.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/AuthorName/AuthorName.tsx
@@ -4,7 +4,6 @@ const AuthorName = ({ authorName }: { authorName: string }) => {
   const colorValue = getColorValue(authorName);
   return (
     <span
-      key={authorName}
       className={["name"].join(" ")}
       data-tooltip-text={authorName}
       style={{ backgroundColor: colorValue }}

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/pallete";
+@import "styles/pallete";
 
 @mixin animation {
   -webkit-transition: bottom 0.3s ease-in-out, opacity 0.3s ease-in-out;
@@ -18,139 +18,139 @@
   border-radius: $border--radius;
 }
 
-.entire {
+.summary__entire {
   width: 85%;
   margin-left: 20px;
-}
 
-.cluster {
-  align-items: center;
-  width: 85%;
-  padding: 10px 0;
-}
-
-.summary {
-  display: flex;
-  align-items: center;
-  flex-direction: row;
-  padding-top: 10px;
-  padding-bottom: 10px;
-}
-
-.nameBox {
-  display: flex;
-  justify-content: center;
-  position: relative;
-}
-
-.name {
-  @include border(50px);
-
-  display: flex;
-  width: 30px;
-  height: 30px;
-  line-height: 30px;
-  font-weight: bold;
-
-  color: $white;
-  justify-content: center;
-  text-align: center;
-  font-size: 15pt;
-  margin-left: -5px;
-  margin-right: -5px;
-
-  &:hover {
-    @include animation();
-    background-color: $gray-200 !important;
-    color: $black !important;
-    z-index: 9999;
+  .cluster {
+    align-items: center;
+    width: 85%;
+    padding: 10px 0;
   }
 
-  &:nth-child(2n) {
+  .summary {
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+
+  .nameBox {
+    display: flex;
+    justify-content: center;
+    position: relative;
+  }
+
+  .name {
+    @include border(50px);
+
+    display: flex;
+    width: 30px;
+    height: 30px;
+    line-height: 30px;
+    font-weight: bold;
+
+    color: $white;
+    justify-content: center;
+    text-align: center;
+    font-size: 15pt;
+    margin-left: -5px;
+    margin-right: -5px;
+
     &:hover {
+      @include animation();
+      background-color: $gray-200 !important;
+      color: $black !important;
+      z-index: 9999;
+    }
+
+    &:nth-child(2n) {
+      &:hover {
+        @include animation();
+        z-index: 9999;
+      }
+    }
+
+    &:nth-child(3n):hover {
       @include animation();
       z-index: 9999;
     }
   }
 
-  &:nth-child(3n):hover {
-    @include animation();
-    z-index: 9999;
-  }
-}
-
-[data-tooltip-text] {
-  &:hover {
-    position: relative;
-  }
-
-  &::after {
-    @include animation();
-    @include shadow();
-    @include border(5px);
-
-    content: attr(data-tooltip-text);
-
-    position: absolute;
-    bottom: 30%;
-    left: -9999px;
-
-    color: #ffffff;
-    font-size: 12px;
-    padding: 7px 12px;
-    margin-bottom: 10px;
-    width: auto;
-    min-width: max-content;
-    word-wrap: break-word;
-
-    opacity: 0;
-    z-index: 9999;
-  }
-
-  &:hover::after {
-    left: 100%;
-    background-color: rgba(34, 34, 34, 0.8);
-    opacity: 1;
-  }
-}
-
-.keywords {
-  width: 100%;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  margin-left: 15px;
-}
-
-.keyword {
-  margin-left: 5px;
-  margin-right: 5px;
-
-  &:hover {
-    @include animation();
-    font-weight: 700;
-    cursor: pointer;
-  }
-
-  &.large {
-    font-size: 18pt;
-    font-weight: 900;
-    line-height: 28px;
-
+  [data-tooltip-text] {
     &:hover {
+      position: relative;
+    }
+
+    &::after {
       @include animation();
-      cursor: pointer;
+      @include shadow();
+      @include border(5px);
+
+      content: attr(data-tooltip-text);
+
+      position: absolute;
+      bottom: 30%;
+      left: -9999px;
+
+      color: #ffffff;
+      font-size: 12px;
+      padding: 7px 12px;
+      margin-bottom: 10px;
+      width: auto;
+      min-width: max-content;
+      word-wrap: break-word;
+
+      opacity: 0;
+      z-index: 9999;
+    }
+
+    &:hover::after {
+      left: 100%;
+      background-color: rgba(34, 34, 34, 0.8);
+      opacity: 1;
     }
   }
 
-  &.medium {
-    font-size: 16pt;
-    font-weight: 700;
-    line-height: 28px;
+  .keywords {
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-left: 15px;
+  }
+
+  .keyword {
+    margin-left: 5px;
+    margin-right: 5px;
 
     &:hover {
       @include animation();
+      font-weight: 700;
       cursor: pointer;
+    }
+
+    &.large {
+      font-size: 18pt;
+      font-weight: 900;
+      line-height: 28px;
+
+      &:hover {
+        @include animation();
+        cursor: pointer;
+      }
+    }
+
+    &.medium {
+      font-size: 16pt;
+      font-weight: 700;
+      line-height: 28px;
+
+      &:hover {
+        @include animation();
+        cursor: pointer;
+      }
     }
   }
 }

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -46,7 +46,7 @@ const Summary = ({ data, selectedData, setSelectedData }: SummaryProps) => {
                   {cluster.summary.authorNames.map(
                     (authorArray: Array<string>) => {
                       return authorArray.map((authorName: string) => (
-                        <AuthorName authorName={authorName} />
+                        <AuthorName key={authorName} authorName={authorName} />
                       ));
                       // const colorValue = getColorValue(authorName);
                       // return (
@@ -70,8 +70,8 @@ const Summary = ({ data, selectedData, setSelectedData }: SummaryProps) => {
 
                     return (
                       <span
+                        key={`${cluster.clusterId}-${keywordObj.keyword}`}
                         className={["keyword", size].join(" ")}
-                        key={keywordObj.keyword}
                       >
                         {keywordObj.keyword}
                       </span>

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -32,7 +32,7 @@ const Summary = ({ data, selectedData, setSelectedData }: SummaryProps) => {
   };
 
   return (
-    <div className="entire">
+    <div className="summary__entire">
       {clusters.map((cluster: Cluster) => {
         return (
           <React.Fragment key={cluster.clusterId}>

--- a/packages/view/src/components/VerticalClusterList/VerticalClusterList.tsx
+++ b/packages/view/src/components/VerticalClusterList/VerticalClusterList.tsx
@@ -2,9 +2,10 @@ import React from "react";
 
 import type { GlobalProps, SelectedDataProps } from "types";
 
-import "./VerticalClusterList.scss";
 import { ClusterGraph } from "./ClusterGraph";
 import { Summary } from "./Summary";
+
+import "./VerticalClusterList.scss";
 
 type Props = GlobalProps & {
   setSelectedData: React.Dispatch<React.SetStateAction<SelectedDataProps>>;


### PR DESCRIPTION
## Related Issue
- #58 

## WorkList
- metric 변경 시 transition 추가 (a147d8cc4f67d152bcf303784010b88af68350a8)
- 툴팁 추가 (b1c6ee16ecc31bd10272aeccc400584f4a771a7c)
- 데이터 10개 초과 시 최대 10개만 렌더되도록 갯수 제한 (ea74c58ceb94804130a57f768f69ec55f6764086)
- author name y축 세부 위치 조정 (a147d8cc4f67d152bcf303784010b88af68350a8)
- bar class 내 text와 rect 그룹화 및 hover 스타일 변경 적용 (b80568d665272ee74d7b20f16e8752d0a71edfec)
- scss 네이밍 수정 및 nesting 적용 (a4950e668cc266cedba346a611563e50843ed2be d4e3028cc67327d4ffe988c9daadcfaeb4ca6e06)
- rebase 후 `Summary` 내 unique key prop error 해결 (136b3d3469328b2930dc8fce92b91cd6b54e25b8)

## Result
<img src="https://user-images.githubusercontent.com/69497936/189365495-88106406-5a57-4980-a7fa-8af597915e44.gif" width="400" />
<img src="https://user-images.githubusercontent.com/69497936/189474303-f55acde8-1915-45f2-8b29-5533d4cb35e4.gif" width="800" height="400"/>
