### PR TITLE
fix(engine): main/master/HEAD 브랜치를 가질 경우 stemId를 main/master/HEAD로 설정

### DIFF
--- a/packages/analysis-engine/src/stem.spec.ts
+++ b/packages/analysis-engine/src/stem.spec.ts
@@ -149,7 +149,7 @@ describe("stem", () => {
 
   it("must have main/master stem", () => {
     const stemDict = buildStemDict(commitDict);
-    expect(stemDict.has("main")).toBeTruthy();
+    expect(stemDict.has("main") || stemDict.has("master")).toBeTruthy();
   });
 
   it("should make stem", () => {

--- a/packages/analysis-engine/src/stem.spec.ts
+++ b/packages/analysis-engine/src/stem.spec.ts
@@ -147,7 +147,7 @@ describe("stem", () => {
     expect(leafNodes.map((node) => node.commit.id)).toEqual(["f", "m", "o"]);
   });
 
-  it("should have main stem", () => {
+  it("must have main/master stem", () => {
     const stemDict = buildStemDict(commitDict);
     expect(stemDict.has("main")).toBeTruthy();
   });

--- a/packages/analysis-engine/src/stem.spec.ts
+++ b/packages/analysis-engine/src/stem.spec.ts
@@ -41,7 +41,7 @@ const fakeCommits: FakeCommitData[] = [
   {
     id: "f",
     parents: ["e"],
-    branches: ["main"],
+    branches: ["sub1", "main"],
     committerDate: new Date("Sat Sep 3 19:34:04 2022 +0900"),
   },
   {
@@ -145,6 +145,11 @@ describe("stem", () => {
   it("should get leaf nodes", () => {
     const leafNodes = getLeafNodes(commitDict);
     expect(leafNodes.map((node) => node.commit.id)).toEqual(["f", "m", "o"]);
+  });
+
+  it("should have main stem", () => {
+    const stemDict = buildStemDict(commitDict);
+    expect(stemDict.has("main")).toBeTruthy();
   });
 
   it("should make stem", () => {

--- a/packages/analysis-engine/src/stem.ts
+++ b/packages/analysis-engine/src/stem.ts
@@ -74,17 +74,27 @@ export function buildStemDict(
   if (mainNode) q.pushFront(mainNode);
   if (headNode) q.pushBack(headNode);
 
-  let implicitBranchNumber = 1;
+  let implicitBranchNumber = 0;
+
+  function getStemId(id: string, branches: string[]) {
+    if (branches.length === 0) {
+      implicitBranchNumber += 1;
+      return `implicit-${implicitBranchNumber}`;
+    }
+    if (id === mainNode?.commit.id) {
+      return mainNode.commit.branches.includes("main") ? "main" : "master";
+    }
+    if (id === headNode?.commit.id) {
+      return "HEAD";
+    }
+    return branches[0];
+  }
 
   while (!q.isEmpty()) {
     const tail = q.pop();
     if (!tail) continue;
 
-    const stemId =
-      tail.commit.branches[0] ?? `implicit-${implicitBranchNumber}`;
-    if (tail.commit.branches.length === 0) {
-      implicitBranchNumber += 1;
-    }
+    const stemId = getStemId(tail.commit.id, tail.commit.branches);
 
     const nodes = getStemNodes(tail.commit.id, commitDict, q, stemId);
     if (nodes.length === 0) continue;

--- a/packages/analysis-engine/src/stem.ts
+++ b/packages/analysis-engine/src/stem.ts
@@ -42,7 +42,7 @@ function compareCommitPriority(a: CommitNode, b: CommitNode): number {
   );
 }
 
-function getStemIdClosure() {
+function buildGetStemId() {
   let implicitBranchNumber = 0;
   return function (
     id: string,
@@ -95,7 +95,7 @@ export function buildStemDict(
   if (mainNode) q.pushFront(mainNode);
   if (headNode) q.pushBack(headNode);
 
-  const getStemId = getStemIdClosure();
+  const getStemId = buildGetStemId();
 
   while (!q.isEmpty()) {
     const tail = q.pop();

--- a/packages/analysis-engine/src/stem.ts
+++ b/packages/analysis-engine/src/stem.ts
@@ -1,7 +1,6 @@
 import { getLeafNodes } from "./commit.util";
 import Queue from "./queue";
-import { CommitNode } from "./types/CommitNode";
-import { Stem } from "./types/Stem";
+import { CommitNode, Stem } from "./types";
 
 export function getStemNodes(
   tailId: string,


### PR DESCRIPTION
### as-is
`commit 32a79953002b7f1aa30e56900cfc38a0fcb27287 (HEAD -> main, upstream/main, upstream/HEAD, origin/main, origin/HEAD)`
HEAD가 main 브랜치에 있을 때는, 브랜치 순서 상에서 main이 가장 앞에 있고

```
commit 5609877533d0c6e9aae6e23f01981ebb056fe2a1 (HEAD -> test-vscode)
Author: ooooorobo <orobos654@gmail.com>
Date:   Sun Sep 11 22:48:06 2022 +0900

    a

commit 32a79953002b7f1aa30e56900cfc38a0fcb27287 (upstream/main, upstream/HEAD, origin/main, origin/HEAD, main)
Author: Paul An <anpaul0615@gmail.com>
Date:   Sun Sep 11 22:22:36 2022 +0900
```
HEAD가 다른 브랜치에 놓여 있을 때는 브랜치 순서 상에서 main이 맨 앞에 있지 않습니다.

그런데 stemDict의 key는 branches[0]으로 설정되어서,
두번째 상황에서는 stemDict의 키로 main이 아니라 upstream/main이 들어가고 있습니다.
(stem.tsL84)

### to-be
commitRaw.branches 배열에서 main/master/HEAD 브랜치의 idx 위치에 관계 없이, branches 배열에 존재한다면 그것을 stemId로 사용해야 합니다.


(+)
원래는 getStemId를 buildStemDict 바깥에 정의할 생각이었는데,
이너 함수로 정의하게 되면
1. headNode, mainNode를 파라미터로 받지 않고도 바로 알 수 있고
2. implicitBranchNumber를 getStemId 안에서 관리하며 implicit branch의 id도 생성할 수 있어서
이너 함수로 정의해도 좋을 것 같았습니다.