### PR TITLE
fix(vscode): read git of current opened workspaced folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -2292,10 +2292,6 @@
             "resolved": "packages/view",
             "link": true
         },
-        "node_modules/@githru-vscode-ext/vscode": {
-            "resolved": "packages/vscode",
-            "link": true
-        },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.10.4",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
@@ -12693,6 +12689,10 @@
             "dependencies": {
                 "assert-plus": "^1.0.0"
             }
+        },
+        "node_modules/githru-vscode-ext": {
+            "resolved": "packages/vscode",
+            "link": true
         },
         "node_modules/github-username": {
             "version": "6.0.0",
@@ -29501,7 +29501,7 @@
             }
         },
         "packages/vscode": {
-            "name": "@githru-vscode-ext/vscode",
+            "name": "githru-vscode-ext",
             "version": "0.1.0",
             "dependencies": {
                 "@githru-vscode-ext/analysis-engine": "^0.1.0"
@@ -31126,7 +31126,7 @@
                 "@octokit/plugin-paginate-rest": {
                     "version": "4.0.0",
                     "requires": {
-                        "@octokit/types": "^7.2.0"
+                        "@octokit/types": "^7.0.0"
                     }
                 },
                 "@octokit/plugin-rest-endpoint-methods": {
@@ -31299,61 +31299,6 @@
                     "dev": true,
                     "optional": true,
                     "peer": true
-                }
-            }
-        },
-        "@githru-vscode-ext/vscode": {
-            "version": "file:packages/vscode",
-            "requires": {
-                "@githru-vscode-ext/analysis-engine": "^0.1.0",
-                "@types/copy-webpack-plugin": "^10.1.0",
-                "@types/glob": "^7.2.0",
-                "@types/mocha": "^9.1.1",
-                "@types/node": "14.x",
-                "@types/vscode": "^1.67.0",
-                "@types/webpack": "^5.28.0",
-                "@typescript-eslint/eslint-plugin": "^5.21.0",
-                "@typescript-eslint/parser": "^5.21.0",
-                "@vscode/test-electron": "^2.1.3",
-                "copy-webpack-plugin": "^11.0.0",
-                "eslint": "^8.14.0",
-                "glob": "^8.0.1",
-                "mocha": "^9.2.2",
-                "prettier": "^2.7.1",
-                "ts-loader": "^9.2.8",
-                "typescript": "^4.6.4",
-                "webpack": "^5.70.0",
-                "webpack-cli": "^4.9.2"
-            },
-            "dependencies": {
-                "@types/node": {
-                    "version": "14.18.24",
-                    "dev": true
-                },
-                "brace-expansion": {
-                    "version": "2.0.1",
-                    "dev": true,
-                    "requires": {
-                        "balanced-match": "^1.0.0"
-                    }
-                },
-                "glob": {
-                    "version": "8.0.3",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^5.0.1",
-                        "once": "^1.3.0"
-                    }
-                },
-                "minimatch": {
-                    "version": "5.1.0",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^2.0.1"
-                    }
                 }
             }
         },
@@ -39248,6 +39193,61 @@
             "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
             "requires": {
                 "assert-plus": "^1.0.0"
+            }
+        },
+        "githru-vscode-ext": {
+            "version": "file:packages/vscode",
+            "requires": {
+                "@githru-vscode-ext/analysis-engine": "^0.1.0",
+                "@types/copy-webpack-plugin": "^10.1.0",
+                "@types/glob": "^7.2.0",
+                "@types/mocha": "^9.1.1",
+                "@types/node": "14.x",
+                "@types/vscode": "^1.67.0",
+                "@types/webpack": "^5.28.0",
+                "@typescript-eslint/eslint-plugin": "^5.21.0",
+                "@typescript-eslint/parser": "^5.21.0",
+                "@vscode/test-electron": "^2.1.3",
+                "copy-webpack-plugin": "^11.0.0",
+                "eslint": "^8.14.0",
+                "glob": "^8.0.1",
+                "mocha": "^9.2.2",
+                "prettier": "^2.7.1",
+                "ts-loader": "^9.2.8",
+                "typescript": "^4.6.4",
+                "webpack": "^5.70.0",
+                "webpack-cli": "^4.9.2"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "14.18.24",
+                    "dev": true
+                },
+                "brace-expansion": {
+                    "version": "2.0.1",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0"
+                    }
+                },
+                "glob": {
+                    "version": "8.0.3",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^5.0.1",
+                        "once": "^1.3.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "5.1.0",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                }
             }
         },
         "github-username": {

--- a/packages/analysis-engine/package.json
+++ b/packages/analysis-engine/package.json
@@ -63,11 +63,5 @@
     "ts-node": "^10.9.1",
     "tslib": "^2.4.0",
     "typescript": "^4.7.4"
-  },
-  "dependencies": {
-    "@octokit/core": "^4.0.4",
-    "@octokit/plugin-retry": "^3.0.9",
-    "@octokit/plugin-throttling": "^4.1.0",
-    "@octokit/rest": "^19.0.3"
   }
 }

--- a/packages/analysis-engine/tsconfig.json
+++ b/packages/analysis-engine/tsconfig.json
@@ -26,7 +26,7 @@
 
     /* Modules */
     "module": "esnext",                                  /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
     "moduleResolution": "node",                          /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.scss
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.scss
@@ -29,7 +29,7 @@
     flex-direction: column;
     height:100px;
     width: 100%;
-    margin-top:3.5%;
+    margin-top:2%;
     margin-bottom:3.5%;
     padding-bottom:2.5%;
     padding-top: 0.25%;

--- a/packages/vscode/.vscodeignore
+++ b/packages/vscode/.vscodeignore
@@ -11,3 +11,4 @@ vsc-extension-quickstart.md
 **/.eslintrc.json
 **/*.map
 **/*.ts
+node_modules

--- a/packages/vscode/LICENSE
+++ b/packages/vscode/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,10 +1,14 @@
 {
-    "name": "@githru-vscode-ext/vscode",
-    "displayName": "vscode",
+    "name": "githru-vscode-ext",
+    "displayName": "githru-vscode-ext",
     "description": "vscode extension module for githru-vscode-ext",
+    "repository": "https://github.com/githru/githru-vscode-ext",
     "version": "0.1.0",
     "engines": {
         "vscode": "^1.67.0"
+    },
+    "author": {
+        "name": "team githru"
     },
     "categories": [
         "Other"
@@ -22,12 +26,11 @@
         ]
     },
     "scripts": {
-        "vscode:prepublish": "npm run package",
         "prebuild": "npm run --prefix ../view/ build",
         "build": "npm run compile",
         "compile": "webpack",
         "watch": "webpack --watch",
-        "package": "webpack --mode production --devtool hidden-source-map",
+        "package": "webpack --mode production --devtool hidden-source-map && vsce package --no-dependencies",
         "compile-tests": "tsc -p . --outDir out",
         "watch-tests": "tsc -p . -w --outDir out",
         "pretest": "npm run compile-tests && npm run compile && npm run lint",
@@ -49,9 +52,9 @@
         "@vscode/test-electron": "^2.1.3",
         "copy-webpack-plugin": "^11.0.0",
         "eslint": "^8.14.0",
-        "prettier": "^2.7.1",
         "glob": "^8.0.1",
         "mocha": "^9.2.2",
+        "prettier": "^2.7.1",
         "ts-loader": "^9.2.8",
         "typescript": "^4.6.4",
         "webpack": "^5.70.0",

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -13,8 +13,14 @@ export function activate(context: vscode.ExtensionContext) {
     console.log('Congratulations, your extension "githru" is now active!');
 
     const disposable = vscode.commands.registerCommand(COMMAND_LAUNCH, async () => {
-		const { path } = await findGit();
-		const gitLog = await getGitLog(path, extensionPath);
+		const gitPath = (await findGit()).path;
+        const currentWorkspacePath = vscode.workspace.workspaceFolders?.[0].uri.path;
+
+        if (currentWorkspacePath === undefined) {
+            throw new Error('Cannot find current workspace path');
+        }
+
+		const gitLog = await getGitLog(gitPath, currentWorkspacePath);
         const csmDict = await analyzeGit({ gitLog });
 
 		const clusterNodes = mapClusterNodesFrom(csmDict);

--- a/packages/vscode/src/utils/NodeTypes.temps.ts
+++ b/packages/vscode/src/utils/NodeTypes.temps.ts
@@ -1,0 +1,78 @@
+// TODO: Entire types will be imported from analysis-engine
+
+// todo: engine ComitRaw 와 통일
+// Holds just commit log raw data
+export type CommitRaw = {
+    id: string;
+    parents: string[];
+    message: string;
+    author: string;
+    authorDate: string;
+    committer: string;
+    date: string;
+    tags: string[];
+    branches: string[];
+  
+    // fill necessary properties...
+  };
+  
+  // todo: engine DifferenceStatistic 와 통일
+  export type DiffStatistics = {
+    changedFileCount: number;
+    insertions: number;
+    deletions: number;
+    files: {
+      [id: string]: {
+        insertions: number;
+        deletions: number;
+      };
+    };
+  };
+  
+  // todo: engine GitUser 와 통일
+  export type GitHubUser = {
+    id: string;
+    names: string[];
+    emails: string[];
+  };
+  
+  export type Commit = {
+    id: string;
+    parentIds: string[];
+    author: GitHubUser;
+    committer: GitHubUser;
+    authorDate: string;
+    commitDate: string;
+    diffStatistics: DiffStatistics;
+    message: string;
+    // fill necessary properties...
+  };
+  
+  export const NODE_TYPE_NAME = ["COMMIT", "CLUSTER"] as const;
+  export type NodeTypeName = typeof NODE_TYPE_NAME[number];
+  
+  export type NodeBase = {
+    nodeTypeName: NodeTypeName;
+    // isRootNode: boolean;
+    // isLeafNode: boolean;
+  
+    // getParents: () => NodeType[];
+  };
+  
+  export type NodeType = CommitNode | ClusterNode;
+  
+  // Node = Commit + analyzed Data as node
+  export type CommitNode = NodeBase & {
+    nodeTypeName: "COMMIT";
+    commit: Commit;
+    // seq: number;
+    clusterId: number; // 동일한 Cluster 내부 commit 참조 id
+    // hasMajorTag: boolean;
+    // hasMinorTag: boolean;
+    // isMergeCommit: boolean;
+  };
+  
+  export type ClusterNode = NodeBase & {
+    nodeTypeName: "CLUSTER";
+    commitNodeList: CommitNode[];
+  };  

--- a/packages/vscode/src/utils/csm.mapper.ts
+++ b/packages/vscode/src/utils/csm.mapper.ts
@@ -1,6 +1,6 @@
 import type { DifferenceStatistic, CommitNode as StemCommitNode, CSMDictionary } from "@githru-vscode-ext/analysis-engine/src/types";
-import type { DiffStatistics, CommitNode, ClusterNode } from "@githru-vscode-ext/view/src/types";
- 
+import { ClusterNode, CommitNode, DiffStatistics } from "./NodeTypes.temps";
+
 /**
  * engine DifferenceStatistic → view DiffStatistics
  */

--- a/packages/vscode/src/webview-loader.ts
+++ b/packages/vscode/src/webview-loader.ts
@@ -47,8 +47,8 @@ export default class WebviewLoader implements vscode.Disposable {
                     <meta name="viewport" content="initial-scale=1.0">
                     <title>githru-vscode-ext webview</title>
                     <script>
-                        window.githruData = ${data};
                         window.isProduction = true;
+                        window.githruData = ${data};
                     </script>
                 </head>
                 <body>


### PR DESCRIPTION
vscode를 띄울 때, 개발중인 path(extensionPath)를 바라보게 하지 않고,
현재 열려있는 workspace folder의 첫번째의 git 을 바라보게 만들었습니다.
(vscode가 multiworkspace를 지원하기 때문에)

+ publish ready 추가합니다.