### PR TITLE
refactor(view): modify and add components props

### DIFF
--- a/packages/view/CONTRIBUTING.md
+++ b/packages/view/CONTRIBUTING.md
@@ -170,6 +170,12 @@ npm run lint
     function GetData( ... ) { ... }
     ```
 
+### Props type
+
+- 모든 Component에서 사용되는 거라면 `/types/global.ts`에 작성합니다.
+
+- 각 Component에서만 사용되는 거라면 `/${COMPONENT}/${COMPONENT}.type.ts`에 작성합니다.
+
 
 # Manifesto
 

--- a/packages/view/CONTRIBUTING.md
+++ b/packages/view/CONTRIBUTING.md
@@ -170,13 +170,6 @@ npm run lint
     function GetData( ... ) { ... }
     ```
 
-### Props type
-
-- 모든 Component에서 사용되는 거라면 `/types/global.ts`에 작성합니다.
-
-- 각 Component에서만 사용되는 거라면 `/${COMPONENT}/${COMPONENT}.type.ts`에 작성합니다.
-
-
 # Manifesto
 
 ## 색상

--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -1,16 +1,10 @@
-import type { CommitNode, SelectedDataProps } from "types";
+import "./Detail.scss";
 import { getTime } from "utils";
 
 import { useCommitListHide } from "./Detail.hook";
 import { getCommitListDetail } from "./Detail.util";
 import { FIRST_SHOW_NUM } from "./Detail.const";
-
-import "./Detail.scss";
-
-type DetailSummaryProps = {
-  commitNodeListInCluster: CommitNode[];
-};
-type DetailProps = { selectedData: SelectedDataProps };
+import type { DetailProps, DetailSummaryProps } from "./Detail.type";
 
 const DetailSummary = ({ commitNodeListInCluster }: DetailSummaryProps) => {
   const { authorLength, fileLength, commitLength, insertions, deletions } =

--- a/packages/view/src/components/Detail/Detail.type.ts
+++ b/packages/view/src/components/Detail/Detail.type.ts
@@ -1,0 +1,6 @@
+import type { ClusterNode, SelectedDataProps } from "types";
+
+export type DetailProps = { selectedData: SelectedDataProps };
+export type DetailSummaryProps = {
+  commitNodeListInCluster: ClusterNode["commitNodeList"];
+};

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -2,9 +2,7 @@ import type { ChangeEvent, MouseEvent } from "react";
 import { useRef, useEffect, useState } from "react";
 import * as d3 from "d3";
 
-import type { ClusterNode } from "types";
-
-import type { StatisticsProps } from "../Statistics.type";
+import type { ClusterNode, GlobalProps } from "types";
 
 import type { AuthorDataType, MetricType } from "./AuthorBarChart.type";
 import {
@@ -16,9 +14,7 @@ import { DIMENSIONS, METRIC_TYPE } from "./AuthorBarChart.const";
 
 import "./AuthorBarChart.scss";
 
-type AuthorBarChartProps = StatisticsProps;
-
-const AuthorBarChart = ({ data: rawData }: AuthorBarChartProps) => {
+const AuthorBarChart = ({ data: rawData }: GlobalProps) => {
   const svgRef = useRef<SVGSVGElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
 

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -2,7 +2,9 @@ import type { ChangeEvent, MouseEvent } from "react";
 import { useRef, useEffect, useState } from "react";
 import * as d3 from "d3";
 
-import type { ClusterNode, StatisticsProps } from "types";
+import type { ClusterNode } from "types";
+
+import type { StatisticsProps } from "../Statistics.type";
 
 import type { AuthorDataType, MetricType } from "./AuthorBarChart.type";
 import {

--- a/packages/view/src/components/Statistics/Statistics.tsx
+++ b/packages/view/src/components/Statistics/Statistics.tsx
@@ -1,8 +1,7 @@
-import type { StatisticsProps } from "types";
-
 import { AuthorBarChart } from "./AuthorBarChart";
 import { FileIcicleSummary } from "./FileIcicleSummary";
 import "./Statistics.scss";
+import type { StatisticsProps } from "./Statistics.type";
 
 const Statistics = ({ data }: StatisticsProps) => {
   return (

--- a/packages/view/src/components/Statistics/Statistics.tsx
+++ b/packages/view/src/components/Statistics/Statistics.tsx
@@ -1,9 +1,10 @@
+import type { GlobalProps } from "types";
+
 import { AuthorBarChart } from "./AuthorBarChart";
 import { FileIcicleSummary } from "./FileIcicleSummary";
 import "./Statistics.scss";
-import type { StatisticsProps } from "./Statistics.type";
 
-const Statistics = ({ data }: StatisticsProps) => {
+const Statistics = ({ data }: GlobalProps) => {
   return (
     <div className="statistics">
       <AuthorBarChart data={data} />

--- a/packages/view/src/components/Statistics/Statistics.type.ts
+++ b/packages/view/src/components/Statistics/Statistics.type.ts
@@ -1,3 +1,0 @@
-import type { GlobalProps } from "types";
-
-export type StatisticsProps = GlobalProps;

--- a/packages/view/src/components/Statistics/Statistics.type.ts
+++ b/packages/view/src/components/Statistics/Statistics.type.ts
@@ -1,0 +1,3 @@
+import type { GlobalProps } from "types";
+
+export type StatisticsProps = GlobalProps;

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -1,13 +1,16 @@
 import type { RefObject } from "react";
-import React, { useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import * as d3 from "d3";
-
-import type { ClusterNode, SelectedDataProps } from "types";
 
 import "./ClusterGraph.scss";
 
 import { selectedDataUpdater } from "../VerticalClusterList.util";
 
+import type {
+  ClusterGraphProps,
+  ClusterGraphElement,
+  SVGElementSelection,
+} from "./ClusterGraph.type";
 import {
   getGraphHeight,
   getClusterSizes,
@@ -21,10 +24,6 @@ import {
   SVG_MARGIN,
   SVG_WIDTH,
 } from "./ClusterGraph.const";
-import type {
-  ClusterGraphElement,
-  SVGElementSelection,
-} from "./ClusterGraph.type";
 
 const drawClusterBox = (container: SVGElementSelection<SVGGElement>) => {
   container
@@ -123,13 +122,6 @@ const drawClusterGraph = (
 
 const destroyClusterGraph = (target: RefObject<SVGElement>) =>
   d3.select(target.current).selectAll("*").remove();
-
-type ClusterGraphProps = {
-  data: ClusterNode[];
-  selectedData: SelectedDataProps;
-  detailElementHeight: number;
-  setSelectedData: React.Dispatch<React.SetStateAction<SelectedDataProps>>;
-};
 
 const ClusterGraph = ({
   data,

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.type.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.type.ts
@@ -2,6 +2,8 @@ import type { BaseType, Selection } from "d3";
 
 import type { ClusterNode } from "types";
 
+import type { VerticalClusterListProps } from "../VerticalClusterList.type";
+
 export type ClusterGraphElement = {
   cluster: ClusterNode;
   clusterSize: number;
@@ -14,3 +16,7 @@ export type SVGElementSelection<T extends BaseType> = Selection<
   SVGSVGElement | null,
   unknown
 >;
+
+export type ClusterGraphProps = VerticalClusterListProps & {
+  detailElementHeight: number;
+};

--- a/packages/view/src/components/VerticalClusterList/Summary/AuthorName/AuthorName.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/AuthorName/AuthorName.tsx
@@ -1,6 +1,7 @@
+import type { AuthorNameProps } from "../Summary.type";
 import { getColorValue } from "../Summary.util";
 
-const AuthorName = ({ authorName }: { authorName: string }) => {
+const AuthorName = ({ authorName }: AuthorNameProps) => {
   const colorValue = getColorValue(authorName);
   return (
     <span

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -1,13 +1,14 @@
-import React, { forwardRef, useRef, useEffect } from "react";
+import { forwardRef, useRef, useEffect } from "react";
 import {
   IoIosArrowDropdownCircle,
   IoIosArrowDropupCircle,
 } from "react-icons/io";
 
-import type { ClusterNode, SelectedDataProps } from "types";
+import type { SelectedDataProps } from "types";
 import { Detail } from "components";
 
 import { selectedDataUpdater } from "../VerticalClusterList.util";
+import type { VerticalClusterListProps } from "../VerticalClusterList.type";
 
 import { AuthorName } from "./AuthorName";
 import type { Cluster } from "./Summary.type";
@@ -15,13 +16,7 @@ import { getClusterById, getInitData } from "./Summary.util";
 
 import "./Summary.scss";
 
-type SummaryProps = {
-  data: ClusterNode[];
-  setSelectedData: React.Dispatch<React.SetStateAction<SelectedDataProps>>;
-  selectedData: SelectedDataProps;
-};
-
-const Summary = forwardRef<HTMLDivElement, SummaryProps>(
+const Summary = forwardRef<HTMLDivElement, VerticalClusterListProps>(
   ({ data, selectedData, setSelectedData }, ref) => {
     const clusters = getInitData({ data });
     const scrollRef = useRef<HTMLDivElement>(null);

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.type.ts
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.type.ts
@@ -1,6 +1,5 @@
-export type Keyword = {
-  keyword: string;
-  count: number;
+export type AuthorNameProps = {
+  authorName: string;
 };
 
 export type Content = {
@@ -9,7 +8,7 @@ export type Content = {
 };
 
 export type Summary = {
-  authorNames: Array<Array<string>>;
+  authorNames: Array<Array<AuthorNameProps["authorName"]>>;
   content: Content;
 };
 

--- a/packages/view/src/components/VerticalClusterList/VerticalClusterList.tsx
+++ b/packages/view/src/components/VerticalClusterList/VerticalClusterList.tsx
@@ -1,23 +1,17 @@
-import React, { useRef } from "react";
+import { useRef } from "react";
 
-import type { GlobalProps, SelectedDataProps } from "types";
+import "./VerticalClusterList.scss";
 
 import { ClusterGraph } from "./ClusterGraph";
 import { Summary } from "./Summary";
 import { useResizeObserver } from "./VerticalClusterList.hook";
-
-import "./VerticalClusterList.scss";
-
-type Props = GlobalProps & {
-  setSelectedData: React.Dispatch<React.SetStateAction<SelectedDataProps>>;
-  selectedData: SelectedDataProps;
-};
+import type { VerticalClusterListProps } from "./VerticalClusterList.type";
 
 const VerticalClusterList = ({
   data,
   setSelectedData,
   selectedData,
-}: Props) => {
+}: VerticalClusterListProps) => {
   const detailRef = useRef<HTMLDivElement>(null);
   const [detailElementHeight] = useResizeObserver(detailRef, selectedData);
 

--- a/packages/view/src/components/VerticalClusterList/VerticalClusterList.type.ts
+++ b/packages/view/src/components/VerticalClusterList/VerticalClusterList.type.ts
@@ -1,0 +1,8 @@
+import type React from "react";
+
+import type { GlobalProps, SelectedDataProps } from "types";
+
+export type VerticalClusterListProps = GlobalProps & {
+  selectedData: SelectedDataProps;
+  setSelectedData: React.Dispatch<React.SetStateAction<SelectedDataProps>>;
+};

--- a/packages/view/src/types/global.ts
+++ b/packages/view/src/types/global.ts
@@ -2,4 +2,3 @@ import type { ClusterNode } from "./NodeTypes.temp";
 
 export type GlobalProps = { data: ClusterNode[] };
 export type SelectedDataProps = ClusterNode | null;
-export type StatisticsProps = { data: ClusterNode[] };


### PR DESCRIPTION
## 관련이슈
[#175 ](https://github.com/githru/githru-vscode-ext/issues/175)

## 이전상황
Compenent props들이 Component 안에 같이 존재했습니다.

## 해결방안
대부분의 Component props를 분리하고 리팩토링했습니다.
다른 곳에서 쓰이지 않는 props type이라면 해당 컴포넌트의 type 파일로 분리해두었습니다.
혹시 안좋은 패턴이 있거나 의도하셨는데 제가 고친 부분이 있다면 편히 말씀해주세요 !