### PR TITLE
style(view): Cluster Graph , Line Chart 반응형 개선 작업

### DIFF
--- a/packages/view/src/App.scss
+++ b/packages/view/src/App.scss
@@ -6,6 +6,7 @@ body {
 
 .head-container {
   margin-bottom: 30px;
+  height: 200px;
 }
 
 .middle-container {

--- a/packages/view/src/components/VerticalClusterList/VerticalClusterList.scss
+++ b/packages/view/src/components/VerticalClusterList/VerticalClusterList.scss
@@ -4,4 +4,9 @@
   height: 100%;
   overflow-y: scroll;
   width: 75%;
+
+  svg {
+    // SVG_WIDTH === 84
+    min-width: 84px;
+  }
 }


### PR DESCRIPTION
# Related Issue
- closed https://github.com/githru/githru-vscode-ext/issues/206


# Result
<img width="533" alt="스크린샷 2022-09-19 오전 3 55 22" src="https://user-images.githubusercontent.com/70205497/190923846-0a252501-357c-4106-9979-7daf18e6ec95.png">



# How to Solved

- WebView의 width가 줄어들게 되면, line chart와 하위 컴포넌트들이 충돌되는 문제 발생합니다.
  - line chart의 height이 정해져있지 않아 내부 컴포넌트의 높이가 가변적으로 변하는 상황이 발생하여 200px로 고정시킴
  
- 추가로 ClusterGraph가 잘리는 문제가 발생합니다. 일정 width 이하로 줄여지지 않게 구현할 수 있고, width를 줄이더라도 line chart와 충돌이 없도록 수정이 필요합니다.
  -  Cluster Graph svg의 width를 84px로 지정했으나, container의 width가 줄어듬에 따라 svg의 width또한 줄어들게 되었음
  => min-width를 84px로 설정하여 깨짐을 방지하였음.