### PR TITLE
test(engine): add sequence to fake commits

### DIFF
--- a/packages/analysis-engine/src/stem.spec.ts
+++ b/packages/analysis-engine/src/stem.spec.ts
@@ -7,118 +7,94 @@ type FakeCommitData = Pick<
   "id" | "parents" | "branches" | "committerDate"
 >;
 
-  // 1
 const fakeCommits: FakeCommitData[] = [
   {
-    id: "a1a605b38df7462e14503a2a0bb8d7453df7c8ae",
+    id: "a",
     parents: [],
     branches: [],
     committerDate: new Date("Sat Sep 3 19:30:40 2022 +0900"),
   },
-  // 2
   {
-    id: "10d086ff54073d5e9b634ffb378a3da4c15b05a9",
-    parents: ["a1a605b38df7462e14503a2a0bb8d7453df7c8ae"],
+    id: "b",
+    parents: ["a"],
     branches: [],
     committerDate: new Date("Sat Sep 3 19:30:58 2022 +0900"),
   },
-  // 3
   {
-    id: "f72a762bd84cae2da0933e637f800a30d6a1840c",
-    parents: [
-      "10d086ff54073d5e9b634ffb378a3da4c15b05a9",
-      "718352fcc051c2a8691d3d96e968d76f7bc6d846",
-    ],
+    id: "c",
+    parents: ["b", "g"],
     branches: [],
     committerDate: new Date("Sat Sep 3 19:32:44 2022 +0900"),
   },
-  // 4
   {
-    id: "699116bdd4e2de914e5f5df76cd5aac3e4b5babe",
-    parents: ["f72a762bd84cae2da0933e637f800a30d6a1840c"],
+    id: "d",
+    parents: ["c"],
     branches: [],
     committerDate: new Date("Sat Sep 3 19:32:55 2022 +0900"),
   },
-  // 5
   {
-    id: "421fb1cbabae99dc314f3076ea17c0bfd16457cb",
-    parents: [
-      "699116bdd4e2de914e5f5df76cd5aac3e4b5babe",
-      "704ba519d85c2d78914a1b7e5100bae19d36814b",
-    ],
+    id: "e",
+    parents: ["d", "i"],
     branches: [],
     committerDate: new Date("Sat Sep 3 19:33:50 2022 +0900"),
   },
-  // 6
   {
-    id: "d5fd016fac43cef3d270736cb169753495f58282",
-    parents: ["421fb1cbabae99dc314f3076ea17c0bfd16457cb"],
+    id: "f",
+    parents: ["e"],
     branches: ["main"],
     committerDate: new Date("Sat Sep 3 19:34:04 2022 +0900"),
   },
-  // 8
   {
-    id: "718352fcc051c2a8691d3d96e968d76f7bc6d846",
-    parents: ["a1a605b38df7462e14503a2a0bb8d7453df7c8ae"],
+    id: "g",
+    parents: ["a"],
     branches: [],
     committerDate: new Date("Sat Sep 3 19:31:25 2022 +0900"),
   },
-  // 9
   {
-    id: "e40da20d4c80677f272b6ed104c55b237ecaa601",
-    parents: ["718352fcc051c2a8691d3d96e968d76f7bc6d846"],
+    id: "h",
+    parents: ["g"],
     branches: [],
     committerDate: new Date("Sat Sep 3 19:33:10 2022 +0900"),
   },
-  // 10
   {
-    id: "704ba519d85c2d78914a1b7e5100bae19d36814b",
-    parents: ["e40da20d4c80677f272b6ed104c55b237ecaa601"],
+    id: "i",
+    parents: ["h"],
     branches: [],
     committerDate: new Date("Sat Sep 3 19:33:14 2022 +0900"),
   },
-  // 11
   {
-    id: "6f77d7232b08e9444791e3931acd3b1aa59abe32",
-    parents: ["f72a762bd84cae2da0933e637f800a30d6a1840c"],
+    id: "j",
+    parents: ["c"],
     branches: [],
     committerDate: new Date("Sat Sep 3 19:34:24 2022 +0900"),
   },
-  // 12
   {
-    id: "48f1d4f2a1b7b0ac21095f3aa43f35f2cb733918",
-    parents: ["6f77d7232b08e9444791e3931acd3b1aa59abe32"],
+    id: "k",
+    parents: ["j"],
     branches: [],
     committerDate: new Date("Sat Sep 3 19:34:44 2022 +0900"),
   },
-  // 13
   {
-    id: "0beb987c722838f5d4bfadfa631c0792cd83849b",
-    parents: ["48f1d4f2a1b7b0ac21095f3aa43f35f2cb733918"],
+    id: "l",
+    parents: ["k"],
     branches: [],
     committerDate: new Date("Sat Sep 3 19:34:45 2022 +0900"),
   },
-  // 14
   {
-    id: "b6d5e7979c71e7e7e7b537838c0d249ec5e63375",
-    parents: ["0beb987c722838f5d4bfadfa631c0792cd83849b"],
+    id: "m",
+    parents: ["l"],
     branches: ["dev"],
     committerDate: new Date("Sat Sep 3 19:34:57 2022 +0900"),
   },
-  // 15
   {
-    id: "dcb3b0752a99d5c9449710f7f781dc2b5bc22cd9",
-    parents: [
-      "0beb987c722838f5d4bfadfa631c0792cd83849b",
-      "704ba519d85c2d78914a1b7e5100bae19d36814b",
-    ],
+    id: "n",
+    parents: ["l", "i"],
     branches: [],
     committerDate: new Date("Sat Sep 3 19:37:35 2022 +0900"),
   },
-  // 16
   {
-    id: "04b02e3efb9e432e3ce91f1b36bbdeb284fddcf5",
-    parents: ["dcb3b0752a99d5c9449710f7f781dc2b5bc22cd9"],
+    id: "o",
+    parents: ["n"],
     branches: ["HEAD"],
     committerDate: new Date("Sat Sep 3 19:37:53 2022 +0900"),
   },
@@ -168,39 +144,31 @@ describe("stem", () => {
 
   it("should get leaf nodes", () => {
     const leafNodes = getLeafNodes(commitDict);
-    expect(leafNodes.map((node) => node.commit.id)).toEqual([
-      "d5fd016fac43cef3d270736cb169753495f58282",
-      "b6d5e7979c71e7e7e7b537838c0d249ec5e63375",
-      "04b02e3efb9e432e3ce91f1b36bbdeb284fddcf5",
-    ]);
+    expect(leafNodes.map((node) => node.commit.id)).toEqual(["f", "m", "o"]);
   });
 
   it("should make stem", () => {
     const stemDict = buildStemDict(commitDict);
     expect(stemDict.get("main")?.nodes.map((node) => node.commit.id)).toEqual([
-      "d5fd016fac43cef3d270736cb169753495f58282",
-      "421fb1cbabae99dc314f3076ea17c0bfd16457cb",
-      "699116bdd4e2de914e5f5df76cd5aac3e4b5babe",
-      "f72a762bd84cae2da0933e637f800a30d6a1840c",
-      "10d086ff54073d5e9b634ffb378a3da4c15b05a9",
-      "a1a605b38df7462e14503a2a0bb8d7453df7c8ae",
+      "f",
+      "e",
+      "d",
+      "c",
+      "b",
+      "a",
     ]);
     expect(
       stemDict.get("implicit-1")?.nodes.map((node) => node.commit.id)
-    ).toEqual([
-      "704ba519d85c2d78914a1b7e5100bae19d36814b",
-      "e40da20d4c80677f272b6ed104c55b237ecaa601",
-      "718352fcc051c2a8691d3d96e968d76f7bc6d846",
-    ]);
+    ).toEqual(["i", "h", "g"]);
     expect(stemDict.get("dev")?.nodes.map((node) => node.commit.id)).toEqual([
-      "b6d5e7979c71e7e7e7b537838c0d249ec5e63375",
-      "0beb987c722838f5d4bfadfa631c0792cd83849b",
-      "48f1d4f2a1b7b0ac21095f3aa43f35f2cb733918",
-      "6f77d7232b08e9444791e3931acd3b1aa59abe32",
+      "m",
+      "l",
+      "k",
+      "j",
     ]);
     expect(stemDict.get("HEAD")?.nodes.map((node) => node.commit.id)).toEqual([
-      "04b02e3efb9e432e3ce91f1b36bbdeb284fddcf5",
-      "dcb3b0752a99d5c9449710f7f781dc2b5bc22cd9",
+      "o",
+      "n",
     ]);
   });
 });

--- a/packages/analysis-engine/src/stem.spec.ts
+++ b/packages/analysis-engine/src/stem.spec.ts
@@ -8,8 +8,8 @@ type FakeCommitData = Pick<
   "id" | "parents" | "branches" | "committerDate"
 >;
 
-const dummy: FakeCommitData[] = [
   // 1
+const fakeCommits: FakeCommitData[] = [
   {
     id: "a1a605b38df7462e14503a2a0bb8d7453df7c8ae",
     parents: [],
@@ -125,9 +125,11 @@ const dummy: FakeCommitData[] = [
   },
 ];
 
-function createTestCommit(fakeCommitData: FakeCommitData): CommitRaw {
+function createTestCommit(
+  fakeCommitData: FakeCommitData,
+  sequence: number
+): CommitRaw {
   return {
-    sequence: 0,
     tags: [],
     author: {
       name: "",
@@ -144,6 +146,7 @@ function createTestCommit(fakeCommitData: FakeCommitData): CommitRaw {
       totalDeletionCount: 0,
       fileDictionary: {},
     },
+    sequence,
     ...fakeCommitData,
   } as CommitRaw;
 }
@@ -153,7 +156,9 @@ describe("stem", () => {
   let commitDict: Map<string, CommitNode>;
 
   beforeEach(() => {
-    commits = dummy.map(createTestCommit);
+    commits = fakeCommits.map((data, idx) =>
+      createTestCommit(data, fakeCommits.length - 1 - idx)
+    );
     commitDict = buildCommitDict(commits);
   });
 

--- a/packages/analysis-engine/src/stem.spec.ts
+++ b/packages/analysis-engine/src/stem.spec.ts
@@ -1,7 +1,6 @@
 import { buildCommitDict, getLeafNodes } from "./commit.util";
 import { buildStemDict } from "./stem";
-import { CommitNode } from "./types/CommitNode";
-import { CommitRaw } from "./types/CommitRaw";
+import { CommitNode, CommitRaw } from "./types";
 
 type FakeCommitData = Pick<
   CommitRaw,


### PR DESCRIPTION
closed #116 

- fakeCommits 배열을 CommitRaw 배열로 변환하는 과정에서, 배열의 인덱스 값으로 sequence 값이 할당되도록 수정했습니다.
  - stem 테스트에서 sequence 값이 중요하지 않기도 하고, 
  - fakeCommits 배열 각 요소에 sequence 값을 직접 넣어주면 이후에 테스트 데이터가 추가될 때 일일이 수정해주기 번거로울 것 같아 직접 넣지 않았습니다.
- fakeCommits의 id 값을 해시 값이 아닌 알파벳 순으로 지정했습니다.
  - 기존의 실제 커밋 해시 값은 알아보기 너무 어려운 것 같아 알파벳으로 수정했습니다. (그림도 함께 수정했습니다.)
  - 넘버링의 경우 sequence 값과 혼동될 것 같아 알파벳을 사용했습니다.

![STEM drawio (1)](https://user-images.githubusercontent.com/40057032/189520335-4e02eaf1-ebaa-4222-9401-10b2a9765fe9.png)
