### PR TITLE
style(view): add Detail Component css

### DIFF
--- a/packages/view/src/components/Detail/Detail.const.ts
+++ b/packages/view/src/components/Detail/Detail.const.ts
@@ -1,0 +1,1 @@
+export const FIRST_SHOW_NUM = 5;

--- a/packages/view/src/components/Detail/Detail.hook.tsx
+++ b/packages/view/src/components/Detail/Detail.hook.tsx
@@ -1,0 +1,23 @@
+import { useState } from "react";
+
+import type { CommitNode } from "types";
+
+import { take } from "./Detail.util";
+
+type UseToggleHook = [boolean, () => void];
+const useToggleHook = (init = false): UseToggleHook => {
+  const [toggle, setToggle] = useState(init);
+  const handleToggle = () => setToggle((prev) => !prev);
+  return [toggle, handleToggle];
+};
+
+export const useCommitListHide = (commitNodeListInCluster: CommitNode[]) => {
+  const list = take(5, commitNodeListInCluster);
+  const [toggle, handleToggle] = useToggleHook();
+  const commitNodeList = toggle ? commitNodeListInCluster : list;
+  return {
+    toggle,
+    handleToggle,
+    commitNodeList,
+  };
+};

--- a/packages/view/src/components/Detail/Detail.scss
+++ b/packages/view/src/components/Detail/Detail.scss
@@ -21,3 +21,11 @@
     color: #f85149;
   }
 }
+
+.detail-summary_toggleButton {
+  border: none;
+  background: none;
+  color: #0077aa;
+  cursor: pointer;
+  margin: 10px 0px;
+}

--- a/packages/view/src/components/Detail/Detail.scss
+++ b/packages/view/src/components/Detail/Detail.scss
@@ -8,7 +8,7 @@
   padding: 10px 20px;
   box-sizing: border-box;
   width: 90%;
-  margin: 20px 0px;
+  margin-bottom: 20px;
 
   color: #8b949e;
   .detail-summary_impact {

--- a/packages/view/src/components/Detail/Detail.scss
+++ b/packages/view/src/components/Detail/Detail.scss
@@ -14,7 +14,7 @@
   .detail-summary_impact {
     color: #000000;
   }
-  .detail-summary_insersions {
+  .detail-summary_insertions {
     color: #3fba50;
   }
   .detail-summary_deletions {

--- a/packages/view/src/components/Detail/Detail.scss
+++ b/packages/view/src/components/Detail/Detail.scss
@@ -1,0 +1,23 @@
+.detail-commit_item_container {
+  list-style: inside;
+}
+
+.detail-summary_container {
+  border-radius: 10px;
+  border: 1px solid black;
+  padding: 10px 20px;
+  box-sizing: border-box;
+  width: 90%;
+  margin: 20px 0px;
+
+  color: #8b949e;
+  .detail-summary_impact {
+    color: #000000;
+  }
+  .detail-summary_insersions {
+    color: #3fba50;
+  }
+  .detail-summary_deletions {
+    color: #f85149;
+  }
+}

--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -19,14 +19,14 @@ const Detail = ({ selectedData }: { selectedData: SelectedDataProps }) => {
       </ul>
       <div className="detail-summary_container">
         Excluding merges,
-        <span className="detail-summary_impact"> {authorLength} authors</span>
+        <span className="detail-summary_impact"> {authorLength} authors </span>
         have pushed
-        <span className="detail-summary_impact"> {commitLength} commits</span>
+        <span className="detail-summary_impact"> {commitLength} commits </span>
         to main. On main,
         <span className="detail-summary_impact"> {fileLength} files </span>
         have changed and there have been
-        <span className="detail-summary_insersions"> {insertions} </span>
-        <span className="detail-summary_impact">additions</span>
+        <span className="detail-summary_insertions"> {insertions} </span>
+        <span className="detail-summary_impact">additions </span>
         and
         <span className="detail-summary_deletions"> {deletions} </span>
         <span className="detail-summary_impact">deletions.</span>

--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -2,6 +2,8 @@ import type { SelectedDataProps } from "types";
 
 import { getCommitListDetail } from "./Detail.util";
 
+import "./Detail.scss";
+
 const Detail = ({ selectedData }: { selectedData: SelectedDataProps }) => {
   if (!selectedData) return null;
   const commitNodeListInCluster = selectedData.commitNodeList;
@@ -10,14 +12,24 @@ const Detail = ({ selectedData }: { selectedData: SelectedDataProps }) => {
 
   return (
     <>
-      {commitNodeListInCluster.map((commitNode) => (
-        <div key={commitNode.commit.id}>{commitNode.commit.message}</div>
-      ))}
-      <div>
-        Excluding merges, {authorLength} authors have pushed {commitLength}
-        commits to main. On main, {fileLength} files have changed and there have
-        been
-        {insertions} additions and {deletions} deletions.
+      <ul className="detail-commit_item_container">
+        {commitNodeListInCluster.map((commitNode) => (
+          <li key={commitNode.commit.id}>{commitNode.commit.message}</li>
+        ))}
+      </ul>
+      <div className="detail-summary_container">
+        Excluding merges,
+        <span className="detail-summary_impact"> {authorLength} authors</span>
+        have pushed
+        <span className="detail-summary_impact"> {commitLength} commits</span>
+        to main. On main,
+        <span className="detail-summary_impact"> {fileLength} files </span>
+        have changed and there have been
+        <span className="detail-summary_insersions"> {insertions} </span>
+        <span className="detail-summary_impact">additions</span>
+        and
+        <span className="detail-summary_deletions"> {deletions} </span>
+        <span className="detail-summary_impact">deletions.</span>
       </div>
     </>
   );

--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -1,36 +1,46 @@
-import type { SelectedDataProps } from "types";
+import type { CommitNode, SelectedDataProps } from "types";
 
 import { getCommitListDetail } from "./Detail.util";
 
 import "./Detail.scss";
 
+const DetailSummary = ({
+  commitNodeListInCluster,
+}: {
+  commitNodeListInCluster: CommitNode[];
+}) => {
+  const { authorLength, fileLength, commitLength, insertions, deletions } =
+    getCommitListDetail({ commitNodeListInCluster });
+  return (
+    <div className="detail-summary_container">
+      Excluding merges,
+      <span className="detail-summary_impact"> {authorLength} authors </span>
+      have pushed
+      <span className="detail-summary_impact"> {commitLength} commits </span>
+      to main. On main,
+      <span className="detail-summary_impact"> {fileLength} files </span>
+      have changed and there have been
+      <span className="detail-summary_insertions"> {insertions} </span>
+      <span className="detail-summary_impact">additions </span>
+      and
+      <span className="detail-summary_deletions"> {deletions} </span>
+      <span className="detail-summary_impact">deletions.</span>
+    </div>
+  );
+};
+
 const Detail = ({ selectedData }: { selectedData: SelectedDataProps }) => {
   if (!selectedData) return null;
   const commitNodeListInCluster = selectedData.commitNodeList;
-  const { authorLength, fileLength, commitLength, insertions, deletions } =
-    getCommitListDetail({ commitNodeListInCluster });
 
   return (
     <>
+      <DetailSummary commitNodeListInCluster={commitNodeListInCluster} />
       <ul className="detail-commit_item_container">
         {commitNodeListInCluster.map((commitNode) => (
           <li key={commitNode.commit.id}>{commitNode.commit.message}</li>
         ))}
       </ul>
-      <div className="detail-summary_container">
-        Excluding merges,
-        <span className="detail-summary_impact"> {authorLength} authors </span>
-        have pushed
-        <span className="detail-summary_impact"> {commitLength} commits </span>
-        to main. On main,
-        <span className="detail-summary_impact"> {fileLength} files </span>
-        have changed and there have been
-        <span className="detail-summary_insertions"> {insertions} </span>
-        <span className="detail-summary_impact">additions </span>
-        and
-        <span className="detail-summary_deletions"> {deletions} </span>
-        <span className="detail-summary_impact">deletions.</span>
-      </div>
     </>
   );
 };

--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -1,8 +1,9 @@
 import type { CommitNode, SelectedDataProps } from "types";
 
-import { getCommitListDetail } from "./Detail.util";
-
 import "./Detail.scss";
+import { useCommitListHide } from "./Detail.hook";
+import { getCommitListDetail } from "./Detail.util";
+import { FIRST_SHOW_NUM } from "./Detail.const";
 
 const DetailSummary = ({
   commitNodeListInCluster,
@@ -30,17 +31,32 @@ const DetailSummary = ({
 };
 
 const Detail = ({ selectedData }: { selectedData: SelectedDataProps }) => {
+  const commitNodeListInCluster = selectedData?.commitNodeList ?? [];
+  const { commitNodeList, toggle, handleToggle } = useCommitListHide(
+    commitNodeListInCluster
+  );
+  const show = commitNodeListInCluster.length > FIRST_SHOW_NUM;
   if (!selectedData) return null;
-  const commitNodeListInCluster = selectedData.commitNodeList;
 
   return (
     <>
       <DetailSummary commitNodeListInCluster={commitNodeListInCluster} />
+
       <ul className="detail-commit_item_container">
-        {commitNodeListInCluster.map((commitNode) => (
+        {commitNodeList.map((commitNode) => (
           <li key={commitNode.commit.id}>{commitNode.commit.message}</li>
         ))}
       </ul>
+
+      {show && (
+        <button
+          className="detail-summary_toggleButton"
+          type="button"
+          onClick={handleToggle}
+        >
+          {toggle ? "Hide ..." : "Read More ..."}
+        </button>
+      )}
     </>
   );
 };

--- a/packages/view/src/components/Detail/Detail.util.ts
+++ b/packages/view/src/components/Detail/Detail.util.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax */
 import type { GlobalProps, CommitNode } from "types/";
 
 type GetCommitListInCluster = GlobalProps & { clusterId: number };
@@ -49,4 +50,13 @@ export const getCommitListDetail = ({
     insertions: diffStatistics.insertions.toLocaleString("en"),
     deletions: diffStatistics.deletions.toLocaleString("en"),
   };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const take = (l: number, arr: any[]) => {
+  const res = [];
+  for (const item of arr) {
+    if (res.length < l) res.push(item);
+  }
+  return res;
 };

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -159,4 +159,8 @@
   height: 280px;
   margin-top: 20px;
   overflow: auto;
+
+  &::-webkit-scrollbar {
+    display: none; /* Chrome, Safari, Opera*/
+  }
 }

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -154,3 +154,9 @@
     }
   }
 }
+
+.summary_detail_container {
+  height: 280px;
+  margin-top: 20px;
+  overflow: auto;
+}

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -48,17 +48,6 @@ const Summary = ({ data, selectedData, setSelectedData }: SummaryProps) => {
                       return authorArray.map((authorName: string) => (
                         <AuthorName key={authorName} authorName={authorName} />
                       ));
-                      // const colorValue = getColorValue(authorName);
-                      // return (
-                      //   <span
-                      //     key={authorName}
-                      //     className={["name"].join(" ")}
-                      //     data-tooltip-text={authorName}
-                      //     style={{ backgroundColor: colorValue }}
-                      //   >
-                      //     {authorName.slice(0, 1)}
-                      //   </span>
-                      // );
                     }
                   )}
                 </span>
@@ -81,9 +70,7 @@ const Summary = ({ data, selectedData, setSelectedData }: SummaryProps) => {
               </p>
             </div>
             {cluster.clusterId === clusterIds && (
-              <div
-                style={{ height: "280px", marginTop: "20px", overflow: "auto" }}
-              >
+              <div className="summary_detail_container">
                 <Detail selectedData={selectedData} />
               </div>
             )}


### PR DESCRIPTION
# Relation Issue

- closed #68 

# WorkList

[fix(view): fix Detail Util Func Smallize](https://github.com/githru/githru-vscode-ext/commit/20628c4e90b414f8496090bf96c5f8065f3232dc)
- [taejs review](https://github.com/githru/githru-vscode-ext/pull/88#issuecomment-1239540340) 를 참고하여 util 함수를 리펙토링하였습니다.

[style(view): add Detail css](https://github.com/githru/githru-vscode-ext/commit/134313937b1b27037d2d249938456d8cca869e29)
- 간단한 Detail Component css 추가하였습니다.

[style(view): add Detail Container css in Summary](https://github.com/githru/githru-vscode-ext/commit/0191d8b14b20b2bb08883c09dc4f8db5414152e1)
- Summary에서 Detail Component를 사용하기에 Detail Component의 Container에 대한 css를 추가하였습니다.

# Result

<img width="886" alt="스크린샷 2022-09-11 오후 1 35 57" src="https://user-images.githubusercontent.com/70205497/189512826-305c9e93-3bf7-4f12-b867-af84f2fea492.png">

# Question

Style에 대해 큰 적용은 없지만 
Color 관련해서 git insight를 참고하다보니 githru에서 정한 color와 결이 다른느낌이 듭니다.
이대로 독단적인 color를 사용해도 되는지 궁금합니다.