### PR TITLE
feat(view): change author bar chart x axis scale and apply responsive layout to `summary` component

### DIFF
--- a/packages/view/src/components/Detail/Detail.scss
+++ b/packages/view/src/components/Detail/Detail.scss
@@ -16,6 +16,7 @@
 
   .detail__summary {
     flex-grow: 0.1;
+    text-align: right;
   }
 
   .insertions {

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -62,7 +62,11 @@ const AuthorBarChart = ({ data: rawData }: AuthorBarChartProps) => {
       .align(0.5);
 
     // Axis
-    const xAxis = d3.axisBottom(xScale).ticks(5).tickSizeOuter(0);
+    const xAxis = d3
+      .axisBottom(xScale)
+      .ticks(5)
+      .tickFormat(d3.format("~s"))
+      .tickSizeOuter(0);
     xAxisGroup.call(xAxis);
 
     const yAxis = d3

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -48,7 +48,10 @@ const AuthorBarChart = ({ data: rawData }: AuthorBarChartProps) => {
     const barGroup = svg.append("g").attr("class", "bars");
 
     // Scales
-    const xScale = d3.scaleLinear().domain([0, 1]).range([0, DIMENSIONS.width]);
+    const xScale = d3
+      .scaleLinear()
+      .domain([0, d3.max(data, (d) => d[metric]) || 1])
+      .range([0, DIMENSIONS.width]);
 
     const yScale = d3
       .scaleBand()
@@ -59,7 +62,7 @@ const AuthorBarChart = ({ data: rawData }: AuthorBarChartProps) => {
       .align(0.5);
 
     // Axis
-    const xAxis = d3.axisBottom(xScale).ticks(5, "%").tickSizeOuter(0);
+    const xAxis = d3.axisBottom(xScale).ticks(5).tickSizeOuter(0);
     xAxisGroup.call(xAxis);
 
     const yAxis = d3
@@ -126,10 +129,7 @@ const AuthorBarChart = ({ data: rawData }: AuthorBarChartProps) => {
       .on("mouseout", handleMouseOut)
       .transition()
       .duration(500)
-      .attr(
-        "width",
-        (d: AuthorDataType) => xScale(d[metric]) / totalMetricValues
-      )
+      .attr("width", (d: AuthorDataType) => xScale(d[metric]))
       .attr("height", yScale.bandwidth())
       .attr("x", 1)
       .attr("y", (d: AuthorDataType) => yScale(d.name) || 0);

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -5,7 +5,11 @@ import * as d3 from "d3";
 import type { ClusterNode, StatisticsProps } from "types";
 
 import type { AuthorDataType, MetricType } from "./AuthorBarChart.type";
-import { getDataByAuthor, sortDataByName } from "./AuthorBarChart.util";
+import {
+  convertNumberFormat,
+  getDataByAuthor,
+  sortDataByName,
+} from "./AuthorBarChart.util";
 import { DIMENSIONS, METRIC_TYPE } from "./AuthorBarChart.const";
 
 import "./AuthorBarChart.scss";
@@ -65,7 +69,7 @@ const AuthorBarChart = ({ data: rawData }: AuthorBarChartProps) => {
     const xAxis = d3
       .axisBottom(xScale)
       .ticks(5)
-      .tickFormat(d3.format("~s"))
+      .tickFormat(convertNumberFormat)
       .tickSizeOuter(0);
     xAxisGroup.call(xAxis);
 

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
@@ -1,3 +1,5 @@
+import * as d3 from "d3";
+
 import type { ClusterNode } from "types";
 
 import type { AuthorDataType } from "./AuthorBarChart.type";
@@ -37,4 +39,13 @@ export const sortDataByName = (a: string, b: string) => {
   if (nameA < nameB) return 1;
   if (nameA > nameB) return -1;
   return 0;
+};
+
+export const convertNumberFormat = (
+  d: number | { valueOf(): number }
+): string => {
+  if (d < 1 && d >= 0) {
+    return `${d}`;
+  }
+  return d3.format("~s")(d);
 };

--- a/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.const.ts
+++ b/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.const.ts
@@ -1,6 +1,6 @@
 export const WIDTH = 600;
-export const HEIGHT = 400;
-export const FONT_SIZE = 18;
+export const HEIGHT = 750;
+export const FONT_SIZE = 24;
 export const MAX_DEPTH = 4;
 export const SINGLE_RECT_WIDTH = WIDTH / MAX_DEPTH;
 export const LABEL_VISIBLE_HEIGHT = 20;

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -172,7 +172,14 @@ const ClusterGraph = ({
     setSelectedData,
   ]);
 
-  return <svg ref={svgRef} width={SVG_WIDTH} height={graphHeight} />;
+  return (
+    <svg
+      className="cluster-graph"
+      ref={svgRef}
+      width={SVG_WIDTH}
+      height={graphHeight}
+    />
+  );
 };
 
 export default ClusterGraph;

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -28,6 +28,61 @@
   }
 }
 
+@media (max-width: 1440px) {
+  .cluster-summary__cluster {
+    width: 850px !important;
+
+    .commit-message {
+      width: 600px !important;
+    }
+  }
+}
+@media (max-width: 1300px) {
+  .cluster-summary__cluster {
+    width: 700px !important;
+
+    .commit-message {
+      width: 500px !important;
+    }
+  }
+}
+@media (max-width: 1130px) {
+  .cluster-summary__cluster {
+    width: 600px !important;
+
+    .commit-message {
+      width: 400px !important;
+    }
+  }
+}
+@media (max-width: 1024px) {
+  .cluster-summary__cluster {
+    width: 500px !important;
+
+    .commit-message {
+      width: 300px !important;
+    }
+  }
+}
+@media (max-width: 930px) {
+  .cluster-summary__cluster {
+    width: 400px !important;
+
+    .commit-message {
+      width: 200px !important;
+    }
+  }
+}
+@media (max-width: 850px) {
+  .cluster-summary__cluster {
+    width: 200px !important;
+
+    .commit-message {
+      width: 100px !important;
+    }
+  }
+}
+
 .cluster-summary__container {
   width: 85%;
   margin-left: 20px;
@@ -35,14 +90,11 @@
 
   .cluster-summary__cluster {
     padding: 5px 0;
+    width: 950px;
   }
 
   .cluster-summary__toggle-contents-button {
     width: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    flex-direction: row;
     padding: 5px 15px;
     border: none;
     background-color: transparent;
@@ -58,42 +110,28 @@
   .cluster-summary__toggle-contents-container {
     display: flex;
     align-items: center;
-    text-overflow: ellipsis;
     width: 100%;
   }
 
   :hover .collapsible-icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-left: 12px;
     visibility: visible;
-    cursor: pointer;
   }
 
   .collapsible-icon {
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-left: 12px;
+    margin-left: 8px;
     background-color: transparent;
     border: none;
-    font-size: 18px;
+    font-size: 24px;
     color: $blue-light-600;
     visibility: hidden;
     cursor: pointer;
-  }
 
-  .collapsible-icon-shown {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-left: 12px;
-    background-color: transparent;
-    border: none;
-    font-size: 18px;
-    color: $blue-light-600;
-    cursor: pointer;
+    & .show {
+      visibility: visible;
+    }
   }
 
   .name-box {
@@ -153,7 +191,6 @@
       position: absolute;
       bottom: 30%;
       left: -9999px;
-
       color: $white;
       font-size: 12px;
       padding: 0px 12px;
@@ -161,7 +198,6 @@
       width: auto;
       min-width: max-content;
       word-wrap: break-word;
-
       opacity: 0;
       z-index: 9999;
     }
@@ -183,60 +219,21 @@
       overflow: hidden;
       text-overflow: ellipsis;
       margin-left: 15px;
+      text-align: left;
+      width: 700px;
       cursor: pointer;
     }
     .more-commit-count {
       font-size: 12px;
+      text-align: right;
+      width: 60px;
     }
   }
-
-  // .keyword {
-  //   margin-left: 5px;
-  //   margin-right: 5px;
-
-  //   &:hover {
-  //     @include animation();
-  //     font-weight: 700;
-  //     cursor: pointer;
-  //   }
-
-  //   &.large {
-  //     font-size: 18pt;
-  //     font-weight: 900;
-  //     line-height: 28px;
-
-  //     &:hover {
-  //       @include animation();
-  //       cursor: pointer;
-  //     }
-  //   }
-
-  //   &.medium {
-  //     font-size: 16pt;
-  //     font-weight: 700;
-  //     line-height: 28px;
-
-  //     &:hover {
-  //       @include animation();
-  //       cursor: pointer;
-  //     }
-  //   }
-  // }
 }
 
 .cluster-summary__detail__container {
   overflow: overlay;
   max-height: 280px;
-
-  // @include keyframes(open_detail) {
-  //   0% {
-  //     max-height: 0;
-  //   }
-  //   100% {
-  //     max-height: 280px;
-  //   }
-  // }
-  // @include animate(open_detail, 0.3s, linear, 1);
 }
 
 .summary-detail__wrapper {
@@ -244,5 +241,4 @@
   padding: 0 30px;
   padding-top: 5px;
   padding-bottom: 20px;
-  box-sizing: border-box;
 }

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -56,7 +56,7 @@ const Summary = forwardRef<HTMLDivElement, SummaryProps>(
                 onClick={() => onClickClusterSummary(cluster.clusterId)}
               >
                 <div className="cluster-summary__toggle-contents-container">
-                  <span className="name-box">
+                  <div className="name-box">
                     {cluster.summary.authorNames.map(
                       (authorArray: Array<string>) => {
                         return authorArray.map((authorName: string) => (
@@ -67,25 +67,23 @@ const Summary = forwardRef<HTMLDivElement, SummaryProps>(
                         ));
                       }
                     )}
-                  </span>
+                  </div>
                   <div className="cluster-summary__contents">
                     <span className="commit-message">
                       {cluster.summary.content.message}
                     </span>
                     <span className="more-commit-count">
                       {cluster.summary.content.count > 0 &&
-                        ` + ${cluster.summary.content.count} more`}
+                        `+ ${cluster.summary.content.count} more`}
                     </span>
                   </div>
-                  {cluster.clusterId === clusterIds ? (
-                    <div className="collapsible-icon-shown">
-                      <IoIosArrowDropupCircle fontSize="1.6rem" />
-                    </div>
-                  ) : (
-                    <div className="collapsible-icon">
-                      <IoIosArrowDropdownCircle fontSize="1.6rem" />
-                    </div>
-                  )}
+                  <div className="collapsible-icon">
+                    {cluster.clusterId === clusterIds ? (
+                      <IoIosArrowDropupCircle className="show" />
+                    ) : (
+                      <IoIosArrowDropdownCircle />
+                    )}
+                  </div>
                 </div>
               </button>
               {cluster.clusterId === clusterIds && (

--- a/packages/view/src/components/VerticalClusterList/VerticalClusterList.scss
+++ b/packages/view/src/components/VerticalClusterList/VerticalClusterList.scss
@@ -2,11 +2,11 @@
   display: flex;
   flex-direction: row;
   height: 100%;
+  overflow-x: hidden;
   overflow-y: scroll;
   width: 75%;
 
-  svg {
-    // SVG_WIDTH === 84
+  svg.cluster-graph {
     min-width: 84px;
   }
 }


### PR DESCRIPTION
## Related Issue & PR
- close #205 
- #209
- close #218

## WorkList
-  **cluster graph에만 css 적용되도록 className 지정 (e1a6891c356617de234938fc852a30ba819016de)**
  이전 #209에서 적용된 css가 summary 내 아이콘에도 함께 적용되어 밀려난 이슈 해결
    <img width="500" alt="image" src="https://user-images.githubusercontent.com/69497936/192106769-8c437c94-5acb-4be0-ba14-93f72543ea09.png">

- **author bar chart x축 scale 수정 (04fe14cf1e95503c9f19f8711fbe139db5d17b40 ffb1df2800195edb9a8ce099b4e305410d773ff0 f5e7dae4a6e1a3efd2aca1748be96d4b77b588fd)**
  >Related Issue
https://github.com/githru/githru-vscode-ext/issues/147
Content
y축 값이 지금은 commit # / Total commit# 의 백분율인데, 이럴 경우 현재처럼 차트의 반 이상이 비어 있게 됩니다 (dominant한 contributor가 있지 않는 이상). 100%를 max로 잡지말고 최대값+a를 max로 잡거나, 혹은 그냥 cardinality (commit#)만 가지고 표시하면 더 보기 좋을 것 같습니다. (추후에 값의 분포에 따라서 top 10 user만 보여준다던지, Percentage가 서로 비슷할 경우, 다를 경우를 분리해서 보여주는 값을 다르게 한다던지 하는 방법도 있겠네요) 

| | AS-IS | TO-BE |
| :---: | :---: | :---: |
| x축 scale 변경해 <br/>차트의 반 이상 비어있는 이슈 해결 | <img width="284" alt="스크린샷 2022-09-25 오전 12 50 00" src="https://user-images.githubusercontent.com/69497936/192107114-7b561e4c-d3eb-4dbd-b009-d69b6c2ff1de.png">  | <img width="284" alt="스크린샷 2022-09-25 오전 12 50 46" src="https://user-images.githubusercontent.com/69497936/192107141-23a6a2ab-ea0d-4ae6-a185-39788e7a0329.png"> |
| x축 1000단위 formatting  | <img width="284" alt="스크린샷 2022-09-25 오전 12 56 03" src="https://user-images.githubusercontent.com/69497936/192107461-462bb004-faae-4c5d-870a-52d22838e27d.png"> | <img width="284" alt="스크린샷 2022-09-25 오전 12 51 49" src="https://user-images.githubusercontent.com/69497936/192107186-23eb942f-a14d-4e32-87a3-dd9de896faf6.png"> |
| 소수점 단위 <br/>SI-prefix 'm'에서 숫자로 변경 | <img width="292" alt="스크린샷 2022-09-25 오전 2 18 36" src="https://user-images.githubusercontent.com/69497936/192110687-e2fced43-21e0-414e-8107-f3e6760d3202.png">  | <img width="292" alt="스크린샷 2022-09-25 오전 2 15 23" src="https://user-images.githubusercontent.com/69497936/192110622-5360ac19-98ae-45eb-9156-fd77c062c5d7.png">|
- **icicle graph height 및 font-size 확대 (1ef40595dfb974ec82d2e8162eb2118fba912798)**

- **summary 반응형 적용** (aa805e9e37177c0671ab1e9b15ba8981e10a17ae)

| | AS-IS | TO-BE |
| :---: | :---: | :---: |
| 기존 summary 내 <br />`commit-message`와 `more-commit-count`<br /> 정렬 맞춰지지 않는 이슈 해결 | <img width="653" alt="스크린샷 2022-09-25 오전 1 01 41" src="https://user-images.githubusercontent.com/69497936/192107648-a37bb3ae-0d9b-4969-b265-ee5f97db0dde.png"> |<img width="653" src="https://user-images.githubusercontent.com/69497936/192107772-ecb52ffb-ff6e-405c-a8d8-06d1adcf14f0.png">  |
| hover 시 css overflow 이슈 해결 | <img width="1053" alt="image" src="https://user-images.githubusercontent.com/69497936/192108962-dffaaf99-1bc1-4af3-bfc2-be89822282c2.png"> | <img width="975" alt="image" src="https://user-images.githubusercontent.com/69497936/192109012-49820966-0f44-4d7b-97ab-0d92912bb66e.png"> |

- AS-IS
  <img width="600" src="https://user-images.githubusercontent.com/69497936/192108605-d81a0044-166b-4a26-b4cd-71484d14fbc7.gif">

- TO-BE
  <img width="600" src="https://user-images.githubusercontent.com/69497936/192108445-45459e48-64f1-4133-8524-22deecd77ed3.gif">





