### PR TITLE
feat(view): global state management using context API used by taejs

### DIFF
--- a/packages/view/src/App.tsx
+++ b/packages/view/src/App.tsx
@@ -1,60 +1,26 @@
-import { useEffect, useMemo, useState } from "react";
-
-import {
-  // Detail,
-  Statistics,
-  TemporalFilter,
-  VerticalClusterList,
-} from "components";
-import type { SelectedDataProps } from "types";
-import { sortBasedOnCommitNode } from "components/TemporalFilter/TemporalFilter.util";
+import { Statistics, TemporalFilter, VerticalClusterList } from "components";
 import { ClocLineChart } from "components/TemporalFilter/ClocLineChart";
 import { CommitLineChart } from "components/TemporalFilter/CommitLineChart";
 
 import "./App.scss";
-import { useGetTotalData } from "./App.hook";
 
 const App = () => {
-  const { data } = useGetTotalData();
-  const [filteredData, setFilteredData] = useState(data);
-  const [selectedData, setSelectedData] = useState<SelectedDataProps>(null);
-  const filteredCommitNodes = useMemo(
-    () => sortBasedOnCommitNode(filteredData),
-    [filteredData]
-  );
-
-  // delete
-  useEffect(() => {
-    setFilteredData(data);
-  }, [data]);
-
-  useEffect(() => {
-    setSelectedData(null);
-  }, [filteredData]);
-
-  if (!data.length || !filteredData.length) return null;
-
   return (
     <div>
       <div className="head-container">
         <article className="temporal-filter">
           <div className="data-control-container">
-            <TemporalFilter data={data} setFilteredData={setFilteredData} />
-            {/* <ThemeSelector /> */}
+            <TemporalFilter />
           </div>
           <div className="line-chart">
-            <ClocLineChart data={filteredCommitNodes} />
-            <CommitLineChart data={filteredCommitNodes} />
+            <ClocLineChart />
+            <CommitLineChart />
           </div>
         </article>
       </div>
       <div className="middle-container">
-        <VerticalClusterList
-          data={filteredData}
-          selectedData={selectedData}
-          setSelectedData={setSelectedData}
-        />
-        <Statistics data={selectedData ? [selectedData] : filteredData} />
+        <VerticalClusterList />
+        <Statistics />
       </div>
     </div>
   );

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -2,7 +2,9 @@ import type { ChangeEvent, MouseEvent } from "react";
 import { useRef, useEffect, useState } from "react";
 import * as d3 from "d3";
 
-import type { ClusterNode, GlobalProps } from "types";
+import type { ClusterNode } from "types";
+
+import { useGetSelectedData } from "../Statistics.hook";
 
 import type { AuthorDataType, MetricType } from "./AuthorBarChart.type";
 import {
@@ -14,7 +16,8 @@ import { DIMENSIONS, METRIC_TYPE } from "./AuthorBarChart.const";
 
 import "./AuthorBarChart.scss";
 
-const AuthorBarChart = ({ data: rawData }: GlobalProps) => {
+const AuthorBarChart = () => {
+  const rawData = useGetSelectedData();
   const svgRef = useRef<SVGSVGElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
 

--- a/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
+++ b/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
@@ -3,7 +3,7 @@ import type { HierarchyRectangularNode } from "d3";
 import type { RefObject } from "react";
 import { useEffect, useRef } from "react";
 
-import type { ClusterNode } from "types";
+import { useGetSelectedData } from "../Statistics.hook";
 
 import { getFileChangesTree } from "./FileIcicleSummary.util";
 import type { FileChangesNode } from "./FileIcicleSummary.type";
@@ -16,6 +16,7 @@ import {
   LABEL_VISIBLE_HEIGHT,
   COLOR_CODE,
 } from "./FileIcicleSummary.const";
+
 import "./FileIcicleSummary.scss";
 
 const partition = (data: FileChangesNode) => {
@@ -129,7 +130,8 @@ const destroyIcicleTree = ($target: RefObject<SVGSVGElement>) => {
   d3.select($target.current).selectAll("svg").remove();
 };
 
-const FileIcicleSummary = ({ data }: { data: ClusterNode[] }) => {
+const FileIcicleSummary = () => {
+  const data = useGetSelectedData();
   const $summary = useRef<SVGSVGElement>(null);
 
   useEffect(() => {

--- a/packages/view/src/components/Statistics/Statistics.hook.tsx
+++ b/packages/view/src/components/Statistics/Statistics.hook.tsx
@@ -1,0 +1,6 @@
+import { useGlobalData } from "hooks/useGlobalData";
+
+export const useGetSelectedData = () => {
+  const { filteredData, selectedData } = useGlobalData();
+  return (selectedData ? [selectedData] : filteredData) ?? [];
+};

--- a/packages/view/src/components/Statistics/Statistics.hook.tsx
+++ b/packages/view/src/components/Statistics/Statistics.hook.tsx
@@ -1,4 +1,4 @@
-import { useGlobalData } from "hooks/useGlobalData";
+import { useGlobalData } from "../../hooks/useGlobalData";
 
 export const useGetSelectedData = () => {
   const { filteredData, selectedData } = useGlobalData();

--- a/packages/view/src/components/Statistics/Statistics.tsx
+++ b/packages/view/src/components/Statistics/Statistics.tsx
@@ -1,10 +1,12 @@
-import type { GlobalProps } from "types";
+import { useGlobalData } from "hooks/useGlobalData";
 
 import { AuthorBarChart } from "./AuthorBarChart";
 import { FileIcicleSummary } from "./FileIcicleSummary";
 import "./Statistics.scss";
 
-const Statistics = ({ data }: GlobalProps) => {
+const Statistics = () => {
+  const { filteredData, selectedData } = useGlobalData();
+  const data = (selectedData ? [selectedData] : filteredData) ?? [];
   return (
     <div className="statistics">
       <AuthorBarChart data={data} />

--- a/packages/view/src/components/Statistics/Statistics.tsx
+++ b/packages/view/src/components/Statistics/Statistics.tsx
@@ -1,16 +1,12 @@
-import { useGlobalData } from "hooks/useGlobalData";
-
 import { AuthorBarChart } from "./AuthorBarChart";
 import { FileIcicleSummary } from "./FileIcicleSummary";
 import "./Statistics.scss";
 
 const Statistics = () => {
-  const { filteredData, selectedData } = useGlobalData();
-  const data = (selectedData ? [selectedData] : filteredData) ?? [];
   return (
     <div className="statistics">
-      <AuthorBarChart data={data} />
-      <FileIcicleSummary data={data} />
+      <AuthorBarChart />
+      <FileIcicleSummary />
     </div>
   );
 };

--- a/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.tsx
+++ b/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.tsx
@@ -10,8 +10,7 @@ import {
 } from "d3";
 import { useEffect, useMemo, useRef } from "react";
 
-import { useGlobalData } from "hooks/useGlobalData";
-
+import { useGlobalData } from "../../../hooks/useGlobalData";
 import {
   getCloc,
   getMinMaxDate,

--- a/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.tsx
+++ b/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.tsx
@@ -8,17 +8,28 @@ import {
   ticks,
   // axisBottom,
 } from "d3";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
-import type { CommitNode } from "../TemporalFilter.type";
-import { getCloc, getMinMaxDate } from "../TemporalFilter.util";
+import { useGlobalData } from "hooks/useGlobalData";
+
+import {
+  getCloc,
+  getMinMaxDate,
+  sortBasedOnCommitNode,
+} from "../TemporalFilter.util";
 
 import "./ClocLineChart.scss";
 // TODO margin 추가하기
 // timeFormatter
+
 import { CLOC_STYLING } from "./ClocLineChart.const";
 
-const ClocLineChart = ({ data }: { data: CommitNode[] }) => {
+const ClocLineChart = () => {
+  const { filteredData } = useGlobalData();
+  const data = useMemo(
+    () => sortBasedOnCommitNode(filteredData ?? []),
+    [filteredData]
+  );
   const wrapperRef = useRef<HTMLDivElement>(null);
   const ref = useRef<SVGSVGElement>(null);
 

--- a/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.tsx
+++ b/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.tsx
@@ -27,7 +27,7 @@ import { CLOC_STYLING } from "./ClocLineChart.const";
 const ClocLineChart = () => {
   const { filteredData } = useGlobalData();
   const data = useMemo(
-    () => sortBasedOnCommitNode(filteredData ?? []),
+    () => sortBasedOnCommitNode(filteredData),
     [filteredData]
   );
   const wrapperRef = useRef<HTMLDivElement>(null);

--- a/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.type.ts
+++ b/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.type.ts
@@ -1,5 +1,5 @@
 export type ClocType = {
   insertion: number;
   deletion: number;
-  CommitDate:string;
+  CommitDate: string;
 };

--- a/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.tsx
+++ b/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.tsx
@@ -10,18 +10,22 @@ import {
   timeFormat,
   timeTicks,
 } from "d3";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
-import type { CommitNode } from "../TemporalFilter.type";
-import { getMinMaxDate } from "../TemporalFilter.util";
+import { useGlobalData } from "hooks/useGlobalData";
 
-// import { CLOC_STYLING } from "./CommitLineChart.const";
+import { getMinMaxDate, sortBasedOnCommitNode } from "../TemporalFilter.util";
 
 import "./CommitLineChart.scss";
 
 const timeFormatter = timeFormat("%Y %m %d");
 
-const CommitLineChart = ({ data }: { data: CommitNode[] }) => {
+const CommitLineChart = () => {
+  const { filteredData } = useGlobalData();
+  const data = useMemo(
+    () => sortBasedOnCommitNode(filteredData ?? []),
+    [filteredData]
+  );
   const wrapperRef = useRef<HTMLDivElement>(null);
   const ref = useRef<SVGSVGElement>(null);
 

--- a/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.tsx
+++ b/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.tsx
@@ -23,7 +23,7 @@ const timeFormatter = timeFormat("%Y %m %d");
 const CommitLineChart = () => {
   const { filteredData } = useGlobalData();
   const data = useMemo(
-    () => sortBasedOnCommitNode(filteredData ?? []),
+    () => sortBasedOnCommitNode(filteredData),
     [filteredData]
   );
   const wrapperRef = useRef<HTMLDivElement>(null);

--- a/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.tsx
+++ b/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.tsx
@@ -12,8 +12,7 @@ import {
 } from "d3";
 import { useEffect, useMemo, useRef } from "react";
 
-import { useGlobalData } from "hooks/useGlobalData";
-
+import { useGlobalData } from "../../../hooks/useGlobalData";
 import { getMinMaxDate, sortBasedOnCommitNode } from "../TemporalFilter.util";
 
 import "./CommitLineChart.scss";

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
@@ -1,7 +1,6 @@
-import type { Dispatch, SetStateAction } from "react";
 import { useState, useEffect } from "react";
 
-import type { ClusterNode, GlobalProps } from "types";
+import { useGlobalData } from "../../hooks/useGlobalData";
 
 import { Filter } from "./Filter";
 import {
@@ -9,24 +8,26 @@ import {
   getMinMaxDate,
   sortBasedOnCommitNode,
 } from "./TemporalFilter.util";
-// import { ThemeSelector } from "./ThemeSelector";
+
 import "./TemporalFilter.scss";
 
-type Props = GlobalProps & {
-  setFilteredData: Dispatch<SetStateAction<ClusterNode[]>>;
-};
-
-const TemporalFilter = ({ data, setFilteredData }: Props) => {
-  const sortedData = sortBasedOnCommitNode(data);
+const TemporalFilter = () => {
+  const { data, setFilteredData } = useGlobalData();
+  const sortedData = sortBasedOnCommitNode(data ?? []);
   const [minDate, maxDate] = getMinMaxDate(sortedData);
   const [fromDate, setFromDate] = useState<string>(minDate);
   const [toDate, setToDate] = useState<string>(maxDate);
 
   useEffect(() => {
+    if (!setFilteredData) return;
     if (fromDate === "" || toDate === "") {
-      setFilteredData(data);
+      setFilteredData(data ?? []);
     } else {
-      const filteredData = filterDataByDate({ data, fromDate, toDate });
+      const filteredData = filterDataByDate({
+        data: data ?? [],
+        fromDate,
+        toDate,
+      });
       filteredData.reverse();
       setFilteredData(filteredData);
     }

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
@@ -20,10 +20,10 @@ const TemporalFilter = () => {
 
   useEffect(() => {
     if (fromDate === "" || toDate === "") {
-      setFilteredData(data ?? []);
+      setFilteredData(data);
     } else {
       const filteredData = filterDataByDate({
-        data: data ?? [],
+        data,
         fromDate,
         toDate,
       });

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
@@ -13,13 +13,12 @@ import "./TemporalFilter.scss";
 
 const TemporalFilter = () => {
   const { data, setFilteredData } = useGlobalData();
-  const sortedData = sortBasedOnCommitNode(data ?? []);
+  const sortedData = sortBasedOnCommitNode(data);
   const [minDate, maxDate] = getMinMaxDate(sortedData);
   const [fromDate, setFromDate] = useState<string>(minDate);
   const [toDate, setToDate] = useState<string>(maxDate);
 
   useEffect(() => {
-    if (!setFilteredData) return;
     if (fromDate === "" || toDate === "") {
       setFilteredData(data ?? []);
     } else {

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.hook.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.hook.tsx
@@ -1,4 +1,5 @@
 import type { Dispatch, RefObject } from "react";
+import type React from "react";
 import { useCallback, useEffect, useRef } from "react";
 import * as d3 from "d3";
 
@@ -109,7 +110,7 @@ export const useHandleClusterGraph = ({
   data: ClusterNode[];
   clusterSizes: number[];
   selectedIndex: number;
-  setSelectedData: Dispatch<ClusterNode | null>;
+  setSelectedData: Dispatch<React.SetStateAction<ClusterNode | null>>;
 }) => {
   const svgRef = useRef<SVGSVGElement>(null);
   const prevSelected = useRef<number>(-1);
@@ -126,10 +127,7 @@ export const useHandleClusterGraph = ({
   const handleClickCluster = useCallback(
     (_: PointerEvent, d: ClusterGraphElement) =>
       setSelectedData(
-        selectedDataUpdater(
-          d.cluster,
-          d.cluster.commitNodeList[0].clusterId
-        ) as any
+        selectedDataUpdater(d.cluster, d.cluster.commitNodeList[0].clusterId)
       ),
     []
   );

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.hook.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.hook.tsx
@@ -129,7 +129,7 @@ export const useHandleClusterGraph = ({
       setSelectedData(
         selectedDataUpdater(d.cluster, d.cluster.commitNodeList[0].clusterId)
       ),
-    []
+    [setSelectedData]
   );
   useEffect(() => {
     drawClusterGraph(

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.hook.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.hook.tsx
@@ -1,0 +1,149 @@
+import type { Dispatch, RefObject } from "react";
+import { useCallback, useEffect, useRef } from "react";
+import * as d3 from "d3";
+
+import type { ClusterNode } from "types";
+
+import { selectedDataUpdater } from "../VerticalClusterList.util";
+
+import {
+  CLUSTER_HEIGHT,
+  DETAIL_HEIGHT,
+  GRAPH_WIDTH,
+  NODE_GAP,
+  SVG_MARGIN,
+} from "./ClusterGraph.const";
+import type {
+  ClusterGraphElement,
+  SVGElementSelection,
+} from "./ClusterGraph.type";
+import { getClusterPosition } from "./ClusterGraph.util";
+
+const drawClusterBox = (container: SVGElementSelection<SVGGElement>) => {
+  container
+    .append("rect")
+    .attr("class", "cluster-graph__cluster")
+    .attr("width", GRAPH_WIDTH)
+    .attr("height", CLUSTER_HEIGHT);
+};
+
+const drawDegreeBox = (container: SVGElementSelection<SVGGElement>) => {
+  const widthScale = d3.scaleLinear().range([0, GRAPH_WIDTH]).domain([0, 10]);
+  container
+    .append("rect")
+    .attr("class", "cluster-graph__degree")
+    .attr("width", (d) => widthScale(Math.min(d.clusterSize, 10)))
+    .attr("height", CLUSTER_HEIGHT)
+    .attr(
+      "x",
+      (d) => (GRAPH_WIDTH - widthScale(Math.min(d.clusterSize, 10))) / 2
+    );
+};
+
+const drawLink = (
+  svgRef: RefObject<SVGSVGElement>,
+  data: ClusterGraphElement[],
+  detailElementHeight: number
+) => {
+  d3.select(svgRef.current)
+    .selectAll(".cluster-graph__link")
+    .data([
+      {
+        start: SVG_MARGIN.top,
+        end: (CLUSTER_HEIGHT + NODE_GAP) * data.length,
+        selected: {
+          prev: data[0].selected.prev,
+          current: data[0].selected.current,
+        },
+      },
+    ])
+    .join("line")
+    .attr("class", "cluster-graph__link")
+    .attr("x1", SVG_MARGIN.left + GRAPH_WIDTH / 2)
+    .attr("y1", (d) => d.start)
+    .attr("x2", SVG_MARGIN.left + GRAPH_WIDTH / 2)
+    .attr("y2", (d) => d.end + (d.selected.prev < 0 ? 0 : detailElementHeight))
+    .transition()
+    .attr(
+      "y2",
+      (d) => d.end + (d.selected.current < 0 ? 0 : detailElementHeight)
+    );
+};
+
+const drawClusterGraph = (
+  svgRef: RefObject<SVGSVGElement>,
+  data: ClusterGraphElement[],
+  detailElementHeight: number,
+  onClickCluster: (_: PointerEvent, d: ClusterGraphElement) => void
+) => {
+  const group = d3
+    .select(svgRef.current)
+    .selectAll(".cluster-graph__container")
+    .data(data)
+    .join("g")
+    .on("click", onClickCluster)
+    .attr("class", "cluster-graph__container")
+    .attr("transform", (d, i) =>
+      getClusterPosition(d, i, detailElementHeight, true)
+    );
+  group
+    .transition()
+    .duration(300)
+    .ease(d3.easeLinear)
+    .attr("transform", (d, i) => getClusterPosition(d, i, detailElementHeight));
+
+  drawLink(svgRef, data, detailElementHeight);
+  drawClusterBox(group);
+  drawDegreeBox(group);
+};
+
+const destroyClusterGraph = (target: RefObject<SVGElement>) =>
+  d3.select(target.current).selectAll("*").remove();
+
+export const useHandleClusterGraph = ({
+  clusterSizes,
+  selectedIndex,
+  data,
+  setSelectedData,
+}: {
+  data: ClusterNode[];
+  clusterSizes: number[];
+  selectedIndex: number;
+  setSelectedData: Dispatch<ClusterNode | null>;
+}) => {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const prevSelected = useRef<number>(-1);
+
+  const clusterGraphElements = data.map((cluster, i) => ({
+    cluster,
+    clusterSize: clusterSizes[i],
+    selected: {
+      prev: prevSelected.current,
+      current: selectedIndex,
+    },
+  }));
+
+  const handleClickCluster = useCallback(
+    (_: PointerEvent, d: ClusterGraphElement) =>
+      setSelectedData(
+        selectedDataUpdater(
+          d.cluster,
+          d.cluster.commitNodeList[0].clusterId
+        ) as any
+      ),
+    []
+  );
+  useEffect(() => {
+    drawClusterGraph(
+      svgRef,
+      clusterGraphElements,
+      DETAIL_HEIGHT,
+      handleClickCluster
+    );
+    prevSelected.current = selectedIndex;
+    return () => {
+      destroyClusterGraph(svgRef);
+    };
+  }, [handleClickCluster, clusterGraphElements, selectedIndex]);
+  return svgRef;
+};

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -1,6 +1,6 @@
 import "./ClusterGraph.scss";
 
-import { useGlobalData } from "hooks/useGlobalData";
+import { useGlobalData } from "../../../hooks/useGlobalData";
 
 import {
   getGraphHeight,

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -1,151 +1,28 @@
-import type { RefObject } from "react";
-import { useEffect, useRef } from "react";
-import * as d3 from "d3";
-
 import "./ClusterGraph.scss";
 
 import { useGlobalData } from "hooks/useGlobalData";
 
-import { selectedDataUpdater } from "../VerticalClusterList.util";
-
-import type {
-  ClusterGraphElement,
-  SVGElementSelection,
-} from "./ClusterGraph.type";
 import {
   getGraphHeight,
   getClusterSizes,
   getSelectedIndex,
-  getClusterPosition,
 } from "./ClusterGraph.util";
-import {
-  CLUSTER_HEIGHT,
-  DETAIL_HEIGHT,
-  GRAPH_WIDTH,
-  NODE_GAP,
-  SVG_MARGIN,
-  SVG_WIDTH,
-} from "./ClusterGraph.const";
-
-const drawClusterBox = (container: SVGElementSelection<SVGGElement>) => {
-  container
-    .append("rect")
-    .attr("class", "cluster-graph__cluster")
-    .attr("width", GRAPH_WIDTH)
-    .attr("height", CLUSTER_HEIGHT);
-};
-
-const drawDegreeBox = (container: SVGElementSelection<SVGGElement>) => {
-  const widthScale = d3.scaleLinear().range([0, GRAPH_WIDTH]).domain([0, 10]);
-  container
-    .append("rect")
-    .attr("class", "cluster-graph__degree")
-    .attr("width", (d) => widthScale(Math.min(d.clusterSize, 10)))
-    .attr("height", CLUSTER_HEIGHT)
-    .attr(
-      "x",
-      (d) => (GRAPH_WIDTH - widthScale(Math.min(d.clusterSize, 10))) / 2
-    );
-};
-
-const drawLink = (
-  svgRef: RefObject<SVGSVGElement>,
-  data: ClusterGraphElement[],
-  detailElementHeight: number
-) => {
-  d3.select(svgRef.current)
-    .selectAll(".cluster-graph__link")
-    .data([
-      {
-        start: SVG_MARGIN.top,
-        end: (CLUSTER_HEIGHT + NODE_GAP) * data.length,
-        selected: {
-          prev: data[0].selected.prev,
-          current: data[0].selected.current,
-        },
-      },
-    ])
-    .join("line")
-    .attr("class", "cluster-graph__link")
-    .attr("x1", SVG_MARGIN.left + GRAPH_WIDTH / 2)
-    .attr("y1", (d) => d.start)
-    .attr("x2", SVG_MARGIN.left + GRAPH_WIDTH / 2)
-    .attr("y2", (d) => d.end + (d.selected.prev < 0 ? 0 : detailElementHeight))
-    .transition()
-    .attr(
-      "y2",
-      (d) => d.end + (d.selected.current < 0 ? 0 : detailElementHeight)
-    );
-};
-
-const drawClusterGraph = (
-  svgRef: RefObject<SVGSVGElement>,
-  data: ClusterGraphElement[],
-  detailElementHeight: number,
-  onClickCluster: (_: PointerEvent, d: ClusterGraphElement) => void
-) => {
-  const group = d3
-    .select(svgRef.current)
-    .selectAll(".cluster-graph__container")
-    .data(data)
-    .join("g")
-    .on("click", onClickCluster)
-    .attr("class", "cluster-graph__container")
-    .attr("transform", (d, i) =>
-      getClusterPosition(d, i, detailElementHeight, true)
-    );
-  group
-    .transition()
-    .duration(300)
-    .ease(d3.easeLinear)
-    .attr("transform", (d, i) => getClusterPosition(d, i, detailElementHeight));
-
-  drawLink(svgRef, data, detailElementHeight);
-  drawClusterBox(group);
-  drawDegreeBox(group);
-};
-
-const destroyClusterGraph = (target: RefObject<SVGElement>) =>
-  d3.select(target.current).selectAll("*").remove();
+import { DETAIL_HEIGHT, SVG_WIDTH } from "./ClusterGraph.const";
+import { useHandleClusterGraph } from "./ClusterGraph.hook";
 
 const ClusterGraph = () => {
   const { filteredData: data, selectedData, setSelectedData } = useGlobalData();
-  const svgRef = useRef<SVGSVGElement>(null);
   const clusterSizes = getClusterSizes(data);
   const selectedIndex = getSelectedIndex(data, selectedData);
   const graphHeight =
     getGraphHeight(clusterSizes) + (selectedIndex < 0 ? 0 : DETAIL_HEIGHT);
-  const prevSelected = useRef<number>(-1);
 
-  const clusterGraphElements = data?.map((cluster, i) => ({
-    cluster,
-    clusterSize: clusterSizes[i],
-    selected: {
-      prev: prevSelected.current,
-      current: selectedIndex,
-    },
-  }));
-
-  useEffect(() => {
-    const handleClickCluster = (_: PointerEvent, d: ClusterGraphElement) => {
-      setSelectedData(
-        selectedDataUpdater(
-          d.cluster,
-          d.cluster.commitNodeList[0].clusterId
-        ) as any
-      );
-    };
-    drawClusterGraph(
-      svgRef,
-      clusterGraphElements,
-      DETAIL_HEIGHT,
-      handleClickCluster
-    );
-    prevSelected.current = selectedIndex;
-    return () => {
-      destroyClusterGraph(svgRef);
-    };
-  }, [clusterGraphElements, selectedIndex, setSelectedData]);
+  const svgRef = useHandleClusterGraph({
+    data,
+    clusterSizes,
+    selectedIndex,
+    setSelectedData,
+  });
 
   return (
     <svg

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -111,8 +111,8 @@ const destroyClusterGraph = (target: RefObject<SVGElement>) =>
 const ClusterGraph = () => {
   const { filteredData: data, selectedData, setSelectedData } = useGlobalData();
   const svgRef = useRef<SVGSVGElement>(null);
-  const clusterSizes = getClusterSizes(data ?? []);
-  const selectedIndex = getSelectedIndex(data ?? [], selectedData ?? null);
+  const clusterSizes = getClusterSizes(data);
+  const selectedIndex = getSelectedIndex(data, selectedData);
   const graphHeight =
     getGraphHeight(clusterSizes) + (selectedIndex < 0 ? 0 : DETAIL_HEIGHT);
   const prevSelected = useRef<number>(-1);
@@ -127,7 +127,6 @@ const ClusterGraph = () => {
   }));
 
   useEffect(() => {
-    if (!setSelectedData) return;
     const handleClickCluster = (_: PointerEvent, d: ClusterGraphElement) => {
       setSelectedData(
         selectedDataUpdater(
@@ -138,12 +137,11 @@ const ClusterGraph = () => {
     };
     drawClusterGraph(
       svgRef,
-      clusterGraphElements ?? [],
+      clusterGraphElements,
       DETAIL_HEIGHT,
       handleClickCluster
     );
     prevSelected.current = selectedIndex;
-    // eslint-disable-next-line consistent-return
     return () => {
       destroyClusterGraph(svgRef);
     };

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -20,7 +20,7 @@ const Summary = () => {
   const selectedClusterId = getClusterIds(selectedData);
   const onClickClusterSummary = (clusterId: number) => () => {
     const selected = getClusterById(data, clusterId);
-    setSelectedData(selectedDataUpdater(selected, clusterId) as any);
+    setSelectedData(selectedDataUpdater(selected, clusterId));
   };
 
   useEffect(() => {

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -18,8 +18,7 @@ const Summary = () => {
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const selectedClusterId = getClusterIds(selectedData);
-  const onClickClusterSummary = (clusterId: number) => {
-    if (!setSelectedData) return;
+  const onClickClusterSummary = (clusterId: number) => () => {
     const selected = getClusterById(data, clusterId);
     setSelectedData(selectedDataUpdater(selected, clusterId) as any);
   };
@@ -43,7 +42,7 @@ const Summary = () => {
             <button
               type="button"
               className="cluster-summary__toggle-contents-button"
-              onClick={() => onClickClusterSummary(cluster.clusterId)}
+              onClick={onClickClusterSummary(cluster.clusterId)}
             >
               <div className="cluster-summary__toggle-contents-container">
                 <div className="name-box">
@@ -69,7 +68,7 @@ const Summary = () => {
               >
                 <div ref={ref}>
                   <div className="summary-detail__wrapper">
-                    <Detail selectedData={selectedData ?? null} />
+                    <Detail selectedData={selectedData} />
                   </div>
                 </div>
               </div>

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -1,9 +1,9 @@
-import { forwardRef, useRef, useEffect } from "react";
+import { useRef, useEffect } from "react";
 
 import { Detail } from "components";
+import { useGlobalData } from "hooks/useGlobalData";
 
 import { selectedDataUpdater } from "../VerticalClusterList.util";
-import type { VerticalClusterListProps } from "../VerticalClusterList.type";
 
 import "./Summary.scss";
 import type { Cluster } from "./Summary.type";
@@ -11,73 +11,74 @@ import { Author } from "./Author";
 import { Content } from "./Content";
 import { getClusterById, getClusterIds, getInitData } from "./Summary.util";
 
-const Summary = forwardRef<HTMLDivElement, VerticalClusterListProps>(
-  ({ data, selectedData, setSelectedData }, ref) => {
-    const clusters = getInitData({ data });
-    const scrollRef = useRef<HTMLDivElement>(null);
+const Summary = () => {
+  const { filteredData: data, selectedData, setSelectedData } = useGlobalData();
+  const ref = useRef<HTMLDivElement>(null);
+  const clusters = getInitData({ data: data ?? [] });
+  const scrollRef = useRef<HTMLDivElement>(null);
 
-    const selectedClusterId = getClusterIds(selectedData);
-    const onClickClusterSummary = (clusterId: number) => {
-      const selected = getClusterById(data, clusterId);
-      setSelectedData(selectedDataUpdater(selected, clusterId));
-    };
+  const selectedClusterId = getClusterIds(selectedData ?? null);
+  const onClickClusterSummary = (clusterId: number) => {
+    if (!setSelectedData) return;
+    const selected = getClusterById(data ?? [], clusterId);
+    setSelectedData(selectedDataUpdater(selected, clusterId) as any);
+  };
 
-    useEffect(() => {
-      scrollRef.current?.scrollIntoView({
-        block: "center",
-        behavior: "smooth",
-      });
-    }, [selectedData]);
+  useEffect(() => {
+    scrollRef.current?.scrollIntoView({
+      block: "center",
+      behavior: "smooth",
+    });
+  }, [selectedData]);
 
-    return (
-      <div className="cluster-summary__container">
-        {clusters.map((cluster: Cluster) => {
-          return (
-            <div
-              role="presentation"
-              className="cluster-summary__cluster"
-              key={cluster.clusterId}
+  return (
+    <div className="cluster-summary__container">
+      {clusters.map((cluster: Cluster) => {
+        return (
+          <div
+            role="presentation"
+            className="cluster-summary__cluster"
+            key={cluster.clusterId}
+          >
+            <button
+              type="button"
+              className="cluster-summary__toggle-contents-button"
+              onClick={() => onClickClusterSummary(cluster.clusterId)}
             >
-              <button
-                type="button"
-                className="cluster-summary__toggle-contents-button"
-                onClick={() => onClickClusterSummary(cluster.clusterId)}
+              <div className="cluster-summary__toggle-contents-container">
+                <div className="name-box">
+                  {cluster.summary.authorNames.map(
+                    (authorArray: Array<string>) => {
+                      return authorArray.map((authorName: string) => (
+                        <Author key={authorName} name={authorName} />
+                      ));
+                    }
+                  )}
+                </div>
+                <Content
+                  content={cluster.summary.content}
+                  clusterId={cluster.clusterId}
+                  selectedClusterId={selectedClusterId}
+                />
+              </div>
+            </button>
+            {cluster.clusterId === selectedClusterId && (
+              <div
+                className="cluster-summary__detail__container"
+                ref={scrollRef}
               >
-                <div className="cluster-summary__toggle-contents-container">
-                  <div className="name-box">
-                    {cluster.summary.authorNames.map(
-                      (authorArray: Array<string>) => {
-                        return authorArray.map((authorName: string) => (
-                          <Author key={authorName} name={authorName} />
-                        ));
-                      }
-                    )}
-                  </div>
-                  <Content
-                    content={cluster.summary.content}
-                    clusterId={cluster.clusterId}
-                    selectedClusterId={selectedClusterId}
-                  />
-                </div>
-              </button>
-              {cluster.clusterId === selectedClusterId && (
-                <div
-                  className="cluster-summary__detail__container"
-                  ref={scrollRef}
-                >
-                  <div ref={ref}>
-                    <div className="summary-detail__wrapper">
-                      <Detail selectedData={selectedData} />
-                    </div>
+                <div ref={ref}>
+                  <div className="summary-detail__wrapper">
+                    <Detail selectedData={selectedData ?? null} />
                   </div>
                 </div>
-              )}
-            </div>
-          );
-        })}
-      </div>
-    );
-  }
-);
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
 
 export default Summary;

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -1,8 +1,8 @@
 import { useRef, useEffect } from "react";
 
 import { Detail } from "components";
-import { useGlobalData } from "hooks/useGlobalData";
 
+import { useGlobalData } from "../../../hooks/useGlobalData";
 import { selectedDataUpdater } from "../VerticalClusterList.util";
 
 import "./Summary.scss";

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -14,13 +14,13 @@ import { getClusterById, getClusterIds, getInitData } from "./Summary.util";
 const Summary = () => {
   const { filteredData: data, selectedData, setSelectedData } = useGlobalData();
   const ref = useRef<HTMLDivElement>(null);
-  const clusters = getInitData({ data: data ?? [] });
+  const clusters = getInitData({ data });
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  const selectedClusterId = getClusterIds(selectedData ?? null);
+  const selectedClusterId = getClusterIds(selectedData);
   const onClickClusterSummary = (clusterId: number) => {
     if (!setSelectedData) return;
-    const selected = getClusterById(data ?? [], clusterId);
+    const selected = getClusterById(data, clusterId);
     setSelectedData(selectedDataUpdater(selected, clusterId) as any);
   };
 

--- a/packages/view/src/components/VerticalClusterList/VerticalClusterList.tsx
+++ b/packages/view/src/components/VerticalClusterList/VerticalClusterList.tsx
@@ -1,31 +1,13 @@
-import { useRef } from "react";
-
 import "./VerticalClusterList.scss";
 
 import { ClusterGraph } from "./ClusterGraph";
 import { Summary } from "./Summary";
-import type { VerticalClusterListProps } from "./VerticalClusterList.type";
 
-const VerticalClusterList = ({
-  data,
-  setSelectedData,
-  selectedData,
-}: VerticalClusterListProps) => {
-  const detailRef = useRef<HTMLDivElement>(null);
-
+const VerticalClusterList = () => {
   return (
     <div className="vertical-cluster-list">
-      <ClusterGraph
-        data={data}
-        selectedData={selectedData}
-        setSelectedData={setSelectedData}
-      />
-      <Summary
-        ref={detailRef}
-        data={data}
-        selectedData={selectedData}
-        setSelectedData={setSelectedData}
-      />
+      <ClusterGraph />
+      <Summary />
     </div>
   );
 };

--- a/packages/view/src/hooks/useGlobalData.tsx
+++ b/packages/view/src/hooks/useGlobalData.tsx
@@ -1,0 +1,49 @@
+import type { Dispatch, ReactNode } from "react";
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+import type { ClusterNode } from "../types";
+import { useGetTotalData } from "../App.hook";
+
+type GlobalDataState = Partial<{
+  data: ClusterNode[];
+  filteredData: ClusterNode[];
+  setFilteredData: Dispatch<ClusterNode[]>;
+  selectedData: ClusterNode[];
+  setSelectedData: Dispatch<ClusterNode[]>;
+}>;
+
+export const GlobalDataContext = createContext<GlobalDataState>(
+  {} as GlobalDataState
+);
+
+export const GlobalDataProvider = ({ children }: { children: ReactNode }) => {
+  const { data } = useGetTotalData();
+  const [filteredData, setFilteredData] = useState<ClusterNode[]>(data);
+  const [selectedData, setSelectedData] = useState<ClusterNode[]>([]);
+
+  useEffect(() => {
+    setSelectedData([]);
+  }, [filteredData]);
+
+  const value = useMemo(
+    () => ({
+      data,
+      filteredData,
+      setFilteredData,
+      selectedData,
+      setSelectedData,
+    }),
+    [data, filteredData, selectedData]
+  );
+
+  return (
+    <GlobalDataContext.Provider value={value}>
+      {children}
+    </GlobalDataContext.Provider>
+  );
+};
+
+export const useGlobalData = () => {
+  const globalData = useContext<GlobalDataState>(GlobalDataContext);
+  return globalData;
+};

--- a/packages/view/src/hooks/useGlobalData.tsx
+++ b/packages/view/src/hooks/useGlobalData.tsx
@@ -10,11 +10,10 @@ import React, {
 import type { ClusterNode } from "../types";
 import { useGetTotalData } from "../App.hook";
 
-type GlobalDataState = Partial<{
+type GlobalDataState = {
   data: ClusterNode[];
   filteredData: ClusterNode[];
   selectedData: ClusterNode | null;
-}> & {
   setFilteredData: Dispatch<React.SetStateAction<ClusterNode[]>>;
   setSelectedData: Dispatch<React.SetStateAction<ClusterNode | null>>;
 };

--- a/packages/view/src/hooks/useGlobalData.tsx
+++ b/packages/view/src/hooks/useGlobalData.tsx
@@ -7,10 +7,11 @@ import { useGetTotalData } from "../App.hook";
 type GlobalDataState = Partial<{
   data: ClusterNode[];
   filteredData: ClusterNode[];
-  setFilteredData: Dispatch<ClusterNode[]>;
   selectedData: ClusterNode | null;
+}> & {
+  setFilteredData: Dispatch<ClusterNode[]>;
   setSelectedData: Dispatch<ClusterNode | null>;
-}>;
+};
 
 export const GlobalDataContext = createContext<GlobalDataState>(
   {} as GlobalDataState
@@ -21,9 +22,6 @@ export const GlobalDataProvider = ({ children }: { children: ReactNode }) => {
   const [filteredData, setFilteredData] = useState<ClusterNode[]>(data);
   const [selectedData, setSelectedData] = useState<ClusterNode | null>(null);
 
-  // useEffect(() => {
-  //   setSelectedData([]);
-  // }, [filteredData]);
   useEffect(() => {
     setFilteredData(data);
   }, [data]);
@@ -52,5 +50,10 @@ export const GlobalDataProvider = ({ children }: { children: ReactNode }) => {
 
 export const useGlobalData = () => {
   const globalData = useContext<GlobalDataState>(GlobalDataContext);
-  return globalData;
+  return {
+    ...globalData,
+    data: globalData?.data ?? [],
+    filteredData: globalData?.filteredData ?? [],
+    selectedData: globalData?.selectedData ?? null,
+  };
 };

--- a/packages/view/src/hooks/useGlobalData.tsx
+++ b/packages/view/src/hooks/useGlobalData.tsx
@@ -8,8 +8,8 @@ type GlobalDataState = Partial<{
   data: ClusterNode[];
   filteredData: ClusterNode[];
   setFilteredData: Dispatch<ClusterNode[]>;
-  selectedData: ClusterNode[];
-  setSelectedData: Dispatch<ClusterNode[]>;
+  selectedData: ClusterNode | null;
+  setSelectedData: Dispatch<ClusterNode | null>;
 }>;
 
 export const GlobalDataContext = createContext<GlobalDataState>(
@@ -19,10 +19,17 @@ export const GlobalDataContext = createContext<GlobalDataState>(
 export const GlobalDataProvider = ({ children }: { children: ReactNode }) => {
   const { data } = useGetTotalData();
   const [filteredData, setFilteredData] = useState<ClusterNode[]>(data);
-  const [selectedData, setSelectedData] = useState<ClusterNode[]>([]);
+  const [selectedData, setSelectedData] = useState<ClusterNode | null>(null);
+
+  // useEffect(() => {
+  //   setSelectedData([]);
+  // }, [filteredData]);
+  useEffect(() => {
+    setFilteredData(data);
+  }, [data]);
 
   useEffect(() => {
-    setSelectedData([]);
+    setSelectedData(null);
   }, [filteredData]);
 
   const value = useMemo(
@@ -35,7 +42,7 @@ export const GlobalDataProvider = ({ children }: { children: ReactNode }) => {
     }),
     [data, filteredData, selectedData]
   );
-
+  if (!data.length || !filteredData.length) return null;
   return (
     <GlobalDataContext.Provider value={value}>
       {children}

--- a/packages/view/src/hooks/useGlobalData.tsx
+++ b/packages/view/src/hooks/useGlobalData.tsx
@@ -1,5 +1,11 @@
 import type { Dispatch, ReactNode } from "react";
-import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 
 import type { ClusterNode } from "../types";
 import { useGetTotalData } from "../App.hook";
@@ -9,8 +15,8 @@ type GlobalDataState = Partial<{
   filteredData: ClusterNode[];
   selectedData: ClusterNode | null;
 }> & {
-  setFilteredData: Dispatch<ClusterNode[]>;
-  setSelectedData: Dispatch<ClusterNode | null>;
+  setFilteredData: Dispatch<React.SetStateAction<ClusterNode[]>>;
+  setSelectedData: Dispatch<React.SetStateAction<ClusterNode | null>>;
 };
 
 export const GlobalDataContext = createContext<GlobalDataState>(

--- a/packages/view/src/index.tsx
+++ b/packages/view/src/index.tsx
@@ -3,11 +3,14 @@ import ReactDOM from "react-dom/client";
 
 import App from "./App";
 import "styles/app.scss";
+import { GlobalDataProvider } from "./hooks/useGlobalData";
 
 const container = document.getElementById("root") as HTMLElement;
 
 ReactDOM.createRoot(container).render(
   <React.StrictMode>
-    <App />
+    <GlobalDataProvider>
+      <App />
+    </GlobalDataProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
# Related PR

- [taejs PR](https://github.com/githru/githru-vscode-ext/pull/106)

# Issue

taejs님의 commit log를 가져와서 작업하고싶었으나 
저의 역량 부족으로 인해 git history 차이가 어느정도 있다고 판단하였고,
rebase로 끌고와 수정하는 것과 taejs님의 코드파일 hooks/useGlobalData.tsx 파일을 그대로 복붙하는 방법 중에
후자의 방법이 비교적 수월할 것이라 판단하여 작업하였습니다.

# Work List

- e88772626a4ba0d5674d46a2a5637d1a72a8043d : taejs님의 코드를 그대로 인용하였습니다.
- fe68c20a99ba50b0e9a0ce7833e45d2e02178825 : props를 모두 지워주었고, context api를 사용한 전역 데이터를 사용하였습니다.
- c8c19f51c9703aaf66995e179ea64df879060909 : partial을 사용한 전역 변수의 값이기에 undefined를 모두 처리해주어야 했는데, initial 함수에서 undefined checking을 진행하였습니다.
- d8a4e00d10a96960ca5000a76816a253173c5268 : Statistics Component에서 사용하는 데이터 타입에 맞게 data를 반환해주는 Component Hook을 만들었습니다.
- d7c38267361e9ed271a862922b8fa6d223a85e97 : ClusterGraph 컴포넌트 파일에 너무 많은 draw logic이 존재하여 전체를 Component Hook으로 분리하였습니다.
- 9b03c87bac2e02683dac02bafc12607593097169 : Summary 컴포넌트에서 Global State 사용에 있어, 유틸 타입 Partial 사용으로인한 undefined checking 로직을 제거하였습니다.

# Todo

추가로 , 전역상태관리 사용으로인하여 Props를 제거할 수 있었습니다.
이에 따라서 Props 관련 Type이 많이 줄어들었는데 
제가 임의적으로 지우는 것보다 각자 구현하신 Component에서 직접 체킹해주는게 나을 것 같아서 지우지 않았습니다.