### PR TITLE
fix(view): modify logic of chart transition in VerticalClusterList

### DIFF
--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.const.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.const.ts
@@ -1,5 +1,6 @@
 export const NODE_GAP = 10;
 export const CLUSTER_HEIGHT = 40;
+export const DETAIL_HEIGHT = 220;
 export const GRAPH_WIDTH = 80;
 export const SVG_WIDTH = GRAPH_WIDTH + 4;
 export const SVG_MARGIN = {

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -79,7 +79,9 @@ const drawLink = (
         SVG_MARGIN.top + (CLUSTER_HEIGHT + i * (CLUSTER_HEIGHT + NODE_GAP));
       return (
         initPosition +
-        (d.selected < i && d.selected >= 0 ? detailElementHeight : 0)
+        (d.selected.current < i && d.selected.current >= 0
+          ? detailElementHeight
+          : 0)
       );
     })
     .attr("y2", (d, i) => {
@@ -88,7 +90,9 @@ const drawLink = (
         (CLUSTER_HEIGHT + NODE_GAP + i * (CLUSTER_HEIGHT + NODE_GAP));
       return (
         initPosition +
-        (d.selected <= i && d.selected >= 0 ? detailElementHeight : 0)
+        (d.selected.current <= i && d.selected.current >= 0
+          ? detailElementHeight
+          : 0)
       );
     });
 };
@@ -135,11 +139,15 @@ const ClusterGraph = ({
   const graphHeight =
     getGraphHeight(clusterSizes) +
     (selectedIndex < 0 ? 0 : detailElementHeight);
+  const prevSelected = useRef<number>(-1);
 
   const clusterGraphElements = data.map((cluster, i) => ({
     cluster,
     clusterSize: clusterSizes[i],
-    selected: selectedIndex,
+    selected: {
+      prev: prevSelected.current,
+      current: selectedIndex,
+    },
   }));
 
   useEffect(() => {
@@ -154,6 +162,7 @@ const ClusterGraph = ({
       detailElementHeight,
       handleClickCluster
     );
+    prevSelected.current = selectedIndex;
     return () => {
       destroyClusterGraph(svgRef);
     };

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.type.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.type.ts
@@ -7,7 +7,10 @@ import type { VerticalClusterListProps } from "../VerticalClusterList.type";
 export type ClusterGraphElement = {
   cluster: ClusterNode;
   clusterSize: number;
-  selected: number;
+  selected: {
+    prev: number;
+    current: number;
+  };
 };
 
 export type SVGElementSelection<T extends BaseType> = Selection<

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.type.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.type.ts
@@ -20,6 +20,4 @@ export type SVGElementSelection<T extends BaseType> = Selection<
   unknown
 >;
 
-export type ClusterGraphProps = VerticalClusterListProps & {
-  detailElementHeight: number;
-};
+export type ClusterGraphProps = VerticalClusterListProps;

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.util.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.util.ts
@@ -21,7 +21,7 @@ export function getClusterPosition(
   detailElementHeight: number,
   isPrev = false
 ) {
-  const selected = isPrev ? Infinity : d.selected;
+  const selected = isPrev ? d.selected.prev : d.selected.current;
   const margin = selected >= 0 && selected < i ? detailElementHeight : 0;
   const x = SVG_MARGIN.left;
   const y = SVG_MARGIN.top + i * (CLUSTER_HEIGHT + NODE_GAP) + margin;

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -33,7 +33,10 @@ const Summary = forwardRef<HTMLDivElement, VerticalClusterListProps>(
     };
 
     useEffect(() => {
-      scrollRef.current?.scrollIntoView({ block: "center" });
+      scrollRef.current?.scrollIntoView({
+        block: "center",
+        behavior: "smooth",
+      });
     }, [selectedData]);
 
     return (

--- a/packages/view/src/components/VerticalClusterList/VerticalClusterList.tsx
+++ b/packages/view/src/components/VerticalClusterList/VerticalClusterList.tsx
@@ -4,7 +4,6 @@ import "./VerticalClusterList.scss";
 
 import { ClusterGraph } from "./ClusterGraph";
 import { Summary } from "./Summary";
-import { useResizeObserver } from "./VerticalClusterList.hook";
 import type { VerticalClusterListProps } from "./VerticalClusterList.type";
 
 const VerticalClusterList = ({
@@ -13,7 +12,6 @@ const VerticalClusterList = ({
   selectedData,
 }: VerticalClusterListProps) => {
   const detailRef = useRef<HTMLDivElement>(null);
-  const [detailElementHeight] = useResizeObserver(detailRef, selectedData);
 
   return (
     <div className="vertical-cluster-list">
@@ -21,7 +19,6 @@ const VerticalClusterList = ({
         data={data}
         selectedData={selectedData}
         setSelectedData={setSelectedData}
-        detailElementHeight={detailElementHeight}
       />
       <Summary
         ref={detailRef}


### PR DESCRIPTION
## Related issues

- https://github.com/githru/githru-vscode-ext/issues/226

## WorkList

293ef890ec8c3dbeff64839579b0acde4269fb37
- `{behavior: "smooth"}` option 추가를 통해 Detail이 펼쳐질 때 스크롤이 부드럽게 펼쳐지도록 개선했습니다.

29357850e5bb7ecbafa9ad03166e3a7103d2f1a8
- @hanseul-lee 님의 의견을 바탕으로 ClusterGraph에서 Detail이 펼쳐질 때 펼쳐지는 방향을 개선했습니다.
- 기존 ClusterGraph에서는 현재 선택된 cluster에서 아랫쪽 cluster가 열리든 위쪽 cluster가 열리든, 모든 open transition이 위에서 아래 방향으로 펼쳐졌습니다.
- 하지만, 아랫쪽 cluster가 펼쳐질 때는 ClusterGraph가 아랫쪽에서 위쪽으로 펼쳐지는 transition을 적용함으로써 좀 더 자연스러운 transition을 부여하고자 했습니다.

**Problem**
- d3 + react를 사용하는데 있어서, d3의 draw 로직을 모두 useEffect hook에서 진행하고, cleanup 시에 destroy 하기 때문에 기존에 그려진 d3 element를 기억하지 못하고 deps의 변경이 있을 때마다 다시 draw 하게 됩니다.
- d3로 transition을 부여하기 위해선, 기존에 그려진 d3 element를 바탕으로 transition() function을 통해서 부여하게 되는데, 앞서 언급한 것과 같이 d3 element를 destroy 하고 다시 draw 하는 작업을 거치기 때문에, Graph의 이전 상태를 기억할 수 없습니다.
- 따라서 React의 useRef hook을 통해 data의 변경이 발생해도 리렌더링이 일어나지 않는 (사실은 useEffect 내부 cleanup에서 destroy가 발생하지 않는) 값으로 이전에 선택된 cluster의 index를 저장해둔 다음, Graph가 펼쳐질 때 이전 상태로 draw 한 뒤 바로 다음 상태로 transition을 걸어서 마치 transition으로만 데이터를 변경하는 것처럼 눈속임하였습니다.
- 하지만, 현재 Detail 컴포넌트의 크기에 따라 ClusterGraph가 펼쳐지는 크기를 observer로 관찰하여 가변적으로 바꾸고 있었기 때문에, detailElementHeight라는 Props의 변경이 초기 렌더링 시 발생하게 되고, 이 때 이전에 선택된 cluster의 index를 저장하는 작업이 중복으로 일어나게되어 transition이 아래와 같이 끊기는 문제가 있었습니다. ( `prev: -1, current: -1` -> `prev: -1 , current: 2` -> `prev: 2, current: 2` state 변경이 동시에 일어나게되어 결국 마지막 값인 `prev: 2, current: 2` 가 반영되고, 이에 따라 draw 하는 값도 2, transition 값도 2가 되어 움직이지 않게 보이게 됨)

<div align="center">
  <img src="https://user-images.githubusercontent.com/49841765/192227954-a8d89423-afa3-4b27-8022-068236f730ea.gif" />
</div>

- 그렇기 때문에, 우선적으로 DETAIL_HEIGHT를 고정시키는 방향으로 구현을 진행했습니다.


80916491e96f563991ab39b9ff69e87653d0b049
- @jin-Pro 님의 의견을 바탕으로 ClusterGraph의 Node link line 구현 방식을 수정했습니다.
- 각 Node 마다 position을 계산해서 다수의 line element를 통해 구현을 진행했던 기존 방식에서, 전체 Node를 관통하고 있는 하나의 line element로 대체함으로써 transition이 보이는 것과 같은 효과를 내도록 수정했습니다.

## Result

<div align="center">
  <img src="https://user-images.githubusercontent.com/49841765/192228694-cc674151-29f4-4ddc-9d35-25f6ca5a0227.gif" />
</div>


