### PR TITLE
fix(engine): fix typo in newline escape seq

### DIFF
--- a/packages/analysis-engine/src/parser.ts
+++ b/packages/analysis-engine/src/parser.ts
@@ -79,7 +79,7 @@ export function getCommitRaws(log: string) {
         let eachCommitMessage = "";
         while (splitByNewLine[indexCheckFileChanged] !== "") {
           if (eachCommitMessage !== "") {
-            eachCommitMessage += "/n";
+            eachCommitMessage += "\n";
           }
           eachCommitMessage += splitByNewLine[indexCheckFileChanged].trim();
           indexCheckFileChanged += 1;


### PR DESCRIPTION
parser.ts 의 개행문자 오타를 수정했습니다. `/n` -> `\n`

@jejecrunch 님, Summary.util.ts 파일에 있는 '/n'은 이 작업이 머지되면 후속으로 처리하실 예정이실 것 같아서 따로 작업하지 않았습니다. 혹시 더 작업이 필요한 부분이 있다면 알려주세요.

closed #215 