### PR TITLE
fix(view): modify variable height ClusterGraph transition & update scroll

### DIFF
--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -163,7 +163,12 @@ const ClusterGraph = ({
     return () => {
       destroyClusterGraph(svgRef);
     };
-  }, [clusterGraphElements, selectedIndex, setSelectedData]);
+  }, [
+    clusterGraphElements,
+    detailElementHeight,
+    selectedIndex,
+    setSelectedData,
+  ]);
 
   return <svg ref={svgRef} width={SVG_WIDTH} height={graphHeight} />;
 };

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -56,7 +56,9 @@ const drawLink = (
     .selectAll(".cluster-graph__link")
     .data(data)
     .join("line")
-    .attr("class", "cluster-graph__link")
+    .attr("class", (_, i) =>
+      data.length - 1 <= i ? "cluster-graph__last_link" : "cluster-graph__link"
+    )
     .attr("x1", SVG_MARGIN.left + GRAPH_WIDTH / 2)
     .attr(
       "y1",
@@ -71,7 +73,7 @@ const drawLink = (
         (CLUSTER_HEIGHT + NODE_GAP + i * (CLUSTER_HEIGHT + NODE_GAP))
     )
     .transition()
-    .duration(100)
+    .duration(300 * (detailElementHeight / 280))
     .ease(d3.easeLinear)
     .attr("y1", (d, i) => {
       const initPosition =

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -4,6 +4,8 @@ import * as d3 from "d3";
 
 import type { ClusterNode, SelectedDataProps } from "types";
 
+import "./ClusterGraph.scss";
+
 import { selectedDataUpdater } from "../VerticalClusterList.util";
 
 import {
@@ -23,8 +25,6 @@ import type {
   ClusterGraphElement,
   SVGElementSelection,
 } from "./ClusterGraph.type";
-
-import "./ClusterGraph.scss";
 
 const drawClusterBox = (container: SVGElementSelection<SVGGElement>) => {
   container
@@ -71,7 +71,7 @@ const drawLink = (
         (CLUSTER_HEIGHT + NODE_GAP + i * (CLUSTER_HEIGHT + NODE_GAP))
     )
     .transition()
-    .duration(300)
+    .duration(100)
     .ease(d3.easeLinear)
     .attr("y1", (d, i) => {
       const initPosition =
@@ -163,18 +163,9 @@ const ClusterGraph = ({
     return () => {
       destroyClusterGraph(svgRef);
     };
-  }, [
-    clusterGraphElements,
-    detailElementHeight,
-    selectedIndex,
-    setSelectedData,
-  ]);
+  }, [clusterGraphElements, selectedIndex, setSelectedData]);
 
-  return (
-    <div>
-      <svg ref={svgRef} width={SVG_WIDTH} height={graphHeight} />
-    </div>
-  );
+  return <svg ref={svgRef} width={SVG_WIDTH} height={graphHeight} />;
 };
 
 export default ClusterGraph;

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -30,7 +30,7 @@
 
 .cluster-summary__container {
   width: 85%;
-  margin-left: 30px;
+  margin-left: 20px;
   margin-top: 5px;
 
   .cluster-summary__cluster {
@@ -217,11 +217,15 @@
 
   @include keyframes(open_detail) {
     0% {
-      height: 0;
+      max-height: 0;
     }
     100% {
-      height: 280px;
+      max-height: 280px;
     }
   }
-  @include animate(open_detail, 0.3s, linear, 1);
+  @include animate(open_detail, 0.3s, ease-in, 1);
+}
+
+.summary-detail__wrapper {
+  max-height: 280px;
 }

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -212,8 +212,6 @@
 .cluster-summary__detail__container {
   overflow: overlay;
   max-height: 280px;
-  padding: 0 30px;
-  margin-bottom: 20px;
 
   @include keyframes(open_detail) {
     0% {
@@ -228,4 +226,8 @@
 
 .summary-detail__wrapper {
   max-height: 280px;
+  padding: 0 30px;
+  padding-top: 5px;
+  padding-bottom: 20px;
+  box-sizing: border-box;
 }

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -221,7 +221,7 @@
       max-height: 280px;
     }
   }
-  @include animate(open_detail, 0.3s, ease-in, 1);
+  @include animate(open_detail, 0.3s, linear, 1);
 }
 
 .summary-detail__wrapper {

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -83,17 +83,19 @@ const Summary = forwardRef<HTMLDivElement, SummaryProps>(
                     </button>
                   )}
                 </div>
-                {cluster.clusterId === clusterIds && (
-                  <div
-                    className="cluster-summary__detail__container"
-                    ref={scrollRef}
-                  >
-                    <div className="summary-detail__wrapper" ref={ref}>
+              </button>
+              {cluster.clusterId === clusterIds && (
+                <div
+                  className="cluster-summary__detail__container"
+                  ref={scrollRef}
+                >
+                  <div ref={ref}>
+                    <div className="summary-detail__wrapper">
                       <Detail selectedData={selectedData} />
                     </div>
                   </div>
-                )}
-              </button>
+                </div>
+              )}
             </div>
           );
         })}

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import React, { forwardRef, useRef, useEffect } from "react";
 
 import type { ClusterNode, SelectedDataProps } from "types";
 import { Detail } from "components";
@@ -20,6 +20,7 @@ type SummaryProps = {
 const Summary = forwardRef<HTMLDivElement, SummaryProps>(
   ({ data, selectedData, setSelectedData }, ref) => {
     const clusters = getInitData({ data });
+    const scrollRef = useRef<HTMLDivElement>(null);
 
     const getClusterIds = (_selectedData: SelectedDataProps) => {
       if (!_selectedData) return null;
@@ -31,6 +32,10 @@ const Summary = forwardRef<HTMLDivElement, SummaryProps>(
       const selected = getClusterById(data, clusterId);
       setSelectedData(selectedDataUpdater(selected, clusterId));
     };
+
+    useEffect(() => {
+      scrollRef.current?.scrollIntoView({ block: "center" });
+    }, [selectedData]);
 
     return (
       <div className="cluster-summary__container">
@@ -79,7 +84,10 @@ const Summary = forwardRef<HTMLDivElement, SummaryProps>(
                   )}
                 </div>
                 {cluster.clusterId === clusterIds && (
-                  <div className="cluster-summary__detail__container">
+                  <div
+                    className="cluster-summary__detail__container"
+                    ref={scrollRef}
+                  >
                     <div className="summary-detail__wrapper" ref={ref}>
                       <Detail selectedData={selectedData} />
                     </div>

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -68,22 +68,24 @@ const Summary = forwardRef<HTMLDivElement, SummaryProps>(
                         ` + ${cluster.summary.content.count} more`}
                     </span>
                   </div>
+                  {cluster.clusterId === clusterIds ? (
+                    <button className="collapsible-button-shown" type="button">
+                      ▲
+                    </button>
+                  ) : (
+                    <button className="collapsible-button" type="button">
+                      ▼
+                    </button>
+                  )}
                 </div>
-                {cluster.clusterId === clusterIds ? (
-                  <button className="collapsible-button-shown" type="button">
-                    ▲
-                  </button>
-                ) : (
-                  <button className="collapsible-button" type="button">
-                    ▼
-                  </button>
+                {cluster.clusterId === clusterIds && (
+                  <div className="cluster-summary__detail__container">
+                    <div className="summary-detail__wrapper" ref={ref}>
+                      <Detail selectedData={selectedData} />
+                    </div>
+                  </div>
                 )}
               </button>
-              {cluster.clusterId === clusterIds && (
-                <div className="cluster-summary__detail__container" ref={ref}>
-                  <Detail selectedData={selectedData} />
-                </div>
-              )}
             </div>
           );
         })}


### PR DESCRIPTION
## WorkList

82539a72e6a515d6178b17e4d691ec60713bfd96
- https://github.com/githru/githru-vscode-ext/pull/154#pullrequestreview-1104405275 에서 언급된 문제를 개선했습니다.
- 하지만, height가 결정된 이후에 다시 한 번 변경되는 작업을 거쳐야만 가변 길이 transition이 동작하기 때문에, 완벽히 개선하지는 못했습니다.
- summary-detail__container와 detail 컴포넌트 사이에 transition이 발생하지 않는 div 태그를 추가하여 height 값이 한 번만 변경되어 resizeObserver가 감지할 수 있도록 수정했습니다.

14091cee368a3e543e0a8b9a1ddf2cfe73a2c075
| AS-IS | TO-BE | 
| :---: | :---: |
| <img width="400" alt="스크린샷 2022-09-12 오전 12 15 47" src="https://user-images.githubusercontent.com/49841765/189832692-f59cd20b-83d6-47b0-8aff-2b6fbd0bc153.gif"> | <img width="400" alt="스크린샷 2022-09-12 오전 12 16 31" src="https://user-images.githubusercontent.com/49841765/189832732-8feb136f-6018-46d5-81fa-d326bde0321c.gif"> |

- Summary에서 height가 큰 detail을 연 상태에서 아랫쪽에서 height가 작은 detail을 열게되면, 전체 height의 차이가 생겨 열린 detail이 위로 숨어버리는 문제가 있었습니다.
- git graph를 참조해본 결과, 어떤 detail이 열리든 scroll 가운데로 고정하는 방식을 택했었고, 이를 반영해보았습니다.

## Fix

https://github.com/githru/githru-vscode-ext/pull/159#issuecomment-1245006810 문제 수정완료했습니다 :)

![fix](https://user-images.githubusercontent.com/49841765/189845290-27a06e82-2a74-4f79-940d-c135a3a3d243.gif)

