### PR TITLE
fix(vscode): activate production mode

### DIFF
--- a/packages/vscode/src/webview-loader.ts
+++ b/packages/vscode/src/webview-loader.ts
@@ -48,7 +48,7 @@ export default class WebviewLoader implements vscode.Disposable {
                     <title>githru-vscode-ext webview</title>
                     <script>
                         window.githruData = ${data};
-                        window.isProduction = false;
+                        window.isProduction = true;
                     </script>
                 </head>
                 <body>


### PR DESCRIPTION
### Content
- `isProduction = false;`로 처리가 되어 있어서 vscode extension의 view가 mocking data로 rendering이 되고 있습니다.
- 차후 process.env === 'production'와 같은 flag로 처리하는 것도 한 방법일 것 같아 보입니다.