### PR TITLE
feat(view): add cluster link line in ClusterGraph (fix issue #146)

### DIFF
--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
@@ -2,13 +2,13 @@
   .cluster-graph_cluster {
     rx: 5;
     stroke-width: 1;
-    stroke: rgb(13, 71, 161, 0.4);
+    stroke: #0077aa;
     fill: transparent;
   }
 
   .cluster-graph_degree {
     rx: 5;
-    fill: rgb(13, 71, 161, 0.4);
+    fill: #0077aa;
   }
 
   &:hover {
@@ -18,4 +18,9 @@
   }
 
   cursor: pointer;
+}
+
+.cluster-graph_link {
+  stroke: #0077aa;
+  stroke-width: 1;
 }

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
@@ -1,18 +1,18 @@
-.cluster-graph_container {
-  .cluster-graph_cluster {
+.cluster-graph__container {
+  .cluster-graph__cluster {
     rx: 5;
     stroke-width: 1;
     stroke: #0077aa;
     fill: transparent;
   }
 
-  .cluster-graph_degree {
+  .cluster-graph__degree {
     rx: 5;
     fill: #0077aa;
   }
 
   &:hover {
-    .cluster-graph_cluster {
+    .cluster-graph__cluster {
       stroke-width: 3;
     }
   }
@@ -20,7 +20,7 @@
   cursor: pointer;
 }
 
-.cluster-graph_link {
+.cluster-graph__link {
   stroke: #0077aa;
   stroke-width: 1;
 }

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -18,6 +18,8 @@ import {
   CLUSTER_HEIGHT,
   DETAIL_HEIGHT,
   GRAPH_WIDTH,
+  NODE_GAP,
+  SVG_MARGIN,
   SVG_WIDTH,
 } from "./ClusterGraph.const";
 import type {
@@ -46,6 +48,48 @@ const drawDegreeBox = (container: SVGElementSelection<SVGGElement>) => {
     );
 };
 
+const drawLink = (
+  svgRef: RefObject<SVGSVGElement>,
+  data: ClusterGraphElement[]
+) => {
+  d3.select(svgRef.current)
+    .selectAll(".cluster-graph_link")
+    .data(data)
+    .join("line")
+    .attr("class", "cluster-graph_link")
+    .attr("x1", SVG_MARGIN.left + GRAPH_WIDTH / 2)
+    .attr(
+      "y1",
+      (_, i) =>
+        SVG_MARGIN.top + (CLUSTER_HEIGHT + i * (CLUSTER_HEIGHT + NODE_GAP))
+    )
+    .attr("x2", SVG_MARGIN.left + GRAPH_WIDTH / 2)
+    .attr(
+      "y2",
+      (_, i) =>
+        SVG_MARGIN.top +
+        (CLUSTER_HEIGHT + NODE_GAP + i * (CLUSTER_HEIGHT + NODE_GAP))
+    )
+    .transition()
+    .duration(300)
+    .ease(d3.easeLinear)
+    .attr("y1", (d, i) => {
+      const initPosition =
+        SVG_MARGIN.top + (CLUSTER_HEIGHT + i * (CLUSTER_HEIGHT + NODE_GAP));
+      return (
+        initPosition + (d.selected < i && d.selected >= 0 ? DETAIL_HEIGHT : 0)
+      );
+    })
+    .attr("y2", (d, i) => {
+      const initPosition =
+        SVG_MARGIN.top +
+        (CLUSTER_HEIGHT + NODE_GAP + i * (CLUSTER_HEIGHT + NODE_GAP));
+      return (
+        initPosition + (d.selected <= i && d.selected >= 0 ? DETAIL_HEIGHT : 0)
+      );
+    });
+};
+
 const drawClusterGraph = (
   svgRef: RefObject<SVGSVGElement>,
   data: ClusterGraphElement[],
@@ -65,6 +109,7 @@ const drawClusterGraph = (
     .ease(d3.easeLinear)
     .attr("transform", (d, i) => getClusterPosition(d, i));
 
+  drawLink(svgRef, data);
   drawClusterBox(group);
   drawDegreeBox(group);
 };

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -30,7 +30,7 @@ import type {
 const drawClusterBox = (container: SVGElementSelection<SVGGElement>) => {
   container
     .append("rect")
-    .attr("class", "cluster-graph_cluster")
+    .attr("class", "cluster-graph__cluster")
     .attr("width", GRAPH_WIDTH)
     .attr("height", CLUSTER_HEIGHT);
 };
@@ -39,7 +39,7 @@ const drawDegreeBox = (container: SVGElementSelection<SVGGElement>) => {
   const widthScale = d3.scaleLinear().range([0, GRAPH_WIDTH]).domain([0, 10]);
   container
     .append("rect")
-    .attr("class", "cluster-graph_degree")
+    .attr("class", "cluster-graph__degree")
     .attr("width", (d) => widthScale(Math.min(d.clusterSize, 10)))
     .attr("height", CLUSTER_HEIGHT)
     .attr(
@@ -53,10 +53,10 @@ const drawLink = (
   data: ClusterGraphElement[]
 ) => {
   d3.select(svgRef.current)
-    .selectAll(".cluster-graph_link")
+    .selectAll(".cluster-graph__link")
     .data(data)
     .join("line")
-    .attr("class", "cluster-graph_link")
+    .attr("class", "cluster-graph__link")
     .attr("x1", SVG_MARGIN.left + GRAPH_WIDTH / 2)
     .attr(
       "y1",
@@ -97,11 +97,11 @@ const drawClusterGraph = (
 ) => {
   const group = d3
     .select(svgRef.current)
-    .selectAll(".cluster-graph_container")
+    .selectAll(".cluster-graph__container")
     .data(data)
     .join("g")
     .on("click", onClickCluster)
-    .attr("class", "cluster-graph_container")
+    .attr("class", "cluster-graph__container")
     .attr("transform", (d, i) => getClusterPosition(d, i, true));
   group
     .transition()

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.type.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.type.ts
@@ -5,7 +5,7 @@ import type { ClusterNode } from "types";
 export type ClusterGraphElement = {
   cluster: ClusterNode;
   clusterSize: number;
-  selected?: number;
+  selected: number;
 };
 
 export type SVGElementSelection<T extends BaseType> = Selection<

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.util.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.util.ts
@@ -25,8 +25,7 @@ export function getClusterPosition(
   i: number,
   isPrev = false
 ) {
-  const curSelected = d.selected || Infinity;
-  const selected = isPrev ? Infinity : curSelected;
+  const selected = isPrev ? Infinity : d.selected;
   const margin = selected >= 0 && selected < i ? DETAIL_HEIGHT : 0;
   const x = SVG_MARGIN.left;
   const y = SVG_MARGIN.top + i * (CLUSTER_HEIGHT + NODE_GAP) + margin;


### PR DESCRIPTION
## WorkList

a9e557f5c206caaa1c62262c0cc447ddabb7cfd1
- 다음 작업을 수정했습니다. 
>node 색깔도 조금 명확하게 바꾸는게 좋겠습니다. 어두운 바탕이라 그런지 잘 안보이네요.

>윗 node와 아래 node가 서로 연결된 느낌이 없어서, node와 node사이에 link (수직선?)을 넣어주던지, 혹은 아예 테이블 형태처럼 붙여주세요. 서로 이어져서 ordering되었다는 인식이 되어야 합니다.
- g element 외부에서 line element 를 추가하여 각 Node를 이어주었습니다. 

## Result

![link](https://user-images.githubusercontent.com/49841765/189654427-8cf35ec6-5377-4e46-9ba9-f920ce6318c8.gif)
