### PR TITLE
fix(view): replace summary  button tag => div tag #201

### DIFF
--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -162,6 +162,7 @@
     display: flex;
     justify-content: space-between;
     width: 100%;
+    font-size: 16px;
 
     .commit-message {
       white-space: nowrap;

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -46,10 +46,10 @@ const Summary = forwardRef<HTMLDivElement, SummaryProps>(
               className="cluster-summary__cluster"
               key={cluster.clusterId}
             >
-              <button
-                type="button"
+              <div
                 className="cluster-summary__toggle-contents-button"
                 onClick={() => onClickClusterSummary(cluster.clusterId)}
+                aria-hidden
               >
                 <div className="cluster-summary__toggle-contents-container">
                   <span className="name-box">
@@ -83,7 +83,7 @@ const Summary = forwardRef<HTMLDivElement, SummaryProps>(
                     </button>
                   )}
                 </div>
-              </button>
+              </div>
               {cluster.clusterId === clusterIds && (
                 <div
                   className="cluster-summary__detail__container"


### PR DESCRIPTION
# Related Issue
- closed https://github.com/githru/githru-vscode-ext/issues/201

# Result

[ 기존 button css ]

<img width="1025" alt="스크린샷 2022-09-19 오전 4 05 56" src="https://user-images.githubusercontent.com/70205497/190924985-e57af067-ebae-48a6-a9d6-ab349479dbb6.png">

[ tag 변경 후 css ]

<img width="1016" alt="스크린샷 2022-09-19 오전 4 06 41" src="https://user-images.githubusercontent.com/70205497/190924993-e356e1a8-13c3-479d-a832-cce01dac0aa4.png">

[ 내부 font-size 16px 적용 후 ]

<img width="788" alt="스크린샷 2022-09-19 오전 4 07 27" src="https://user-images.githubusercontent.com/70205497/190925007-d926a52d-6a73-46df-a46e-b92c446136af.png">



# How to Solved
[no-static-element-interactions](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-static-element-interactions.md) 에 의하면 ```role="button"```을 적용하여 해결하라 하였으나 해결이 되지 않았음.

[click-events-have-key-events](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/click-events-have-key-events.md)에 의하면 ```aria-hidden={true}```를 적용하여 해결하라 함.

# New Problem

https://nuli.navercorp.com/community/article/1132937 에 의하면
```aria-hidden은 스크린 리더와 같은 보조기술 사용자의 콘텐츠 탐색을 제한합니다.``` 라고 하여 추후 수정이 필요함을 느낍니다.
