### PR TITLE
style(view): fix authorBarChart layout sizes 

### DIFF
--- a/packages/view/src/App.scss
+++ b/packages/view/src/App.scss
@@ -1,7 +1,15 @@
+// FIXME
+body {
+  background: #212121;
+  color: #fff;
+}
+
+.head-container {
+  padding-bottom: 25px;
+}
+
 .middle-container {
   display: flex;
-  padding-top:25px;
-}
-.head-container{
-  padding-bottom: 25px;
+  padding-top: 25px;
+  height: calc(100vh - 200px);
 }

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.const.ts
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.const.ts
@@ -1,6 +1,6 @@
 export const DIMENSIONS = {
-  width: 300,
-  height: 300,
+  width: 200,
+  height: 200,
   margins: 60,
 };
 

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
@@ -1,20 +1,18 @@
 @import "styles/app.scss";
 
 .author-bar-chart-wrap {
-  width: 500px;
-  background: $gray-900;
-  height: 100%;
+  width: fit-content;
   display: flex;
   flex-direction: column;
   align-items: center;
-  font-size: 20px;
+  padding: 10px 0;
 }
 
 .author-bar-chart__select-box {
+  font-size: 10px;
   background: transparent;
   border: none;
-  margin: 50px;
-  width: 100px;
+  width: 80px;
   height: 30px;
   color: $white;
   outline: $white auto 1px;
@@ -28,7 +26,6 @@
   .axis {
     color: $white;
     font-weight: bold;
-    font-size: 11px;
 
     &.y-axis {
       text {
@@ -39,7 +36,6 @@
     &.x-axis {
       .x-axis-label {
         fill: $white;
-        font-size: 15px;
       }
     }
   }
@@ -48,7 +44,7 @@
     .bar {
       &:hover {
         rect {
-          fill: $gray-900;
+          fill: transparent;
           stroke: #0077aa;
           stroke-width: 2;
         }
@@ -61,7 +57,7 @@
       .name {
         fill: $white;
         stroke: none;
-        font-size: 14px;
+        font-size: 10px;
         text-anchor: start;
         font-weight: normal;
       }
@@ -75,7 +71,7 @@
   background: $white;
   padding: 8px 16px;
   text-align: center;
-  font-size: 15px;
+  font-size: 10px;
   line-height: 1.5;
   border-radius: 5px;
   color: $gray-900;

--- a/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.scss
+++ b/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.scss
@@ -1,0 +1,3 @@
+.file-icicle-summary {
+  height: 50%;
+}

--- a/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
+++ b/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
@@ -165,7 +165,7 @@ const FileIcicleSummary = () => {
   }, [data]);
 
   return (
-    <div>
+    <div className="file-icicle-summary">
       FileIcicleSummary
       <svg ref={$summary} />
     </div>

--- a/packages/view/src/components/Statistics/Statistics.scss
+++ b/packages/view/src/components/Statistics/Statistics.scss
@@ -1,0 +1,5 @@
+.statistics {
+  display: flex;
+  flex-direction: column;
+  gap: 5vh;
+}

--- a/packages/view/src/components/VerticalClusterList/VerticalClusterList.scss
+++ b/packages/view/src/components/VerticalClusterList/VerticalClusterList.scss
@@ -1,6 +1,6 @@
 .vertical-cluster-list {
   display: flex;
   flex-direction: row;
-  height: 600px;
+  height: 100%;
   overflow-y: scroll;
 }

--- a/packages/view/src/styles/_reset.scss
+++ b/packages/view/src/styles/_reset.scss
@@ -31,7 +31,7 @@ h3,
 h4,
 h5,
 h6 {
-  font-size: 100%;
+  font-size: 10px;
   font-weight: normal;
 }
 ul {


### PR DESCRIPTION
## WorkList
- 전반적 레이아웃 100%에 맞게 축소 (5af00a869b326483d531bad7170c5488de7884f0)
  - 100% 시 화면 레이아웃에 모든 컴포넌트가 보이지 않는 문제 존재
  - 아래 영진님께서 전달해주신 css 바탕으로 기존 전체 컴포넌트 통합 시 레이아웃 크기가 영역을 벗어나는 부분 수정하였습니다.
    ```
    .middle-container {
      height: calc(100vh - 200px);
    }
  
    // 하위 컴포넌트
    height:100%
    height:50%
    ```
  - 반응형이 정확히 적용된 것이 아니라 혹시 수정할 부분 있다면 말씀주시면 감사하겠습니다



## Result
| AS-IS | TO-BE | 
| :---: | :---: |
| <img width="1020" alt="스크린샷 2022-09-12 오전 12 15 47" src="https://user-images.githubusercontent.com/69497936/189535253-41ae348e-dc16-4c58-b192-440b377dc6a2.png"> | <img width="1019" alt="스크린샷 2022-09-12 오전 12 16 31" src="https://user-images.githubusercontent.com/69497936/189535250-696af41b-b31b-4a8a-89e0-23b78c6b7e25.png"> |


<br />
<br />

cf.  기존 `AuthorBarChart`에만 적용된 background-color를 transparent로 변경 후 [App.scss](https://github.com/githru/githru-vscode-ext/pull/141/files#diff-e9643cd30170bf1a85ad665dbaf56e9d7d6a5a22a6fbc319fe899499c2118c52)에 임시로 `background`와 `color`적용해 놓았습니다. 이 부분 추후 작업 시 제거부탁드립니다.
