### PR TITLE
fix(engine): include HEAD info from the parser

### DIFF
--- a/packages/analysis-engine/src/parser.ts
+++ b/packages/analysis-engine/src/parser.ts
@@ -55,19 +55,17 @@ export function getCommitRaws(log: string) {
         ids.push(commitInfos[0]);
         commitInfos.splice(0, 1);
         parentsMatrix.push(commitInfos);
-        let branchAndTagsInfos = splitedCommitLine[1];
-        if (typeof branchAndTagsInfos !== "undefined") {
-          if (branchAndTagsInfos.startsWith("HEAD ->")) {
-            [, branchAndTagsInfos] = branchAndTagsInfos.split("HEAD ->");
-          }
-          branchAndTagsInfos.split(",").forEach((eachInfo) => {
-            if (eachInfo.trim().startsWith("tag:"))
+        const branchAndTagInfos = splitedCommitLine[1]
+          ?.replace(")", "")
+          .replace(" -> ", ", ")
+          .split(", ");
+        if (branchAndTagInfos) {
+          branchAndTagInfos.forEach((branchAndTagInfo) => {
+            if (branchAndTagInfo.startsWith("tag:"))
               return tagsMatrix[commitIdx].push(
-                eachInfo.replace("tag: ", "").trim()
+                branchAndTagInfo.replace("tag: ", "")
               );
-            return branchesMatrix[commitIdx].push(
-              eachInfo.replace(")", "").trim()
-            );
+            return branchesMatrix[commitIdx].push(branchAndTagInfo);
           });
         }
         return false;


### PR DESCRIPTION
### Content
- 기존에 `HEAD -> main` 으로 표기된 정보에 대해서 "main"만 branch정보로 포함하는 것이 아닌, HEAD도 같이 포함하도록 수정
- https://github.com/githru/githru-vscode-ext/issues/169

### Example
- splitedCommitLine[1]에 대해서(1) branchAndTagInfos로 전환하는(2) 예시

<img width="631" alt="스크린샷 2022-09-17 오후 5 53 59" src="https://user-images.githubusercontent.com/28749913/190848912-eaee6f65-5993-4afc-9088-c5ea074791fb.png">
