### PR TITLE
fix(view): fix tempral filter overlap scroll bar

### DIFF
--- a/packages/vscode/src/webview-loader.ts
+++ b/packages/vscode/src/webview-loader.ts
@@ -52,7 +52,7 @@ export default class WebviewLoader implements vscode.Disposable {
                     </script>
                 </head>
                 <body>
-                    <div id="root" style="position: absolute;width: 100%; height: 100%; overflow: auto; margin-left:80px; left: -80px;">
+                    <div id="root"/>
                     <script src="${reactAppUri}"></script>
                     <script>
                         const vscode = acquireVsCodeApi();


### PR DESCRIPTION
webview를 loader할때 root 태그에 적용한 스타일로 인해서 temporal filter가 scroll bar를 덮는 문제를 수정했습니다.

## 📌 Result
| AS-IS | TO-BE | 
| :---: | :---: |
| <img width="700" alt="스크린샷 2022-09-12 오전 12 15 47" src="https://user-images.githubusercontent.com/81841082/189560792-f42cfdd8-1c6c-469c-a1f4-2c4801a7c8ff.png"> | <img width="700" alt="스크린샷 2022-09-12 오전 12 16 31" src="https://user-images.githubusercontent.com/81841082/189560759-5c2c93db-13c6-4925-83e4-0d0d84d91919.png"> |

## 📌 To Reviewers
Hotfix로 포함해야할지 모르겠어서 마일스톤 v0.2.0로 우선은 분류해놓았습니다. 