### PR TITLE
feat(view): add transition in ClusterGraph

### DIFF
--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.const.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.const.ts
@@ -1,5 +1,5 @@
 export const NODE_GAP = 20;
-export const COMMIT_HEIGHT = 50;
+export const CLUSTER_HEIGHT = 50;
 export const GRAPH_WIDTH = 100;
 export const SVG_WIDTH = GRAPH_WIDTH + 4;
 export const DETAIL_HEIGHT = 300;

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
@@ -1,18 +1,18 @@
-.cluster-container {
-  .cluster-box {
+.cluster-graph_container {
+  .cluster-graph_cluster {
     rx: 5;
     stroke-width: 1;
     stroke: rgb(13, 71, 161, 0.4);
     fill: transparent;
   }
 
-  .degree-box {
+  .cluster-graph_degree {
     rx: 5;
     fill: rgb(13, 71, 161, 0.4);
   }
 
   &:hover {
-    .cluster-box {
+    .cluster-graph_cluster {
       stroke-width: 3;
     }
   }

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -56,7 +56,8 @@ const drawClusterGraph = (
     .attr("transform", (d, i) => getClusterPosition(d, i, true));
   group
     .transition()
-    .duration(500)
+    .duration(300)
+    .ease(d3.easeLinear)
     .attr("transform", (d, i) => getClusterPosition(d, i));
 
   drawClusterBox(group);
@@ -81,13 +82,11 @@ const ClusterGraph = ({
   const clusterSizes = getClusterSizes(data);
   const graphHeight = getGraphHeight(clusterSizes);
   const selectedIndex = getSelectedIndex(data, selectedData);
-  const selectedPrevIndex = useRef(-1);
 
   const clusterGraphElements = data.map((cluster, i) => ({
     cluster,
     clusterSize: clusterSizes[i],
     selected: selectedIndex,
-    prevSelected: selectedPrevIndex.current,
   }));
 
   useEffect(() => {
@@ -97,18 +96,10 @@ const ClusterGraph = ({
       );
     };
     drawClusterGraph(svgRef, clusterGraphElements, handleClickCluster);
-    selectedPrevIndex.current = selectedIndex;
     return () => {
       destroyClusterGraph(svgRef);
     };
   }, [clusterGraphElements, selectedIndex, setSelectedData]);
-
-  useEffect(() => {
-    return () => {
-      selectedPrevIndex.current = -1;
-      destroyClusterGraph(svgRef);
-    };
-  }, [data]);
 
   return <svg ref={svgRef} width={SVG_WIDTH} height={graphHeight} />;
 };

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -14,7 +14,12 @@ import {
   getSelectedIndex,
   getClusterPosition,
 } from "./ClusterGraph.util";
-import { CLUSTER_HEIGHT, GRAPH_WIDTH, SVG_WIDTH } from "./ClusterGraph.const";
+import {
+  CLUSTER_HEIGHT,
+  DETAIL_HEIGHT,
+  GRAPH_WIDTH,
+  SVG_WIDTH,
+} from "./ClusterGraph.const";
 import type {
   ClusterGraphElement,
   SVGElementSelection,
@@ -80,8 +85,9 @@ const ClusterGraph = ({
 }: ClusterGraphProps) => {
   const svgRef = useRef<SVGSVGElement>(null);
   const clusterSizes = getClusterSizes(data);
-  const graphHeight = getGraphHeight(clusterSizes);
   const selectedIndex = getSelectedIndex(data, selectedData);
+  const graphHeight =
+    getGraphHeight(clusterSizes) + (selectedIndex < 0 ? 0 : DETAIL_HEIGHT);
 
   const clusterGraphElements = data.map((cluster, i) => ({
     cluster,

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -23,7 +23,7 @@ import type {
 const drawClusterBox = (container: SVGElementSelection<SVGGElement>) => {
   container
     .append("rect")
-    .attr("class", "cluster-box")
+    .attr("class", "cluster-graph_cluster")
     .attr("width", GRAPH_WIDTH)
     .attr("height", CLUSTER_HEIGHT);
 };
@@ -32,7 +32,7 @@ const drawDegreeBox = (container: SVGElementSelection<SVGGElement>) => {
   const widthScale = d3.scaleLinear().range([0, GRAPH_WIDTH]).domain([0, 10]);
   container
     .append("rect")
-    .attr("class", "degree-box")
+    .attr("class", "cluster-graph_degree")
     .attr("width", (d) => widthScale(Math.min(d.clusterSize, 10)))
     .attr("height", CLUSTER_HEIGHT)
     .attr(
@@ -48,11 +48,11 @@ const drawClusterGraph = (
 ) => {
   const group = d3
     .select(svgRef.current)
-    .selectAll(".cluster-container")
+    .selectAll(".cluster-graph_container")
     .data(data)
     .join("g")
     .on("click", onClickCluster)
-    .attr("class", "cluster-container")
+    .attr("class", "cluster-graph_container")
     .attr("transform", (d, i) => getClusterPosition(d, i, true));
   group
     .transition()

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent, RefObject } from "react";
+import type { RefObject } from "react";
 import React, { useEffect, useRef } from "react";
 import * as d3 from "d3";
 
@@ -8,15 +8,13 @@ import "./ClusterGraph.scss";
 
 import { selectedDataUpdater } from "../VerticalClusterList.util";
 
-import { getGraphHeight, getClusterSizes } from "./ClusterGraph.util";
 import {
-  COMMIT_HEIGHT,
-  DETAIL_HEIGHT,
-  GRAPH_WIDTH,
-  NODE_GAP,
-  SVG_MARGIN,
-  SVG_WIDTH,
-} from "./ClusterGraph.const";
+  getGraphHeight,
+  getClusterSizes,
+  getSelectedIndex,
+  getClusterPosition,
+} from "./ClusterGraph.util";
+import { CLUSTER_HEIGHT, GRAPH_WIDTH, SVG_WIDTH } from "./ClusterGraph.const";
 import type {
   ClusterGraphElement,
   SVGElementSelection,
@@ -25,20 +23,9 @@ import type {
 const drawClusterBox = (container: SVGElementSelection<SVGGElement>) => {
   container
     .append("rect")
-    .attr("class", "cluster-box ")
+    .attr("class", "cluster-box")
     .attr("width", GRAPH_WIDTH)
-    .attr("height", COMMIT_HEIGHT)
-    .attr("x", SVG_MARGIN.left)
-    .attr("y", (d, i, prev) =>
-      i === 0
-        ? SVG_MARGIN.top
-        : prev[i - 1].y.baseVal.value +
-          prev[i - 1].height.baseVal.value +
-          NODE_GAP +
-          (d.selected === d.cluster.commitNodeList[0].clusterId
-            ? DETAIL_HEIGHT
-            : 0)
-    );
+    .attr("height", CLUSTER_HEIGHT);
 };
 
 const drawDegreeBox = (container: SVGElementSelection<SVGGElement>) => {
@@ -47,44 +34,31 @@ const drawDegreeBox = (container: SVGElementSelection<SVGGElement>) => {
     .append("rect")
     .attr("class", "degree-box")
     .attr("width", (d) => widthScale(Math.min(d.clusterSize, 10)))
-    .attr("height", COMMIT_HEIGHT)
+    .attr("height", CLUSTER_HEIGHT)
     .attr(
       "x",
-      (d) =>
-        SVG_MARGIN.left +
-        GRAPH_WIDTH / 2 -
-        widthScale(Math.min(d.clusterSize, 10)) / 2
-    )
-    .attr("y", (d, i, prev) =>
-      i === 0
-        ? SVG_MARGIN.top
-        : prev[i - 1].y.baseVal.value +
-          prev[i - 1].height.baseVal.value +
-          NODE_GAP +
-          (d.selected === d.cluster.commitNodeList[0].clusterId
-            ? DETAIL_HEIGHT
-            : 0)
+      (d) => (GRAPH_WIDTH - widthScale(Math.min(d.clusterSize, 10))) / 2
     );
 };
 
 const drawClusterGraph = (
   svgRef: RefObject<SVGSVGElement>,
   data: ClusterGraphElement[],
-  onClickCluster: (
-    this: SVGGElement,
-    event: MouseEvent,
-    d: ClusterGraphElement
-  ) => void
+  onClickCluster: (_: PointerEvent, d: ClusterGraphElement) => void
 ) => {
-  console.log(data);
   const group = d3
     .select(svgRef.current)
     .selectAll(".cluster-container")
     .data(data)
-    .enter()
-    .append("g")
+    .join("g")
+    .on("click", onClickCluster)
     .attr("class", "cluster-container")
-    .on("click", onClickCluster);
+    .attr("transform", (d, i) => getClusterPosition(d, i, true));
+  group
+    .transition()
+    .duration(500)
+    .attr("transform", (d, i) => getClusterPosition(d, i));
+
   drawClusterBox(group);
   drawDegreeBox(group);
 };
@@ -98,16 +72,6 @@ type ClusterGraphProps = {
   setSelectedData: React.Dispatch<React.SetStateAction<SelectedDataProps>>;
 };
 
-const getSelectedNextId = (
-  data: ClusterNode[],
-  selectedData: SelectedDataProps
-) => {
-  const selectedId = selectedData?.commitNodeList[0].clusterId;
-  const selectedNextId =
-    data.findIndex((item) => item.commitNodeList[0].clusterId === selectedId) +
-    1;
-  return data[selectedNextId]?.commitNodeList[0]?.clusterId;
-};
 const ClusterGraph = ({
   data,
   selectedData,
@@ -116,24 +80,35 @@ const ClusterGraph = ({
   const svgRef = useRef<SVGSVGElement>(null);
   const clusterSizes = getClusterSizes(data);
   const graphHeight = getGraphHeight(clusterSizes);
-  const selectedNextId = getSelectedNextId(data, selectedData);
+  const selectedIndex = getSelectedIndex(data, selectedData);
+  const selectedPrevIndex = useRef(-1);
 
   const clusterGraphElements = data.map((cluster, i) => ({
     cluster,
     clusterSize: clusterSizes[i],
-    selected: selectedNextId,
+    selected: selectedIndex,
+    prevSelected: selectedPrevIndex.current,
   }));
 
   useEffect(() => {
-    const handleClickCluster = (_: MouseEvent, d: ClusterGraphElement) =>
+    const handleClickCluster = (_: PointerEvent, d: ClusterGraphElement) => {
       setSelectedData(
         selectedDataUpdater(d.cluster, d.cluster.commitNodeList[0].clusterId)
       );
+    };
     drawClusterGraph(svgRef, clusterGraphElements, handleClickCluster);
+    selectedPrevIndex.current = selectedIndex;
     return () => {
       destroyClusterGraph(svgRef);
     };
-  }, [clusterGraphElements, setSelectedData]);
+  }, [clusterGraphElements, selectedIndex, setSelectedData]);
+
+  useEffect(() => {
+    return () => {
+      selectedPrevIndex.current = -1;
+      destroyClusterGraph(svgRef);
+    };
+  }, [data]);
 
   return <svg ref={svgRef} width={SVG_WIDTH} height={graphHeight} />;
 };

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.type.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.type.ts
@@ -6,10 +6,11 @@ export type ClusterGraphElement = {
   cluster: ClusterNode;
   clusterSize: number;
   selected?: number;
+  prevSelected?: number;
 };
 
 export type SVGElementSelection<T extends BaseType> = Selection<
-  T,
+  T | BaseType,
   ClusterGraphElement,
   SVGSVGElement | null,
   unknown

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.type.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.type.ts
@@ -6,7 +6,6 @@ export type ClusterGraphElement = {
   cluster: ClusterNode;
   clusterSize: number;
   selected?: number;
-  prevSelected?: number;
 };
 
 export type SVGElementSelection<T extends BaseType> = Selection<

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.util.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.util.ts
@@ -1,6 +1,12 @@
-import type { ClusterNode } from "types";
+import type { ClusterNode, SelectedDataProps } from "types";
 
-import { COMMIT_HEIGHT, NODE_GAP } from "./ClusterGraph.const";
+import {
+  CLUSTER_HEIGHT,
+  DETAIL_HEIGHT,
+  NODE_GAP,
+  SVG_MARGIN,
+} from "./ClusterGraph.const";
+import type { ClusterGraphElement } from "./ClusterGraph.type";
 
 export function getClusterSizes(data: ClusterNode[]) {
   return data.map((node) => node.commitNodeList.length);
@@ -8,8 +14,31 @@ export function getClusterSizes(data: ClusterNode[]) {
 
 export function getGraphHeight(clusterSizes: number[]) {
   return (
-    clusterSizes.length * COMMIT_HEIGHT +
+    clusterSizes.length * CLUSTER_HEIGHT +
     clusterSizes.length * NODE_GAP +
     NODE_GAP
   );
+}
+
+export function getClusterPosition(
+  d: ClusterGraphElement,
+  i: number,
+  isPrev = false
+) {
+  const selected = (isPrev ? d.prevSelected : d.selected) || Infinity;
+  const margin = selected >= 0 && selected < i ? DETAIL_HEIGHT : 0;
+  const x = SVG_MARGIN.left;
+  const y = SVG_MARGIN.top + i * (CLUSTER_HEIGHT + NODE_GAP) + margin;
+  return `translate(${x}, ${y})`;
+}
+
+export function getSelectedIndex(
+  data: ClusterNode[],
+  selectedData: SelectedDataProps
+) {
+  const selectedId = selectedData?.commitNodeList[0].clusterId;
+  const selectedIndex = data.findIndex(
+    (item) => item.commitNodeList[0].clusterId === selectedId
+  );
+  return selectedIndex;
 }

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.util.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.util.ts
@@ -25,7 +25,8 @@ export function getClusterPosition(
   i: number,
   isPrev = false
 ) {
-  const selected = (isPrev ? d.prevSelected : d.selected) || Infinity;
+  const curSelected = d.selected || Infinity;
+  const selected = isPrev ? Infinity : curSelected;
   const margin = selected >= 0 && selected < i ? DETAIL_HEIGHT : 0;
   const x = SVG_MARGIN.left;
   const y = SVG_MARGIN.top + i * (CLUSTER_HEIGHT + NODE_GAP) + margin;

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -18,6 +18,16 @@
   border-radius: $border--radius;
 }
 
+@mixin animate($animation, $duration, $method, $times) {
+  animation: $animation $duration $method $times;
+}
+
+@mixin keyframes($name) {
+  @keyframes #{$name} {
+    @content;
+  }
+}
+
 .summary__entire {
   width: 85%;
   margin-left: 20px;
@@ -158,9 +168,19 @@
 .summary_detail_container {
   height: 280px;
   margin-top: 20px;
-  overflow: auto;
+  overflow: scroll;
 
   &::-webkit-scrollbar {
     display: none; /* Chrome, Safari, Opera*/
   }
+
+  @include keyframes(open_detail) {
+    0% {
+      height: 0;
+    }
+    100% {
+      height: 280px;
+    }
+  }
+  @include animate(open_detail, 0.3s, linear, 1);
 }


### PR DESCRIPTION
## WorkList

b9cc3a44d20b15fe89e047b16f91aed47b543f39
- selectedData 변경 시 Detail 컴포넌트가 보여질 때 ClusterGraph에 transition 추가했습니다.
- 컴포넌트 렌더링시에 svg가 매번 리렌더링 되기 때문에, transition을 적용하기 위해선 이전 selectedIndex 값을 기억하고 있어야 합니다.
- 그렇기 때문에 useRef를 통해 이전 selected 값을 기억하도록 하고, d3의 draw 작업이 마무리되면 현재 selected 값을 selectedPrev에 저장합니다.
- 이후 해당 값을 data로 넘겨 초기 위치는 이전 selected를 기반으로, 이어지는 transition은 현재 selected 값을 기준으로 발생하도록 구현했습니다.

0ea3fc758dc429a8dc0685587e84393223cb3f7d
- ClusterGraph 의 className들을 컨벤션에 맞게 수정했습니다. (ex. cluster-graph_container)

27ae411a72ca5ab78eaf3e7d6aba42f2e3f520ab
- summary 컴포넌트에 Detail이 펼쳐지는 transition을 적용했습니다.
- Detail의 open transition과 close transition이 동시에 일어날 때, ClusterGraph와 싱크가 맞지 않는 문제가 있기 때문에 clusterGraph와 Summary의 close transition을 삭제했습니다.

7466762ecedaed3369a65b76951a1d0871a07cc2
- detail 컴포넌트가 펼쳐질 때, ClusterGraph height가 증가하지 않아 아랫부분이 잘려나가는 문제를 해결했습니다.

## Result

<div align="center">
<img src="https://user-images.githubusercontent.com/49841765/189545460-12dbfc3c-963c-4a9b-b7ed-20287286cc7a.gif" />
</div>
