### PR TITLE
style(view): fix style issues in authorBarChart

### DIFF
--- a/packages/view/src/App.scss
+++ b/packages/view/src/App.scss
@@ -5,11 +5,11 @@ body {
 }
 
 .head-container {
-  padding-bottom: 10px;
+  margin-bottom: 30px;
 }
 
 .middle-container {
   display: flex;
-  padding-top: 25px;
+  justify-content: center;
   height: calc(100vh - 200px);
 }

--- a/packages/view/src/App.scss
+++ b/packages/view/src/App.scss
@@ -5,7 +5,7 @@ body {
 }
 
 .head-container {
-  padding-bottom: 25px;
+  padding-bottom: 10px;
 }
 
 .middle-container {

--- a/packages/view/src/App.tsx
+++ b/packages/view/src/App.tsx
@@ -26,7 +26,7 @@ const App = () => {
     setSelectedData(null);
   }, [filteredData]);
 
-  if (!data.length) return null;
+  if (!data.length || !filteredData.length) return null;
 
   return (
     <div>
@@ -41,7 +41,6 @@ const App = () => {
         />
         <Statistics data={selectedData ? [selectedData] : filteredData} />
       </div>
-      {/* <Detail selectedData={selectedData} /> */}
     </div>
   );
 };

--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -1,10 +1,11 @@
 import type { CommitNode, SelectedDataProps } from "types";
+import { getTime } from "utils/time";
 
-import "./Detail.scss";
 import { useCommitListHide } from "./Detail.hook";
 import { getCommitListDetail } from "./Detail.util";
 import { FIRST_SHOW_NUM } from "./Detail.const";
-import { getTime } from "utils/time";
+
+import "./Detail.scss";
 
 const DetailSummary = ({
   commitNodeListInCluster,

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
@@ -4,24 +4,25 @@
   width: fit-content;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  padding: 10px 0;
+  align-items: flex-end;
 }
 
 .author-bar-chart__select-box {
   font-size: 10px;
   background: transparent;
-  border: none;
-  width: 80px;
-  height: 30px;
+  border: 1px solid $white;
+  border-radius: 5px;
+  width: fit-content;
+  padding: 0 10px;
+  height: 25px;
   color: $white;
-  outline: $white auto 1px;
+  outline: none;
   text-align: center;
 }
 
 .author-bar-chart {
   overflow: visible;
-  margin: 40px;
+  margin: 20px 40px 40px;
 
   .axis {
     color: $white;

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -74,7 +74,7 @@ const AuthorBarChart = ({ data: rawData }: AuthorBarChartProps) => {
       .attr("class", "x-axis-label")
       .style(
         "transform",
-        `translate(${DIMENSIONS.width / 2}px, ${DIMENSIONS.margins}px)`
+        `translate(${DIMENSIONS.width / 2}px, ${DIMENSIONS.margins - 10}px)`
       )
       .text(`${metric} # / Total ${metric} # (%)`);
 
@@ -170,7 +170,7 @@ const AuthorBarChart = ({ data: rawData }: AuthorBarChartProps) => {
       >
         {METRIC_TYPE.map((option) => (
           <option key={option} value={option}>
-            {option}
+            {option === METRIC_TYPE[0] ? `${option} #` : option}
           </option>
         ))}
       </select>

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -65,7 +65,7 @@ const AuthorBarChart = ({ data: rawData }: AuthorBarChartProps) => {
     const yAxis = d3
       .axisLeft(yScale)
       .ticks(0)
-      .tickSizeInner(3)
+      .tickSizeInner(0)
       .tickSizeOuter(0);
     yAxisGroup.call(yAxis);
 

--- a/packages/view/src/components/Statistics/Statistics.scss
+++ b/packages/view/src/components/Statistics/Statistics.scss
@@ -2,4 +2,6 @@
   display: flex;
   flex-direction: column;
   gap: 5vh;
+  padding: 0 20px;
+  width: 300px;
 }

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -165,7 +165,11 @@ const ClusterGraph = ({
     };
   }, [clusterGraphElements, selectedIndex, setSelectedData]);
 
-  return <svg ref={svgRef} width={SVG_WIDTH} height={graphHeight} />;
+  return (
+    <div>
+      <svg ref={svgRef} width={SVG_WIDTH} height={graphHeight} />
+    </div>
+  );
 };
 
 export default ClusterGraph;

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -4,8 +4,6 @@ import * as d3 from "d3";
 
 import type { ClusterNode, SelectedDataProps } from "types";
 
-import "./ClusterGraph.scss";
-
 import { selectedDataUpdater } from "../VerticalClusterList.util";
 
 import {
@@ -25,6 +23,8 @@ import type {
   ClusterGraphElement,
   SVGElementSelection,
 } from "./ClusterGraph.type";
+
+import "./ClusterGraph.scss";
 
 const drawClusterBox = (container: SVGElementSelection<SVGGElement>) => {
   container
@@ -163,7 +163,12 @@ const ClusterGraph = ({
     return () => {
       destroyClusterGraph(svgRef);
     };
-  }, [clusterGraphElements, selectedIndex, setSelectedData]);
+  }, [
+    clusterGraphElements,
+    detailElementHeight,
+    selectedIndex,
+    setSelectedData,
+  ]);
 
   return (
     <div>

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -30,7 +30,7 @@
 
 .summary__entire {
   width: 85%;
-  margin-left: 20px;
+  margin-left: 30px;
   margin-top: 5px;
 
   .cluster {

--- a/packages/view/src/components/VerticalClusterList/VerticalClusterList.hook.ts
+++ b/packages/view/src/components/VerticalClusterList/VerticalClusterList.hook.ts
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react";
 import type { RefObject } from "react";
+import { useEffect, useState } from "react";
+
 import type { SelectedDataProps } from "types";
 
 export const useResizeObserver = (
@@ -27,7 +28,7 @@ export const useResizeObserver = (
         RO = null;
       }
     };
-  }, [ref.current, selectedData]);
+  }, [ref, selectedData]);
 
   return [height];
 };

--- a/packages/view/src/components/VerticalClusterList/VerticalClusterList.scss
+++ b/packages/view/src/components/VerticalClusterList/VerticalClusterList.scss
@@ -3,5 +3,5 @@
   flex-direction: row;
   height: 100%;
   overflow-y: scroll;
-  width: 80%;
+  width: 75%;
 }

--- a/packages/view/src/styles/_reset.scss
+++ b/packages/view/src/styles/_reset.scss
@@ -66,3 +66,37 @@ td,
 th {
   padding: 0;
 }
+
+body {
+  &::-webkit-scrollbar,
+  &::-webkit-scrollbar:horizontal {
+    display: block;
+  }
+  *::-webkit-scrollbar {
+    width: 8px;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: rgba(189, 189, 189, 0.2);
+    border: none;
+    outline: none;
+    border-radius: 10px;
+
+    &:hover {
+      background-color: rgba(189, 189, 189, 0.5);
+    }
+  }
+  *::-webkit-scrollbar-track {
+    background-color: transparent;
+    border-radius: 10px;
+  }
+
+  *:hover::-webkit-scrollbar,
+  *:hover::-webkit-scrollbar:horizontal {
+    display: block;
+  }
+
+  *::-webkit-scrollbar:horizontal {
+    display: none;
+    height: 6px;
+  }
+}

--- a/packages/view/src/utils/time.ts
+++ b/packages/view/src/utils/time.ts
@@ -2,10 +2,10 @@ const TWO_YEAR_LENGTH = 2;
 
 const SECOND_LENGTH_IN_TIME_FORMAT = 4;
 
-const utcToLocaltime = (utc: Date) => new Date(utc).toLocaleString();
+const utcToLocalTime = (utc: Date) => new Date(utc).toLocaleString();
 
 export const getTime = (utc: Date) =>
-  utcToLocaltime(utc).slice(
+  utcToLocalTime(utc).slice(
     TWO_YEAR_LENGTH,
-    utcToLocaltime.length - SECOND_LENGTH_IN_TIME_FORMAT
+    utcToLocalTime.length - SECOND_LENGTH_IN_TIME_FORMAT
   );


### PR DESCRIPTION
## Related Issue
- #147 

## WorkList
- 멘토님께서 언급해주신 부분 수정 (8760d1143980c564749b77f818c185f51d747d01 cbdb8a00e95d597e25e7c5570f0c1364f143d389 e8639fb97ba50cfa1e2680776e01072eb8db1b20)
  >  1. 윗쪽 select box에서 commit을 commit #로 바꿔주세요.
  >  2. select box의 테두리만 굵은데 나머지와 통일성 있게 바꿔주시고,
  >  3. select box 위치를 오른쪽 위로 바꿔주세요.
  >  4. select box와 chart, 아래 축 정보의 margin을 줄여주세요.
  >  5. y축의 tick은 없어도 되겠습니다.
- 전반적인 레이아웃 수정
  - Statistics에 padding 추가
  - middle-container 중앙에 위치하도록 수정
- 스크롤바 스타일 수정 (bdc46c369e9762cd8fdd61b7ec070c231d50a623)
   - 기존 전반적 스타일과 통일감 없이 튀는 스크롤바 스타일 통일감 있게 변경

## Result
- AS-IS
  <img width="1512" alt="스크린샷 2022-09-12 오후 10 52 31" src="https://user-images.githubusercontent.com/69497936/189698278-dcb4e2bd-569b-4264-829e-f4a086740c9e.png">


- TO-BE
  <img width="1512" alt="스크린샷 2022-09-13 오전 12 40 03" src="https://user-images.githubusercontent.com/69497936/189698197-95dce60d-424f-4884-8ddd-5690373f439a.png">
