### PR TITLE
fix(view): improve CLS performance

### DIFF
--- a/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.scss
+++ b/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.scss
@@ -1,15 +1,15 @@
 @import "styles/app.scss";
 
-.cloc-linechart-wrap {
+.cloc-line-chart-wrap {
   height: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
   font-size: 20px;
-  margin:auto 0;
+  margin: auto 0;
 }
 
-.cloc-linechart {
+.cloc-line-chart {
   overflow: visible;
   // margin-left: 60px;
   // margin-right:60px;

--- a/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.tsx
+++ b/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.tsx
@@ -72,8 +72,8 @@ const ClocLineChart = ({ data }: { data: CommitNode[] }) => {
   }, [data]);
 
   return (
-    <div className="cloc-linechart-wrap " ref={wrapperRef}>
-      <svg className="cloc-linechart" ref={ref} />
+    <div className="cloc-line-chart-wrap " ref={wrapperRef}>
+      <svg className="cloc-line-chart" ref={ref} />
     </div>
   );
 };

--- a/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.scss
+++ b/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.scss
@@ -1,15 +1,15 @@
 @import "styles/app.scss";
 
-.commit-linechart-wrap {
+.commit-line-chart-wrap {
   height: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
   font-size: 20px;
-  margin:auto 0;
+  margin: auto 0;
 }
 
-.commit-linechart {
+.commit-line-chart {
   overflow: visible;
   // margin-left: 60px;
   // margin-right:60px;

--- a/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.tsx
+++ b/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.tsx
@@ -92,8 +92,8 @@ const CommitLineChart = ({ data }: { data: CommitNode[] }) => {
       .attr("fill", "#666666");
   }, [data]);
   return (
-    <div className="commit-linechart-wrap" ref={wrapperRef}>
-      <svg className="commit-linechart" ref={ref} />
+    <div className="commit-line-chart-wrap" ref={wrapperRef}>
+      <svg className="commit-line-chart" ref={ref} />
     </div>
   );
 };

--- a/packages/view/src/components/VerticalClusterList/VerticalClusterList.scss
+++ b/packages/view/src/components/VerticalClusterList/VerticalClusterList.scss
@@ -3,4 +3,5 @@
   flex-direction: row;
   height: 600px;
   overflow-y: scroll;
+  width: 80%;
 }

--- a/packages/view/src/styles/_reset.scss
+++ b/packages/view/src/styles/_reset.scss
@@ -48,7 +48,7 @@ html {
 *,
 *::before,
 *::after {
-  box-sizing: inherit;
+  box-sizing: border-box;
 }
 img,
 video {


### PR DESCRIPTION
## WorkList
- 초기 레이아웃 깜빡임 관련 CLS 성능 개선 (7aa9862ccf25d0b10321d88515b4f65bd9c1d499)

## Result
| | AS-IS | TO-BE| 
| :---: | :---: | :---: |
| 화면 | ![ezgif com-gif-maker-6](https://user-images.githubusercontent.com/69497936/189528013-2dae1921-d53f-48f1-a911-cea64f81423a.gif) | ![ezgif com-gif-maker-4](https://user-images.githubusercontent.com/69497936/189527896-00e8584b-0561-4d35-961d-597b1a4b10e6.gif)|
| Lighthouse <br />측정 | <img width="927" alt="스크린샷 2022-09-11 오후 10 17 00" src="https://user-images.githubusercontent.com/69497936/189529752-3fb92204-d390-41a1-bc9f-5d2b3ff6f61a.png"> | <img width="926" alt="스크린샷 2022-09-11 오후 10 17 48" src="https://user-images.githubusercontent.com/69497936/189529756-0627fe73-bef2-4475-b1f5-75982c2a3503.png"> |
| Performance | 85 | 93 |
| CLS | 0.233 | 0.059 |





<br />

## Detail
### 화면 개선
초기 로딩 시 Vertical Cluster List의 width가 존재하지 않아 Statistics가 왼쪽으로 밀려나며 깜빡거리는 현상 해결
- ![ezgif com-gif-maker-6](https://user-images.githubusercontent.com/69497936/189528013-2dae1921-d53f-48f1-a911-cea64f81423a.gif)  ![ezgif com-gif-maker-4](https://user-images.githubusercontent.com/69497936/189527896-00e8584b-0561-4d35-961d-597b1a4b10e6.gif)

<br />

### Lighthouse Performance 개션
- **Performance**: 85 -> 93
- **Cumulative Layout Shift(CLS)**: 0.233 -> 0.059
<img width="927" alt="스크린샷 2022-09-11 오후 10 17 00" src="https://user-images.githubusercontent.com/69497936/189529752-3fb92204-d390-41a1-bc9f-5d2b3ff6f61a.png">
<img width="926" alt="스크린샷 2022-09-11 오후 10 17 48" src="https://user-images.githubusercontent.com/69497936/189529756-0627fe73-bef2-4475-b1f5-75982c2a3503.png">


