### PR TITLE
fix(view): update cluster graph size (width, height, gap)

### DIFF
--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.const.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.const.ts
@@ -1,6 +1,6 @@
-export const NODE_GAP = 20;
-export const CLUSTER_HEIGHT = 50;
-export const GRAPH_WIDTH = 100;
+export const NODE_GAP = 10;
+export const CLUSTER_HEIGHT = 40;
+export const GRAPH_WIDTH = 80;
 export const SVG_WIDTH = GRAPH_WIDTH + 4;
 export const DETAIL_HEIGHT = 300;
 export const SVG_MARGIN = {


### PR DESCRIPTION
## WorkList

af6a9f2534193f60f2e8e3c90517c143b37d4294
- #146 의 VerticalClusterGraph size 수정 작업을 수행했습니다.
- 기존 size는 width : height이 100 : 50 으로 2 : 1 비율이었고, 이를 40 : 80 으로 수정했습니다. (35 : 70은 너무 작음)
- ClusterGraph 만 적용했고, 지혜님 작업과 병합할 예정입니다.

## Result

| AS-IS | TO-BE | 
| :---: | :---: |
| <img width="1020" alt="스크린샷 2022-09-12 오전 12 15 47" src="https://user-images.githubusercontent.com/49841765/189594114-9e668162-d9a8-445c-b25f-83bd427706fb.png"> | <img width="1019" alt="스크린샷 2022-09-12 오전 12 16 31" src="https://user-images.githubusercontent.com/49841765/189594204-51969399-f1c4-4d91-83ca-68403ace5126.png"> |