### PR TITLE
fix(engine): bugfix idendtifing nested-merge from squash-commits (#126)

### DIFF
--- a/packages/analysis-engine/src/csm.ts
+++ b/packages/analysis-engine/src/csm.ts
@@ -47,27 +47,27 @@ export const buildCSMDict = (
       while (squashTaskQueue.length > 0) {
         // get target
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const mergeCommitNode = squashTaskQueue.shift()!;
+        const squashStartNode = squashTaskQueue.shift()!;
 
         // get target's stem
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const mergeCommitStemId = mergeCommitNode.stemId!;
-        const mergeCommitStem = stemDict.get(mergeCommitStemId);
-        if (!mergeCommitStem) {
+        const squashStemId = squashStartNode.stemId!;
+        const squashStem = stemDict.get(squashStemId);
+        if (!squashStem) {
           // eslint-disable-next-line no-continue
           continue;
         }
 
         // prepare squash
-        const mergeCommitStemLastIndex = mergeCommitStem.nodes.length - 1;
-        const spliceIndex = mergeCommitStem.nodes.findIndex(
-          ({ commit: { id } }) => id === mergeCommitNode.commit.id
+        const squashStemLastIndex = squashStem.nodes.length - 1;
+        const squashStartNodeIndex = squashStem.nodes.findIndex(
+          ({ commit: { id } }) => id === squashStartNode.commit.id
         );
-        const spliceCount = mergeCommitStemLastIndex - spliceIndex + 1;
+        const spliceCount = squashStemLastIndex - squashStartNodeIndex + 1;
 
         // squash
-        const spliceCommitNodes = mergeCommitStem.nodes.splice(
-          spliceIndex,
+        const spliceCommitNodes = squashStem.nodes.splice(
+          squashStartNodeIndex,
           spliceCount
         );
         squashCommitNodes.push(...spliceCommitNodes);
@@ -83,7 +83,7 @@ export const buildCSMDict = (
           .filter(
             (node) =>
               node.stemId !== csmNode.base.stemId &&
-              node.stemId !== mergeCommitStemId
+              node.stemId !== squashStemId
           );
 
         squashTaskQueue.push(...nestedMergeParentCommits);

--- a/packages/analysis-engine/src/csm.ts
+++ b/packages/analysis-engine/src/csm.ts
@@ -72,12 +72,17 @@ export const buildCSMDict = (
         );
         squashCommitNodes.push(...spliceCommitNodes);
 
-        // check nested merge
-        const nestedMergeCommits = spliceCommitNodes
-          .map((node) => commitDict.get(node.commit.parents[1]))
-          .filter((node): node is CommitNode => node !== undefined);
+        // check nested-merge
+        const nestedMergeParentCommitIds = spliceCommitNodes
+          .filter((node) => node.commit.parents.length > 1)
+          .map((node) => node.commit.parents)
+          .reduce((pCommitIds, parents) => [...pCommitIds, ...parents], []);
+        const nestedMergeParentCommits = nestedMergeParentCommitIds
+          .map((commitId) => commitDict.get(commitId))
+          .filter((node): node is CommitNode => node !== undefined)
+          .filter((node) => node.stemId !== csmNode.base.stemId);
 
-        squashTaskQueue.push(...nestedMergeCommits);
+        squashTaskQueue.push(...nestedMergeParentCommits);
       }
 
       squashCommitNodes.sort((a, b) => a.commit.sequence - b.commit.sequence);

--- a/packages/analysis-engine/src/csm.ts
+++ b/packages/analysis-engine/src/csm.ts
@@ -80,7 +80,11 @@ export const buildCSMDict = (
         const nestedMergeParentCommits = nestedMergeParentCommitIds
           .map((commitId) => commitDict.get(commitId))
           .filter((node): node is CommitNode => node !== undefined)
-          .filter((node) => node.stemId !== csmNode.base.stemId);
+          .filter(
+            (node) =>
+              node.stemId !== csmNode.base.stemId &&
+              node.stemId !== mergeCommitStemId
+          );
 
         squashTaskQueue.push(...nestedMergeParentCommits);
       }


### PR DESCRIPTION
CSM 생성시, squash 대상 내 머지커밋 식별 로직을 아래와 같이 변경했습니다.

```
1) 현재 stem 의 루트노트부터 순회 시작
2) 머지커밋 여부 확인
  - parents.length > 1 일때
3) 머지커밋 stem 으로 따라올라가기
  - parents 중 현재 stemId 와 다른 stem 필터링
4) 머지커밋 stem 에서 squash 대상 잘라내기
  - spliceIndex + spliceCount 계산
  - splice
5) squash 대상에서 머지커밋여부 확인하기
  - 2와 동일
6) 3,4,5반복
```


## 수정후 결과데이터
![image](https://user-images.githubusercontent.com/8488507/189488578-4f73dfec-0986-4cb9-ab93-6ae1da55714c.png)

```typescript
        // ...
        {
          base: {
            commit: {
              sequence: 95,
              id: 'fd46b07926bce8745ebe83d0a66dd05fb1b4613a',
              parents: [
                'd9483784b6b946ee6fb4e2c83f4b554c753ab632',
                '3af7bc61a73bd044d5b9be7d8252ab3e21489284'
              ],
              branches: [],
              tags: [],
              author: {
                name: 'Parksunghyeon',
                email: '79688915+pshdev1030@users.noreply.github.com'
              },
              authorDate: 'Sun Sep 4 01:24:24 2022 +0900',
              committer: { name: 'GitHub', email: 'noreply@github.com' },
              committerDate: 'Sun Sep 4 01:24:24 2022 +0900',
              message: 'Merge pull request #75 from githru/all-contributors/add-pshdev1030/n/ndocs: add pshdev1030 as a contributor for code',
              differenceStatistic: {
                fileDictionary: {},
                totalDeletionCount: 0,
                totalInsertionCount: 0
              }
            },
            stemId: 'main'
          },
          source: [
            {
              commit: {
                sequence: 96,
                id: '3af7bc61a73bd044d5b9be7d8252ab3e21489284',
                parents: [
                  '851519b1cf18c512813b86f3fbcb094c4b7c821a',
                  'd9483784b6b946ee6fb4e2c83f4b554c753ab632'
                ],
                branches: [ 'upstream/all-contributors/add-pshdev1030' ],
                tags: [],
                author: {
                  name: 'Parksunghyeon',
                  email: '79688915+pshdev1030@users.noreply.github.com'
                },
                authorDate: 'Sun Sep 4 01:22:37 2022 +0900',
                committer: { name: 'GitHub', email: 'noreply@github.com' },
                committerDate: 'Sun Sep 4 01:22:37 2022 +0900',
                message: "Merge branch 'main' into all-contributors/add-pshdev1030",
                differenceStatistic: {
                  fileDictionary: {},
                  totalDeletionCount: 0,
                  totalInsertionCount: 0
                }
              },
              stemId: 'upstream/all-contributors/add-pshdev1030'
            },
            {
              commit: {
                sequence: 100,
                id: '851519b1cf18c512813b86f3fbcb094c4b7c821a',
                parents: [ '0bca4023a5b55ffd1ae3fb57d1eb8f5d893700ff' ],
                branches: [],
                tags: [],
                author: {
                  name: 'allcontributors[bot]',
                  email: '46447321+allcontributors[bot]@users.noreply.github.com'
                },
                authorDate: 'Sat Sep 3 14:33:11 2022 +0000',
                committer: { name: 'GitHub', email: 'noreply@github.com' },
                committerDate: 'Sat Sep 3 14:33:11 2022 +0000',
                message: 'docs: update .all-contributorsrc',
                differenceStatistic: {
                  fileDictionary: {},
                  totalDeletionCount: 0,
                  totalInsertionCount: 0
                }
              },
              stemId: 'upstream/all-contributors/add-pshdev1030'
            },
            {
              commit: {
                sequence: 101,
                id: '0bca4023a5b55ffd1ae3fb57d1eb8f5d893700ff',
                parents: [ '2337e8f864179eed625b1222d14d86d67b3e635d' ],
                branches: [],
                tags: [],
                author: {
                  name: 'allcontributors[bot]',
                  email: '46447321+allcontributors[bot]@users.noreply.github.com'
                },
                authorDate: 'Sat Sep 3 14:33:10 2022 +0000',
                committer: { name: 'GitHub', email: 'noreply@github.com' },
                committerDate: 'Sat Sep 3 14:33:10 2022 +0000',
                message: 'docs: update README.md',
                differenceStatistic: {
                  fileDictionary: {},
                  totalDeletionCount: 0,
                  totalInsertionCount: 0
                }
              },
              stemId: 'upstream/all-contributors/add-pshdev1030'
            }
          ]
        },
        // ...
```
=> 머지커밋인 `fd46b0` 을 CSMBase 로 두고, 하위 CSMSource 로는 `3af7bc`, `851519`, `0bca40` 가 포함됨
=> 그 중 `3af7bc` 는 sub브랜치 작업도중 main브랜치 작업내용을 merge 해온 커밋임
=> 따라서 `3af7bc` 의 parents[1] 은 main브랜치를 바라보게됨
=> 이번 PR에서 squash nested-merge 선정로직이 머지커밋의 parents[1] 을 따라올라가는게 아니라,
    모든 parents 중에서 현재 탐색중인 stem과 다른 stem만을 따라올라가도록 변경됨 
=> 즉 `3af7bc` 의 동일stem 부모를 따라올라가 squash 대상으로 묶을수있게됨

