### PR TITLE
feat(engine): build stem & CSM based on passed branch name

### DIFF
--- a/packages/analysis-engine/src/csm.spec.ts
+++ b/packages/analysis-engine/src/csm.spec.ts
@@ -1,9 +1,6 @@
 import { buildCSMDict } from "./csm";
 
-import type { CommitRaw } from "./types/CommitRaw";
-import type { CommitNode } from "./types/CommitNode";
-import type { Stem } from "./types/Stem";
-import type { CSMDictionary } from "./types/CSM";
+import type { CommitRaw, CommitNode, Stem, CSMDictionary } from "./types";
 
 describe("csm", () => {
   // master = [0, 1,              2,                 3, 4, 5]
@@ -76,7 +73,7 @@ describe("csm", () => {
     let csmDict: CSMDictionary;
 
     beforeAll(() => {
-      csmDict = buildCSMDict(fakeCommitNodeDict, fakeStemDict);
+      csmDict = buildCSMDict(fakeCommitNodeDict, fakeStemDict, "master");
     });
 
     it("should return csm-dictionary", () => {

--- a/packages/analysis-engine/src/csm.ts
+++ b/packages/analysis-engine/src/csm.ts
@@ -6,13 +6,13 @@ import type { CommitNode, Stem, CSMDictionary, CSMNode } from "./types";
  *
  * @param {Map<string, CommitNode>} commitDict
  * @param {Map<string, Stem>} stemDict
- * @param mainBranchName
+ * @param baseBranchName
  * @returns {CSMDictionary}
  */
 export const buildCSMDict = (
   commitDict: Map<string, CommitNode>,
   stemDict: Map<string, Stem>,
-  mainBranchName: string
+  baseBranchName: string
 ): CSMDictionary => {
   if (stemDict.size === 0) {
     throw new Error("no stem");
@@ -22,7 +22,7 @@ export const buildCSMDict = (
   const csmDict: CSMDictionary = {};
 
   // v0.1 에서는 master STEM 으로만 CSM 생성함
-  const masterStem = stemDict.get(mainBranchName);
+  const masterStem = stemDict.get(baseBranchName);
   if (!masterStem) {
     throw new Error("no master-stem");
     // return {};
@@ -94,7 +94,7 @@ export const buildCSMDict = (
     csmNodes.push(csmNode);
   });
 
-  csmDict[mainBranchName] = csmNodes;
+  csmDict[baseBranchName] = csmNodes;
 
   return csmDict;
 };

--- a/packages/analysis-engine/src/csm.ts
+++ b/packages/analysis-engine/src/csm.ts
@@ -6,6 +6,7 @@ import type { CommitNode, Stem, CSMDictionary, CSMNode } from "./types";
  *
  * @param {Map<string, CommitNode>} commitDict
  * @param {Map<string, Stem>} stemDict
+ * @param mainBranchName
  * @returns {CSMDictionary}
  */
 export const buildCSMDict = (

--- a/packages/analysis-engine/src/csm.ts
+++ b/packages/analysis-engine/src/csm.ts
@@ -1,8 +1,5 @@
 /* eslint-disable import/prefer-default-export */
-
-import type { CommitNode } from "./types/CommitNode";
-import type { Stem } from "./types/Stem";
-import type { CSMDictionary, CSMNode } from "./types/CSM";
+import type { CommitNode, Stem, CSMDictionary, CSMNode } from "./types";
 
 /**
  * CSM 생성
@@ -13,7 +10,8 @@ import type { CSMDictionary, CSMNode } from "./types/CSM";
  */
 export const buildCSMDict = (
   commitDict: Map<string, CommitNode>,
-  stemDict: Map<string, Stem>
+  stemDict: Map<string, Stem>,
+  mainBranchName: string
 ): CSMDictionary => {
   if (stemDict.size === 0) {
     throw new Error("no stem");
@@ -23,12 +21,11 @@ export const buildCSMDict = (
   const csmDict: CSMDictionary = {};
 
   // v0.1 에서는 master STEM 으로만 CSM 생성함
-  const masterStem = stemDict.get("master") ?? stemDict.get("main");
+  const masterStem = stemDict.get(mainBranchName);
   if (!masterStem) {
     throw new Error("no master-stem");
     // return {};
   }
-  const branch = "master";
   const stemNodes = masterStem.nodes.reverse(); // start on root-node
 
   const csmNodes: CSMNode[] = [];
@@ -54,7 +51,6 @@ export const buildCSMDict = (
         const squashStemId = squashStartNode.stemId!;
         const squashStem = stemDict.get(squashStemId);
         if (!squashStem) {
-          // eslint-disable-next-line no-continue
           continue;
         }
 
@@ -97,7 +93,7 @@ export const buildCSMDict = (
     csmNodes.push(csmNode);
   });
 
-  csmDict[branch] = csmNodes;
+  csmDict[mainBranchName] = csmNodes;
 
   return csmDict;
 };

--- a/packages/analysis-engine/src/index.ts
+++ b/packages/analysis-engine/src/index.ts
@@ -9,12 +9,12 @@ type AnalysisEngineArgs = {
 };
 
 export const analyzeGit = async (args: AnalysisEngineArgs) => {
-  const mainBranchName = "main";
+  const baseBranchName = "main";
 
   const commitRaws = getCommitRaws(args.gitLog);
   const commitDict = buildCommitDict(commitRaws);
-  const stemDict = buildStemDict(commitDict, mainBranchName);
-  const csmDict = buildCSMDict(commitDict, stemDict, mainBranchName);
+  const stemDict = buildStemDict(commitDict, baseBranchName);
+  const csmDict = buildCSMDict(commitDict, stemDict, baseBranchName);
 
   if (args.isDebugMode) {
     console.log(csmDict);

--- a/packages/analysis-engine/src/index.ts
+++ b/packages/analysis-engine/src/index.ts
@@ -9,10 +9,12 @@ type AnalysisEngineArgs = {
 };
 
 export const analyzeGit = async (args: AnalysisEngineArgs) => {
-  const commitRaws = await getCommitRaws(args.gitLog);
+  const mainBranchName = "main";
+
+  const commitRaws = getCommitRaws(args.gitLog);
   const commitDict = buildCommitDict(commitRaws);
-  const stemDict = buildStemDict(commitDict);
-  const csmDict = buildCSMDict(commitDict, stemDict);
+  const stemDict = buildStemDict(commitDict, mainBranchName);
+  const csmDict = buildCSMDict(commitDict, stemDict, mainBranchName);
 
   if (args.isDebugMode) {
     console.log(csmDict);

--- a/packages/analysis-engine/src/stem.spec.ts
+++ b/packages/analysis-engine/src/stem.spec.ts
@@ -138,7 +138,7 @@ describe("stem", () => {
   });
 
   it("should make instance of Map", () => {
-    const stemDict = buildStemDict(commitDict);
+    const stemDict = buildStemDict(commitDict, "main");
     expect(stemDict).toBeInstanceOf(Map);
   });
 
@@ -148,12 +148,11 @@ describe("stem", () => {
   });
 
   it("must have main/master stem", () => {
-    const stemDict = buildStemDict(commitDict);
+    const stemDict = buildStemDict(commitDict, "main");
     expect(stemDict.has("main") || stemDict.has("master")).toBeTruthy();
   });
 
   it("should make stem", () => {
-    const stemDict = buildStemDict(commitDict);
     expect(stemDict.get("main")?.nodes.map((node) => node.commit.id)).toEqual([
       "f",
       "e",
@@ -162,6 +161,7 @@ describe("stem", () => {
       "b",
       "a",
     ]);
+    const stemDict = buildStemDict(commitDict, "main");
     expect(
       stemDict.get("implicit-1")?.nodes.map((node) => node.commit.id)
     ).toEqual(["i", "h", "g"]);

--- a/packages/analysis-engine/src/stem.spec.ts
+++ b/packages/analysis-engine/src/stem.spec.ts
@@ -152,28 +152,47 @@ describe("stem", () => {
     expect(stemDict.has("main") || stemDict.has("master")).toBeTruthy();
   });
 
-  it("should make stem", () => {
-    expect(stemDict.get("main")?.nodes.map((node) => node.commit.id)).toEqual([
-      "f",
-      "e",
-      "d",
-      "c",
-      "b",
-      "a",
-    ]);
+  it("should build stem based on 'main' branch", () => {
     const stemDict = buildStemDict(commitDict, "main");
+    const expectedStemDict = {
+      main: ["f", "e", "d", "c", "b", "a"],
+      dev: ["m", "l", "k", "j"],
+      HEAD: ["o", "n"],
+      "implicit-1": ["i", "h", "g"],
+    };
+    expect(stemDict.get("main")?.nodes.map((node) => node.commit.id)).toEqual(
+      expectedStemDict.main
+    );
     expect(
       stemDict.get("implicit-1")?.nodes.map((node) => node.commit.id)
-    ).toEqual(["i", "h", "g"]);
-    expect(stemDict.get("dev")?.nodes.map((node) => node.commit.id)).toEqual([
-      "m",
-      "l",
-      "k",
-      "j",
-    ]);
-    expect(stemDict.get("HEAD")?.nodes.map((node) => node.commit.id)).toEqual([
-      "o",
-      "n",
-    ]);
+    ).toEqual(expectedStemDict["implicit-1"]);
+    expect(stemDict.get("dev")?.nodes.map((node) => node.commit.id)).toEqual(
+      expectedStemDict.dev
+    );
+    expect(stemDict.get("HEAD")?.nodes.map((node) => node.commit.id)).toEqual(
+      expectedStemDict.HEAD
+    );
+  });
+
+  it("builds stem based on 'dev' branch", () => {
+    const stemDict = buildStemDict(commitDict, "dev");
+    const expectedStemDict = {
+      dev: ["m", "l", "k", "j", "c", "b", "a"],
+      sub1: ["f", "e", "d"],
+      HEAD: ["o", "n"],
+      "implicit-1": ["i", "h", "g"],
+    };
+    expect(stemDict.get("dev")?.nodes.map((node) => node.commit.id)).toEqual(
+      expectedStemDict.dev
+    );
+    expect(stemDict.get("sub1")?.nodes.map((node) => node.commit.id)).toEqual(
+      expectedStemDict.sub1
+    );
+    expect(stemDict.get("HEAD")?.nodes.map((node) => node.commit.id)).toEqual(
+      expectedStemDict.HEAD
+    );
+    expect(
+      stemDict.get("implicit-1")?.nodes.map((node) => node.commit.id)
+    ).toEqual(expectedStemDict["implicit-1"]);
   });
 });

--- a/packages/analysis-engine/src/stem.ts
+++ b/packages/analysis-engine/src/stem.ts
@@ -47,7 +47,7 @@ function buildGetStemId() {
   return function (
     id: string,
     branches: string[],
-    mainBranchName: string,
+    baseBranchName: string,
     mainNode?: CommitNode,
     headNode?: CommitNode
   ) {
@@ -56,7 +56,7 @@ function buildGetStemId() {
       return `implicit-${implicitBranchNumber}`;
     }
     if (id === mainNode?.commit.id) {
-      return mainBranchName;
+      return baseBranchName;
     }
     if (id === headNode?.commit.id) {
       return "HEAD";
@@ -68,11 +68,11 @@ function buildGetStemId() {
 /**
  * Stem 생성
  * @param commitDict
- * @param mainBranchName
+ * @param baseBranchName
  */
 export function buildStemDict(
   commitDict: Map<string, CommitNode>,
-  mainBranchName: string
+  baseBranchName: string
 ): Map<string, Stem> {
   const q = new Queue<CommitNode>(compareCommitPriority);
 
@@ -85,7 +85,7 @@ export function buildStemDict(
   const stemDict = new Map<string, Stem>();
   const leafNodes = getLeafNodes(commitDict);
   const mainNode = leafNodes.find((node) =>
-    node.commit.branches.includes(mainBranchName)
+    node.commit.branches.includes(baseBranchName)
   );
   const headNode = leafNodes.find((node) =>
     node.commit.branches.includes("HEAD")
@@ -109,7 +109,7 @@ export function buildStemDict(
     const stemId = getStemId(
       tail.commit.id,
       tail.commit.branches,
-      mainBranchName,
+      baseBranchName,
       mainNode,
       headNode
     );

--- a/packages/analysis-engine/src/stem.ts
+++ b/packages/analysis-engine/src/stem.ts
@@ -42,7 +42,7 @@ function compareCommitPriority(a: CommitNode, b: CommitNode): number {
   );
 }
 
-function buildGetStemId() {
+function buildGetStemId(mainBranchName: string) {
   let implicitBranchNumber = 0;
   return function (
     id: string,
@@ -55,7 +55,7 @@ function buildGetStemId() {
       return `implicit-${implicitBranchNumber}`;
     }
     if (id === mainNode?.commit.id) {
-      return mainNode.commit.branches.includes("main") ? "main" : "master";
+      return mainBranchName;
     }
     if (id === headNode?.commit.id) {
       return "HEAD";
@@ -65,7 +65,8 @@ function buildGetStemId() {
 }
 
 export function buildStemDict(
-  commitDict: Map<string, CommitNode>
+  commitDict: Map<string, CommitNode>,
+  mainBranchName: string
 ): Map<string, Stem> {
   const q = new Queue<CommitNode>(compareCommitPriority);
 
@@ -77,10 +78,8 @@ export function buildStemDict(
    */
   const stemDict = new Map<string, Stem>();
   const leafNodes = getLeafNodes(commitDict);
-  const mainNode = leafNodes.find(
-    (node) =>
-      node.commit.branches.includes("main") ||
-      node.commit.branches.includes("master")
+  const mainNode = leafNodes.find((node) =>
+    node.commit.branches.includes(mainBranchName)
   );
   const headNode = leafNodes.find((node) =>
     node.commit.branches.includes("HEAD")
@@ -95,7 +94,7 @@ export function buildStemDict(
   if (mainNode) q.pushFront(mainNode);
   if (headNode) q.pushBack(headNode);
 
-  const getStemId = buildGetStemId();
+  const getStemId = buildGetStemId(mainBranchName);
 
   while (!q.isEmpty()) {
     const tail = q.pop();

--- a/packages/analysis-engine/src/stem.ts
+++ b/packages/analysis-engine/src/stem.ts
@@ -42,11 +42,12 @@ function compareCommitPriority(a: CommitNode, b: CommitNode): number {
   );
 }
 
-function buildGetStemId(mainBranchName: string) {
+function buildGetStemId() {
   let implicitBranchNumber = 0;
   return function (
     id: string,
     branches: string[],
+    mainBranchName: string,
     mainNode?: CommitNode,
     headNode?: CommitNode
   ) {
@@ -64,6 +65,11 @@ function buildGetStemId(mainBranchName: string) {
   };
 }
 
+/**
+ * Stem 생성
+ * @param commitDict
+ * @param mainBranchName
+ */
 export function buildStemDict(
   commitDict: Map<string, CommitNode>,
   mainBranchName: string
@@ -94,7 +100,7 @@ export function buildStemDict(
   if (mainNode) q.pushFront(mainNode);
   if (headNode) q.pushBack(headNode);
 
-  const getStemId = buildGetStemId(mainBranchName);
+  const getStemId = buildGetStemId();
 
   while (!q.isEmpty()) {
     const tail = q.pop();
@@ -103,6 +109,7 @@ export function buildStemDict(
     const stemId = getStemId(
       tail.commit.id,
       tail.commit.branches,
+      mainBranchName,
       mainNode,
       headNode
     );


### PR DESCRIPTION
closed #144 

파라미터로 전달된 branch 이름을 기준으로 Stem과 CSM을 생성하도록 `build{Stem/CSM}Dict` 함수를 변경합니다.

### 예시 1. Stem 테스트 데이터

![STEM의 복사본 drawio](https://user-images.githubusercontent.com/40057032/190893733-6f05c566-6429-42a4-bbad-9a0f0271ba88.png)

'dev' 브랜치를 기준으로 생성한 경우
```js
const stemDict = {
  dev: [a, b, c, j, k, l, m],
  main: [d, e, f],
  head: [n, o],
  'implicit-1': [g, h, i]
}
const csmDict = {
  'dev': [
    { base: a, source: [] },
    { base: b, source: [] },
    { base: c, source: [g] },
    { base: j, source: [] },
    { base: k, source: [] },
    { base: l, source: [] },
    { base: m, source: [] },
}
```

### 예시 2. CSM 테스트 데이터

![csm-test drawio](https://user-images.githubusercontent.com/40057032/190894031-48fe103e-6d2d-4970-b8c8-87dda310a691.png)

sub1 브랜치를 기준으로
```js
const stemDict = {
  sub1: [0, 1, 6, 7, 8, 9, 10, 11],
  sub2: [12, 13, 14, 15 ,16],
  main: [2, 3]
}

const csmDict = {
  'sub1': [
    { base: 0, source: [] },
    { base: 1, source: [] },
    { base: 6, source: [] },
    { base: 7, source: [] },
    { base: 8, source: [13, 12] },
    { base: 9, source: [] },
    { base: 10, source: [] },
    { base: 11, source: [16, 15, 14] },
```

CSM 작업하신 @anpaul0615 , @hy57in 님 확인 부탁드립니다.