### PR TITLE
feat(view): fixed summary height and delete animation

### DIFF
--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -213,19 +213,19 @@
   overflow: overlay;
   max-height: 280px;
 
-  @include keyframes(open_detail) {
-    0% {
-      max-height: 0;
-    }
-    100% {
-      max-height: 280px;
-    }
-  }
-  @include animate(open_detail, 0.3s, linear, 1);
+  // @include keyframes(open_detail) {
+  //   0% {
+  //     max-height: 0;
+  //   }
+  //   100% {
+  //     max-height: 280px;
+  //   }
+  // }
+  // @include animate(open_detail, 0.3s, linear, 1);
 }
 
 .summary-detail__wrapper {
-  max-height: 280px;
+  height: 220px;
   padding: 0 30px;
   padding-top: 5px;
   padding-bottom: 20px;


### PR DESCRIPTION
## Related PR
- #159 

## WorkList
> git graph를 참조해본 결과, 어떤 detail이 열리든 scroll 가운데로 고정하는 방식을 택했었고, 이를 반영해보았습니다. (@vgihan)

- summary heigth 고정
  - 기존 기한님이 참고하신 git-graph 토대로 height 고정
  - 추가 마우스 움직임 없이 다음 클러스터 연속으로 확인 가능 및 화면 정중앙에 위치
- 클러스터 클릭시 animation 제거
  - 기존 summary 내 animation 최적화 되어 있지 않아 toggle되며 겹쳐지는 문제 존재
    (추후 작업 시 다시 복구 예정일지 몰라 일단 주석 처리해두었습니다.)

## Result 
- AS-IS
![ezgif com-gif-maker-11](https://user-images.githubusercontent.com/69497936/189878705-ea76c651-8d20-48d1-9772-f685d9c16489.gif)

- TO-BE
![ezgif com-gif-maker-12](https://user-images.githubusercontent.com/69497936/189878698-97a8eb0b-19ed-4246-9b62-654cf5c82421.gif)
