### PR TITLE
style(view): fix style issues in detail component

### DIFF
--- a/packages/view/src/components/Detail/Detail.scss
+++ b/packages/view/src/components/Detail/Detail.scss
@@ -1,17 +1,20 @@
-.detail-summary_container {
+@import "styles/app";
+
+.detail__summary__container {
   display: flex;
   justify-content: space-between;
+  margin: 15px 0 20px;
   align-items: center;
-  margin-top: 14px;
-  
+  font-size: 14px;
+
   .divider {
     margin-right: 1rem;
     flex-grow: 10;
     height: 0;
-    border: 1px solid rgb(255, 255, 255);
+    border: 1px solid $white;
   }
 
-  .text {
+  .detail__summary {
     flex-grow: 0.1;
   }
 
@@ -24,24 +27,41 @@
   }
 }
 
-.detail-commit_item_container {
-  li {
-    list-style-type: none;
+.detail__commit-list__container {
+  padding: 0 20px;
+  font-size: 14px;
+
+  .commit-item {
     display: flex;
-    margin-top: 4px;
-    
-    span {
-      color: rgb(177, 177, 177);
-    }
-    
     justify-content: space-between;
+    margin-top: 4px;
+    color: $gray-600;
+
+    .commit-detail {
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 1;
+      overflow: hidden;
+
+      .message {
+        color: $white;
+      }
+    }
+    .commit-id {
+      padding-left: 50px;
+    }
   }
 }
 
-.detail-summary_toggleButton {
+.toggle-button {
+  display: flex;
+  margin: 20px auto 0;
   border: none;
   background: none;
   color: #0077aa;
   cursor: pointer;
-  margin: 10px 0px;
+
+  &:hover {
+    color: $gray-300;
+  }
 }

--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -1,5 +1,5 @@
 import type { CommitNode, SelectedDataProps } from "types";
-import { getTime } from "utils/time";
+import { getTime } from "utils";
 
 import { useCommitListHide } from "./Detail.hook";
 import { getCommitListDetail } from "./Detail.util";
@@ -7,17 +7,19 @@ import { FIRST_SHOW_NUM } from "./Detail.const";
 
 import "./Detail.scss";
 
-const DetailSummary = ({
-  commitNodeListInCluster,
-}: {
+type DetailSummaryProps = {
   commitNodeListInCluster: CommitNode[];
-}) => {
+};
+type DetailProps = { selectedData: SelectedDataProps };
+
+const DetailSummary = ({ commitNodeListInCluster }: DetailSummaryProps) => {
   const { authorLength, fileLength, commitLength, insertions, deletions } =
     getCommitListDetail({ commitNodeListInCluster });
+
   return (
-    <div className="detail-summary_container">
+    <div className="detail__summary__container">
       <div className="divider" />
-      <div className="text">
+      <div className="detail__summary">
         <strong>{authorLength}</strong> authors |{" "}
         <strong>{commitLength}</strong> commits | <strong>{fileLength}</strong>{" "}
         changed files | <strong className="insertions">{insertions}</strong>{" "}
@@ -28,44 +30,38 @@ const DetailSummary = ({
   );
 };
 
-const Detail = ({ selectedData }: { selectedData: SelectedDataProps }) => {
+const Detail = ({ selectedData }: DetailProps) => {
   const commitNodeListInCluster = selectedData?.commitNodeList ?? [];
   const { commitNodeList, toggle, handleToggle } = useCommitListHide(
     commitNodeListInCluster
   );
-  const show = commitNodeListInCluster.length > FIRST_SHOW_NUM;
+  const isShow = commitNodeListInCluster.length > FIRST_SHOW_NUM;
+
   if (!selectedData) return null;
 
   return (
     <>
       <DetailSummary commitNodeListInCluster={commitNodeListInCluster} />
-
-      <ul className="detail-commit_item_container">
+      <ul className="detail__commit-list__container">
         {commitNodeList.map(({ commit }) => {
           const { id, message, author, authorDate } = commit;
-
           return (
-            <li key={id} className="detail-commit_item">
-              <div>
-                - {message},{" "}
+            <li key={id} className="commit-item">
+              <div className="commit-detail">
+                <span className="message">{message}, </span>
                 <span>
                   {author.names[0]}, {getTime(authorDate)}
                 </span>
               </div>
-              <div>
-                <span>{id}</span>
+              <div className="commit-id">
+                <span>{id.slice(0, 6)}</span>
               </div>
             </li>
           );
         })}
       </ul>
-
-      {show && (
-        <button
-          className="detail-summary_toggleButton"
-          type="button"
-          onClick={handleToggle}
-        >
+      {isShow && (
+        <button type="button" className="toggle-button" onClick={handleToggle}>
           {toggle ? "Hide ..." : "Read More ..."}
         </button>
       )}

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
@@ -1,6 +1,6 @@
 @import "styles/app.scss";
 
-.author-bar-chart-wrap {
+.author-bar-chart__container {
   width: fit-content;
   display: flex;
   flex-direction: column;

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -163,7 +163,7 @@ const AuthorBarChart = ({ data: rawData }: AuthorBarChartProps) => {
   };
 
   return (
-    <div className="author-bar-chart-wrap">
+    <div className="author-bar-chart__container">
       <select
         className="author-bar-chart__select-box"
         onChange={handleChangeMetric}

--- a/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
+++ b/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
@@ -3,7 +3,7 @@ import type { HierarchyRectangularNode } from "d3";
 import type { RefObject } from "react";
 import { useEffect, useRef } from "react";
 
-import type { ClusterNode } from "../../../types";
+import type { ClusterNode } from "types";
 
 import { getFileChangesTree } from "./FileIcicleSummary.util";
 import type { FileChangesNode } from "./FileIcicleSummary.type";

--- a/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.util.ts
+++ b/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.util.ts
@@ -1,4 +1,4 @@
-import type { ClusterNode } from "../../../types";
+import type { ClusterNode } from "types";
 
 import type {
   FileChanges,

--- a/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.scss
+++ b/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.scss
@@ -11,10 +11,6 @@
 
 .cloc-line-chart {
   overflow: visible;
-  // margin-left: 60px;
-  // margin-right:60px;
-  // margin-bottom: 60px;
-  // margin-top:60px;
   background: $gray-300;
   margin: 10px;
   padding-bottom: 5px;

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
@@ -1,4 +1,12 @@
 .cluster-graph__container {
+  cursor: pointer;
+
+  &:hover {
+    .cluster-graph__cluster {
+      stroke-width: 3;
+    }
+  }
+
   .cluster-graph__cluster {
     rx: 5;
     stroke-width: 1;
@@ -10,14 +18,6 @@
     rx: 5;
     fill: #0077aa;
   }
-
-  &:hover {
-    .cluster-graph__cluster {
-      stroke-width: 3;
-    }
-  }
-
-  cursor: pointer;
 }
 
 .cluster-graph__link {

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -1,4 +1,4 @@
-@import "styles/pallete";
+@import "styles/app";
 
 @mixin animation {
   -webkit-transition: bottom 0.3s ease-in-out, opacity 0.3s ease-in-out;
@@ -28,18 +28,16 @@
   }
 }
 
-.summary__entire {
+.cluster-summary__container {
   width: 85%;
   margin-left: 30px;
   margin-top: 5px;
 
-  .cluster {
-    align-items: center;
-    width: 85%;
+  .cluster-summary__cluster {
     padding: 5px 0;
   }
 
-  .summary {
+  .cluster-summary__toggle-contents-button {
     width: 100%;
     display: flex;
     align-items: center;
@@ -50,18 +48,22 @@
     background-color: transparent;
     cursor: pointer;
     color: $white;
+
+    &:hover {
+      border-radius: 40px;
+      background-color: lighten($gray-800, 5);
+    }
   }
 
-  .summary:hover {
-    border-radius: 40px;
-    background-color: lighten($gray-600, 5);
-  }
-
-  .text-wrapper {
+  .cluster-summary__toggle-contents-container {
     display: flex;
     align-items: center;
     text-overflow: ellipsis;
-    width: 85%;
+    width: 100%;
+  }
+
+  :hover .collapsible-button {
+    visibility: visible;
   }
 
   .collapsible-button {
@@ -69,23 +71,17 @@
     border: none;
     font-size: 18px;
     color: $blue-light-600;
-    display: none;
-    cursor: pointer;
+    visibility: hidden;
   }
 
-  .collapsible-button--shown {
+  .collapsible-button-shown {
     background-color: transparent;
     border: none;
     font-size: 18px;
     color: $blue-light-600;
-    cursor: pointer;
   }
 
-  :hover .collapsible-button {
-    display: block;
-  }
-
-  .nameBox {
+  .name-box {
     display: flex;
     justify-content: center;
     position: relative;
@@ -143,7 +139,7 @@
       bottom: 30%;
       left: -9999px;
 
-      color: #ffffff;
+      color: $white;
       font-size: 12px;
       padding: 0px 12px;
       margin-bottom: 10px;
@@ -162,57 +158,62 @@
     }
   }
 
-  .contents {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    margin-left: 15px;
-    cursor: pointer;
-  }
+  .cluster-summary__contents {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
 
-  .keyword {
-    margin-left: 5px;
-    margin-right: 5px;
-
-    &:hover {
-      @include animation();
-      font-weight: 700;
+    .commit-message {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      margin-left: 15px;
       cursor: pointer;
     }
-
-    &.large {
-      font-size: 18pt;
-      font-weight: 900;
-      line-height: 28px;
-
-      &:hover {
-        @include animation();
-        cursor: pointer;
-      }
-    }
-
-    &.medium {
-      font-size: 16pt;
-      font-weight: 700;
-      line-height: 28px;
-
-      &:hover {
-        @include animation();
-        cursor: pointer;
-      }
+    .more-commit-count {
+      font-size: 12px;
     }
   }
+
+  // .keyword {
+  //   margin-left: 5px;
+  //   margin-right: 5px;
+
+  //   &:hover {
+  //     @include animation();
+  //     font-weight: 700;
+  //     cursor: pointer;
+  //   }
+
+  //   &.large {
+  //     font-size: 18pt;
+  //     font-weight: 900;
+  //     line-height: 28px;
+
+  //     &:hover {
+  //       @include animation();
+  //       cursor: pointer;
+  //     }
+  //   }
+
+  //   &.medium {
+  //     font-size: 16pt;
+  //     font-weight: 700;
+  //     line-height: 28px;
+
+  //     &:hover {
+  //       @include animation();
+  //       cursor: pointer;
+  //     }
+  //   }
+  // }
 }
 
-.summary_detail_container {
+.cluster-summary__detail__container {
+  overflow: overlay;
   max-height: 280px;
-  overflow: auto;
-  // height: 280px;
-  // margin-top: 20px;
-  // overflow: scroll;
-  &::-webkit-scrollbar {
-    display: none; /* Chrome, Safari, Opera*/
-  }
+  padding: 0 30px;
+  margin-bottom: 20px;
 
   @include keyframes(open_detail) {
     0% {

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -33,56 +33,58 @@ const Summary = forwardRef<HTMLDivElement, SummaryProps>(
     };
 
     return (
-      <div className="summary__entire">
+      <div className="cluster-summary__container">
         {clusters.map((cluster: Cluster) => {
           return (
-            <React.Fragment key={cluster.clusterId}>
-              <div role="presentation" className="cluster">
-                <button
-                  className="summary"
-                  type="button"
-                  onClick={() => onClickClusterSummary(cluster.clusterId)}
-                >
-                  <div className="text-wrapper">
-                    <span className="nameBox">
-                      {cluster.summary.authorNames.map(
-                        (authorArray: Array<string>) => {
-                          return authorArray.map((authorName: string) => (
-                            <AuthorName
-                              key={authorName}
-                              authorName={authorName}
-                            />
-                          ));
-                        }
-                      )}
+            <div
+              role="presentation"
+              className="cluster-summary__cluster"
+              key={cluster.clusterId}
+            >
+              <button
+                type="button"
+                className="cluster-summary__toggle-contents-button"
+                onClick={() => onClickClusterSummary(cluster.clusterId)}
+              >
+                <div className="cluster-summary__toggle-contents-container">
+                  <span className="name-box">
+                    {cluster.summary.authorNames.map(
+                      (authorArray: Array<string>) => {
+                        return authorArray.map((authorName: string) => (
+                          <AuthorName
+                            key={authorName}
+                            authorName={authorName}
+                          />
+                        ));
+                      }
+                    )}
+                  </span>
+                  <div className="cluster-summary__contents">
+                    <span className="commit-message">
+                      {cluster.summary.content.message}
                     </span>
-                    <span className="contents">
-                      {`${cluster.summary.content.message.slice(0, 70)} ${
-                        cluster.summary.content.message.length > 70 ? "..." : ""
-                      } ${
-                        cluster.summary.content.count > 0
-                          ? `+ ${cluster.summary.content.count} more`
-                          : ""
-                      } `}
+                    <span className="more-commit-count">
+                      {cluster.summary.content.count > 0 &&
+                        ` + ${cluster.summary.content.count} more`}
                     </span>
                   </div>
-                  {cluster.clusterId === clusterIds ? (
-                    <button className="collapsible-button--shown" type="button">
-                      ▲
-                    </button>
-                  ) : (
-                    <button className="collapsible-button" type="button">
-                      ▼
-                    </button>
-                  )}
-                </button>
-                {cluster.clusterId === clusterIds && (
-                  <div className="summary_detail_container" ref={ref}>
-                    <Detail selectedData={selectedData} />
-                  </div>
+                </div>
+                {cluster.clusterId === clusterIds ? (
+                  <button className="collapsible-button-shown" type="button">
+                    ▲
+                  </button>
+                ) : (
+                  <button className="collapsible-button" type="button">
+                    ▼
+                  </button>
                 )}
-              </div>
-            </React.Fragment>
+              </button>
+              {cluster.clusterId === clusterIds && (
+                <div className="cluster-summary__detail__container" ref={ref}>
+                  <Detail selectedData={selectedData} />
+                </div>
+              )}
+            </div>
           );
         })}
       </div>

--- a/packages/view/src/styles/_reset.scss
+++ b/packages/view/src/styles/_reset.scss
@@ -31,7 +31,7 @@ h3,
 h4,
 h5,
 h6 {
-  font-size: 10px;
+  font-size: inherit;
   font-weight: normal;
 }
 ul {
@@ -68,6 +68,8 @@ th {
 }
 
 body {
+  font-size: 10px;
+
   &::-webkit-scrollbar,
   &::-webkit-scrollbar:horizontal {
     display: block;

--- a/packages/view/src/utils/index.ts
+++ b/packages/view/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./time";


### PR DESCRIPTION
## Related Issue, PR
- #146 
- #154 

## WorkList
- css class 네이밍 BEM 컨벤션으로 수정
- 최상위 감싸는 컴포넌트 네이밍 `container`로 통일 (기존 wrap, wrapper, entire 등 혼재)
- Summary 컴포넌트 내 불필요한 depth 및 조건문 제거
- 전반적인 Detail 컴포넌트 스타일 수정
  - Detail 컴포넌트 내 [text ellipsis 이슈](https://github.com/githru/githru-vscode-ext/pull/154) 해결
  - 커밋 해시 6자리로 수정
  - 컴포넌트 간 padding 및 margin 조절
  - more commit count 내용 아이콘 옆으로 이동
  - more 버튼 hover 시 색 추가
  - 스크롤바 때문에 내용이 밀려나는 이슈 해결
     
| AS-IS | TO-BE |
|:---:|:---:|
|<img width="800" src="https://user-images.githubusercontent.com/69497936/189802779-908ccf04-a98f-4551-9a4e-bcb4a3845f6f.png">|<img width="800" src="https://user-images.githubusercontent.com/69497936/189802946-a32ea377-089a-4406-9d25-1edb321d1a84.png">|
|![ezgif com-gif-maker-8](https://user-images.githubusercontent.com/69497936/189803499-ef0f13a7-2ff1-4537-8943-10e792a81e15.gif)| ![ezgif com-gif-maker-7](https://user-images.githubusercontent.com/69497936/189803382-1b5b3392-0615-4c1c-9f66-42dc0c2c9e54.gif)|

<br />

## Result

- AS-IS
![image](https://user-images.githubusercontent.com/69497936/189803931-bede4515-762c-4393-8ed3-d5fb4008df64.png)

- TO-BE
![image](https://user-images.githubusercontent.com/69497936/189803992-fce27848-7f51-4554-b20e-c3a49f405301.png)
