### PR TITLE
feat(view): add feature shows cluster by author in author bar chart

### DIFF
--- a/packages/view/src/App.tsx
+++ b/packages/view/src/App.tsx
@@ -1,28 +1,18 @@
 import { Statistics, TemporalFilter, VerticalClusterList } from "components";
-import { ClocLineChart } from "components/TemporalFilter/ClocLineChart";
-import { CommitLineChart } from "components/TemporalFilter/CommitLineChart";
 
 import "./App.scss";
 
 const App = () => {
   return (
-    <div>
+    <>
       <div className="head-container">
-        <article className="temporal-filter">
-          <div className="data-control-container">
-            <TemporalFilter />
-          </div>
-          <div className="line-chart">
-            <ClocLineChart />
-            <CommitLineChart />
-          </div>
-        </article>
+        <TemporalFilter />
       </div>
       <div className="middle-container">
         <VerticalClusterList />
         <Statistics />
       </div>
-    </div>
+    </>
   );
 };
 

--- a/packages/view/src/components/Detail/Detail.scss
+++ b/packages/view/src/components/Detail/Detail.scss
@@ -5,7 +5,7 @@
   justify-content: space-between;
   margin: 15px 0 20px;
   align-items: center;
-  font-size: 14px;
+  font-size: 12px;
 
   .divider {
     margin-right: 1rem;
@@ -17,9 +17,35 @@
   .detail__summary {
     flex-grow: 0.1;
     text-align: right;
+
+    span {
+      position: relative;
+      margin-right: 10px;
+
+      strong {
+        margin-right: 2px;
+      }
+
+      &::after {
+        content: "";
+        position: absolute;
+        top: 2px;
+        right: -5px;
+        width: 1px;
+        height: 12px;
+        background: $white;
+      }
+      &:last-child {
+        margin-right: 0;
+
+        &::after {
+          display: none;
+        }
+      }
+    }
   }
 
-  .insertions {
+  .additions {
     color: green;
   }
 
@@ -30,7 +56,7 @@
 
 .detail__commit-list__container {
   padding: 0 20px;
-  font-size: 14px;
+  font-size: 12px;
 
   .commit-item {
     display: flex;
@@ -46,6 +72,7 @@
 
       .message {
         color: $white;
+        margin-right: 4px;
       }
     }
     .commit-id {

--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -10,15 +10,25 @@ const DetailSummary = ({ commitNodeListInCluster }: DetailSummaryProps) => {
   const { authorLength, fileLength, commitLength, insertions, deletions } =
     getCommitListDetail({ commitNodeListInCluster });
 
+  const summaryItems = [
+    { name: "authors", count: authorLength },
+    { name: "commits", count: commitLength },
+    { name: "changed files", count: fileLength },
+    { name: "additions", count: insertions },
+    { name: "deletions", count: deletions },
+  ];
+  console.log(insertions);
+
   return (
     <div className="detail__summary__container">
       <div className="divider" />
       <div className="detail__summary">
-        <strong>{authorLength}</strong> authors |{" "}
-        <strong>{commitLength}</strong> commits | <strong>{fileLength}</strong>{" "}
-        changed files | <strong className="insertions">{insertions}</strong>{" "}
-        additions and <strong className="deletions">{deletions}</strong>{" "}
-        deletions codes
+        {summaryItems.map(({ name, count }) => (
+          <span key={name}>
+            <strong className={name}>{count.toLocaleString("en")}</strong>
+            {count <= 1 ? name.slice(0, -1) : name}
+          </span>
+        ))}
       </div>
     </div>
   );
@@ -42,9 +52,9 @@ const Detail = ({ selectedData }: DetailProps) => {
           return (
             <li key={id} className="commit-item">
               <div className="commit-detail">
-                <span className="message">{message}, </span>
-                <span>
-                  {author.names[0]}, {getTime(commitDate)}
+                <span className="message">{message} </span>
+                <span className="author-date">
+                  {author.names[0]}, {getTime(commitDate)}{" "}
                 </span>
               </div>
               <div className="commit-id">

--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -1,10 +1,11 @@
-import "./Detail.scss";
 import { getTime } from "utils";
 
 import { useCommitListHide } from "./Detail.hook";
 import { getCommitListDetail } from "./Detail.util";
 import { FIRST_SHOW_NUM } from "./Detail.const";
 import type { DetailProps, DetailSummaryProps } from "./Detail.type";
+
+import "./Detail.scss";
 
 const DetailSummary = ({ commitNodeListInCluster }: DetailSummaryProps) => {
   const { authorLength, fileLength, commitLength, insertions, deletions } =

--- a/packages/view/src/components/Detail/Detail.util.ts
+++ b/packages/view/src/components/Detail/Detail.util.ts
@@ -43,12 +43,13 @@ export const getCommitListDetail = ({
       deletions: 0,
     }
   );
+
   return {
-    authorLength: authorLength.toLocaleString("en"),
-    fileLength: fileLength.toLocaleString("en"),
-    commitLength: commitNodeListInCluster.length.toLocaleString("en"),
-    insertions: diffStatistics.insertions.toLocaleString("en"),
-    deletions: diffStatistics.deletions.toLocaleString("en"),
+    authorLength,
+    fileLength,
+    commitLength: commitNodeListInCluster.length,
+    insertions: diffStatistics.insertions,
+    deletions: diffStatistics.deletions,
   };
 };
 

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
@@ -7,20 +7,26 @@
   align-items: flex-end;
 }
 
-.author-bar-chart__select-box {
-  font-size: 10px;
-  background: transparent;
-  border: 1px solid $white;
-  border-radius: 5px;
-  width: fit-content;
-  padding: 0 10px;
-  height: 25px;
-  color: $white;
-  outline: none;
-  text-align: center;
+.author-bar-chart__header {
+  width: 100%;
+  text-align: right;
+  padding-left: 40px;
 
-  option {
-    background: $gray-900;
+  & .select-box {
+    font-size: 10px;
+    background: transparent;
+    border: 1px solid $white;
+    border-radius: 5px;
+    width: fit-content;
+    padding: 0 10px;
+    height: 25px;
+    color: $white;
+    outline: none;
+    text-align: center;
+
+    option {
+      background: $gray-900;
+    }
   }
 }
 
@@ -46,6 +52,8 @@
   }
 
   .bars {
+    cursor: pointer;
+
     .bar {
       &:hover {
         rect {

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -133,6 +133,7 @@ const AuthorBarChart = () => {
         setFilteredData(sortDataByAuthor(filteredData.reverse(), d.name));
         setPrevData(filteredData.reverse());
       }
+      tooltip.style("display", "none");
     };
 
     // Draw bars

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -3,6 +3,7 @@ import { useRef, useEffect, useState } from "react";
 import * as d3 from "d3";
 
 import type { ClusterNode } from "types";
+import { useGlobalData } from "hooks";
 
 import { useGetSelectedData } from "../Statistics.hook";
 
@@ -10,6 +11,7 @@ import type { AuthorDataType, MetricType } from "./AuthorBarChart.type";
 import {
   convertNumberFormat,
   getDataByAuthor,
+  sortDataByAuthor,
   sortDataByName,
 } from "./AuthorBarChart.util";
 import { DIMENSIONS, METRIC_TYPE } from "./AuthorBarChart.const";
@@ -17,11 +19,14 @@ import { DIMENSIONS, METRIC_TYPE } from "./AuthorBarChart.const";
 import "./AuthorBarChart.scss";
 
 const AuthorBarChart = () => {
+  const { data: totalData, filteredData, setFilteredData } = useGlobalData();
   const rawData = useGetSelectedData();
+
   const svgRef = useRef<SVGSVGElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
 
   const [metric, setMetric] = useState<MetricType>(METRIC_TYPE[0]);
+  const [prevData, setPrevData] = useState<ClusterNode[]>([]);
 
   const authorData = getDataByAuthor(rawData as ClusterNode[]);
   let data = authorData.sort((a, b) => {
@@ -103,17 +108,31 @@ const AuthorBarChart = () => {
         .style("top", `${e.pageY - 70}px`)
         .html(
           `<p class="name">${d.name}</p>
-          <p>${metric}: 
-            <span class="selected">
-              ${d[metric].toLocaleString()}
-            </span> 
-            / ${totalMetricValues.toLocaleString()} 
-            (${((d[metric] / totalMetricValues) * 100).toFixed(1)}%) 
-          </p>`
+              <p>${metric}: 
+                <span class="selected">
+                  ${d[metric].toLocaleString()}
+                </span> 
+                / ${totalMetricValues.toLocaleString()} 
+                (${((d[metric] / totalMetricValues) * 100).toFixed(1)}%) 
+              </p>`
         );
     };
     const handleMouseOut = () => {
       tooltip.style("display", "none");
+    };
+    const handleClickBar = (
+      _: MouseEvent<SVGRectElement | SVGTextElement>,
+      d: AuthorDataType
+    ) => {
+      const isAuthorSelected = !!prevData.length;
+
+      if (isAuthorSelected) {
+        setFilteredData(prevData);
+        setPrevData([]);
+      } else {
+        setFilteredData(sortDataByAuthor(filteredData.reverse(), d.name));
+        setPrevData(filteredData.reverse());
+      }
     };
 
     // Draw bars
@@ -136,6 +155,7 @@ const AuthorBarChart = () => {
       .on("mouseover", handleMouseOver)
       .on("mousemove", handleMouseMove)
       .on("mouseout", handleMouseOut)
+      .on("click", handleClickBar)
       .transition()
       .duration(500)
       .attr("width", (d: AuthorDataType) => xScale(d[metric]))
@@ -163,9 +183,18 @@ const AuthorBarChart = () => {
         .on("mouseover", handleMouseOver)
         .on("mousemove", handleMouseMove)
         .on("mouseout", handleMouseOut)
+        .on("click", handleClickBar)
         .html((d: AuthorDataType) => d.name);
     });
-  }, [data, metric]);
+  }, [
+    data,
+    filteredData,
+    metric,
+    prevData,
+    rawData,
+    setFilteredData,
+    totalData,
+  ]);
 
   const handleChangeMetric = (e: ChangeEvent<HTMLSelectElement>): void => {
     setMetric(e.target.value as MetricType);
@@ -173,16 +202,15 @@ const AuthorBarChart = () => {
 
   return (
     <div className="author-bar-chart__container">
-      <select
-        className="author-bar-chart__select-box"
-        onChange={handleChangeMetric}
-      >
-        {METRIC_TYPE.map((option) => (
-          <option key={option} value={option}>
-            {option === METRIC_TYPE[0] ? `${option} #` : option}
-          </option>
-        ))}
-      </select>
+      <div className="author-bar-chart__header">
+        <select className="select-box" onChange={handleChangeMetric}>
+          {METRIC_TYPE.map((option) => (
+            <option key={option} value={option}>
+              {option === METRIC_TYPE[0] ? `${option} #` : option}
+            </option>
+          ))}
+        </select>
+      </div>
       <svg className="author-bar-chart" ref={svgRef} />
       <div className="author-bar-chart__tooltip" ref={tooltipRef} />
     </div>

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -130,8 +130,8 @@ const AuthorBarChart = () => {
         setFilteredData(prevData);
         setPrevData([]);
       } else {
-        setFilteredData(sortDataByAuthor(filteredData.reverse(), d.name));
-        setPrevData(filteredData.reverse());
+        setFilteredData(sortDataByAuthor(filteredData, d.name));
+        setPrevData(filteredData);
       }
       tooltip.style("display", "none");
     };

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
@@ -65,5 +65,5 @@ export const sortDataByAuthor = (
       { nodeTypeName: "CLUSTER" as const, commitNodeList: checkedCluster },
     ];
   }, []);
-  return sortedData.reverse();
+  return sortedData;
 };

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
@@ -1,6 +1,6 @@
 import * as d3 from "d3";
 
-import type { ClusterNode } from "types";
+import type { ClusterNode, CommitNode } from "types";
 
 import type { AuthorDataType } from "./AuthorBarChart.type";
 
@@ -48,4 +48,22 @@ export const convertNumberFormat = (
     return `${d}`;
   }
   return d3.format("~s")(d);
+};
+
+export const sortDataByAuthor = (
+  data: ClusterNode[],
+  author: string
+): ClusterNode[] => {
+  const sortedData = data.reduce((acc: ClusterNode[], cluster: ClusterNode) => {
+    const checkedCluster = cluster.commitNodeList.filter(
+      (commitNode: CommitNode) =>
+        commitNode.commit.author.names.includes(author)
+    );
+    if (!checkedCluster.length) return acc;
+    return [
+      ...acc,
+      { nodeTypeName: "CLUSTER" as const, commitNodeList: checkedCluster },
+    ];
+  }, []);
+  return sortedData.reverse();
 };

--- a/packages/view/src/components/Statistics/Statistics.hook.tsx
+++ b/packages/view/src/components/Statistics/Statistics.hook.tsx
@@ -1,4 +1,4 @@
-import { useGlobalData } from "hooks/useGlobalData";
+import { useGlobalData } from "hooks";
 
 export const useGetSelectedData = () => {
   const { filteredData, selectedData } = useGlobalData();

--- a/packages/view/src/components/Statistics/Statistics.hook.tsx
+++ b/packages/view/src/components/Statistics/Statistics.hook.tsx
@@ -2,5 +2,5 @@ import { useGlobalData } from "hooks";
 
 export const useGetSelectedData = () => {
   const { filteredData, selectedData } = useGlobalData();
-  return (selectedData ? [selectedData] : filteredData) ?? [];
+  return selectedData ? [selectedData] : filteredData;
 };

--- a/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.scss
+++ b/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.scss
@@ -11,7 +11,7 @@
 
 .cloc-line-chart {
   overflow: visible;
-  background: $gray-300;
+  background: #212121;
   margin: 10px;
   padding-bottom: 5px;
   padding-top: 20px;

--- a/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.tsx
+++ b/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.tsx
@@ -10,7 +10,7 @@ import {
 } from "d3";
 import { useEffect, useMemo, useRef } from "react";
 
-import { useGlobalData } from "hooks/useGlobalData";
+import { useGlobalData } from "hooks";
 
 import {
   getCloc,

--- a/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.tsx
+++ b/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.tsx
@@ -1,13 +1,4 @@
-import {
-  axisLeft,
-  extent,
-  scaleBand,
-  scaleLinear,
-  scaleTime,
-  select,
-  ticks,
-  // axisBottom,
-} from "d3";
+import { extent, scaleBand, scaleLinear, scaleTime, select } from "d3";
 import { useEffect, useMemo, useRef } from "react";
 
 import { useGlobalData } from "hooks";
@@ -34,7 +25,7 @@ const ClocLineChart = () => {
   const ref = useRef<SVGSVGElement>(null);
 
   useEffect(() => {
-    if (!wrapperRef.current || !ref.current || !data.length) return;
+    if (!wrapperRef.current || !ref.current) return;
 
     const { width, height } = wrapperRef.current.getBoundingClientRect();
     const svg = select(ref.current)
@@ -60,25 +51,14 @@ const ClocLineChart = () => {
       .range([0, width]);
 
     // const xAxis = axisBottom<Date>(xScale);
-
     const yScale = scaleLinear().domain([yMin, yMax]).range([height, 0]);
 
-    const yAxis = axisLeft(yScale).tickValues(ticks(yMin, yMax, 5));
-
-    svg.append("g").call(yAxis);
-
+    // const yAxis = axisLeft(yScale).tickValues(ticks(yMin, yMax, 5));
+    // svg.append("g").call(yAxis);
     // svg.append("g").attr("transform", `translate(${width},0)`);
-
-    // svg
-    //   .append("text")
-    //   .attr("text-anchor", "right")
-    //   .style("font-size", "16px")
-    //   .text("cloc");
 
     svg
       .selectAll(".cloc")
-      .style("background", "gray")
-      .text("cloc chart")
       .data(data)
       .join("rect")
       .classed("cloc", true)
@@ -86,7 +66,7 @@ const ClocLineChart = () => {
       .attr("y", (d) => yScale(getCloc(d)))
       .attr("height", (d) => height - yScale(getCloc(d)))
       .attr("width", xScaleBand.bandwidth())
-      .attr("fill", "#B6B6B4");
+      .attr("fill", "#0077aa");
 
     svg
       .append("text")
@@ -94,7 +74,8 @@ const ClocLineChart = () => {
       .attr("x", "5px")
       .attr("y", "15px")
       .attr("font-size", "10px")
-      .attr("font-weight", "500");
+      .attr("font-weight", "500")
+      .attr("fill", "white");
   }, [data]);
 
   return (

--- a/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.scss
+++ b/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.scss
@@ -11,5 +11,5 @@
 
 .commit-line-chart {
   overflow: visible;
-  background: $gray-300;
+  background: #212121;
 }

--- a/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.tsx
+++ b/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.tsx
@@ -12,7 +12,7 @@ import {
 } from "d3";
 import { useEffect, useMemo, useRef } from "react";
 
-import { useGlobalData } from "hooks/useGlobalData";
+import { useGlobalData } from "hooks";
 
 import { getMinMaxDate, sortBasedOnCommitNode } from "../TemporalFilter.util";
 

--- a/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.tsx
+++ b/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.tsx
@@ -93,7 +93,7 @@ const CommitLineChart = () => {
       .attr("y", (d) => yScale(d.commit))
       .attr("height", (d) => height - yScale(d.commit))
       .attr("width", xScaleBand.bandwidth())
-      .attr("fill", "#B6B6B4");
+      .attr("fill", "#0077aa");
 
     svg
       .append("text")
@@ -101,7 +101,8 @@ const CommitLineChart = () => {
       .attr("x", "5px")
       .attr("y", "15px")
       .attr("font-size", "10px")
-      .attr("font-weight", "500");
+      .attr("font-weight", "500")
+      .attr("fill", "white");
   }, [data]);
 
   return (

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
@@ -8,6 +8,8 @@ import {
   getMinMaxDate,
   sortBasedOnCommitNode,
 } from "./TemporalFilter.util";
+import { ClocLineChart } from "./ClocLineChart";
+import { CommitLineChart } from "./CommitLineChart";
 
 import "./TemporalFilter.scss";
 
@@ -53,30 +55,38 @@ const TemporalFilter = () => {
   };
 
   return (
-    <section className="filter">
-      <form>
-        <div>
-          <span>From:</span>
-          <input
-            className="date-from"
-            type="date"
-            min={getYYYYMMDD(minDate)}
-            max={getYYYYMMDD(maxDate)}
-            value={filteredPeriod.fromDate}
-            onChange={fromDateChangeHandler}
-          />
-          <span>To:</span>
-          <input
-            className="date-to"
-            type="date"
-            min={getYYYYMMDD(minDate)}
-            max={getYYYYMMDD(maxDate)}
-            value={filteredPeriod.toDate}
-            onChange={toDateChangeHandler}
-          />
-        </div>
-      </form>
-    </section>
+    <article className="temporal-filter">
+      <div className="data-control-container">
+        <section className="filter">
+          <form>
+            <div>
+              <span>From:</span>
+              <input
+                className="date-from"
+                type="date"
+                min={getYYYYMMDD(minDate)}
+                max={getYYYYMMDD(maxDate)}
+                value={filteredPeriod.fromDate}
+                onChange={fromDateChangeHandler}
+              />
+              <span>To:</span>
+              <input
+                className="date-to"
+                type="date"
+                min={getYYYYMMDD(minDate)}
+                max={getYYYYMMDD(maxDate)}
+                value={filteredPeriod.toDate}
+                onChange={toDateChangeHandler}
+              />
+            </div>
+          </form>
+        </section>
+      </div>
+      <div className="line-chart">
+        <ClocLineChart />
+        <CommitLineChart />
+      </div>
+    </article>
   );
 };
 

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 
-import { useGlobalData } from "hooks/useGlobalData";
-import { getYYYYMMDD } from "utils/time";
+import { useGlobalData } from "hooks";
+import { getYYYYMMDD } from "utils";
 
 import {
   filterDataByDate,

--- a/packages/view/src/components/TemporalFilter/ThemeSelector/ThemeSelector.tsx
+++ b/packages/view/src/components/TemporalFilter/ThemeSelector/ThemeSelector.tsx
@@ -1,9 +1,0 @@
-const ThemeSelector = () => {
-  return (
-    <section className="theme-selector">
-      <input type="checkbox" />
-    </section>
-  );
-};
-
-export default ThemeSelector;

--- a/packages/view/src/components/TemporalFilter/ThemeSelector/index.ts
+++ b/packages/view/src/components/TemporalFilter/ThemeSelector/index.ts
@@ -1,1 +1,0 @@
-export { default as ThemeSelector } from "./ThemeSelector";

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -1,6 +1,6 @@
 import "./ClusterGraph.scss";
 
-import { useGlobalData } from "hooks/useGlobalData";
+import { useGlobalData } from "hooks";
 
 import {
   getGraphHeight,

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -149,18 +149,16 @@
     line-height: 30px;
     font-weight: bold;
 
-    color: $gray-50;
     justify-content: center;
     text-align: center;
-    font-size: 15pt;
+    font-size: 15px;
     margin-left: -5px;
     margin-right: -5px;
     z-index: 1;
 
     &:hover {
       @include animation();
-      background: $gray-200 !important;
-      color: $gray-800 !important;
+      background: rgba(50, 50, 50, 0.9) !important;
       z-index: 9999;
     }
   }
@@ -182,18 +180,17 @@
     &::after {
       @include animation();
       @include shadow();
-      @include border(5px);
+      @include border(2px);
 
       content: attr(data-tooltip-text);
 
       position: absolute;
-      bottom: 30%;
-      left: -9999px;
-      color: $white;
-      font-size: 12px;
-      padding: 0px 12px;
-      margin-bottom: 10px;
-      width: auto;
+      left: 30px;
+      top: -20px;
+      color: black;
+      font-size: 10px;
+      line-height: 1.5;
+      padding: 5px 12px;
       min-width: max-content;
       word-wrap: break-word;
       opacity: 0;
@@ -201,8 +198,7 @@
     }
 
     &:hover::after {
-      left: 100%;
-      background-color: rgba(0, 119, 170, 0.8);
+      background-color: $white;
       opacity: 1;
     }
   }
@@ -211,6 +207,7 @@
     display: flex;
     justify-content: space-between;
     width: 100%;
+    font-size: 12px;
 
     .commit-message {
       white-space: nowrap;
@@ -222,9 +219,9 @@
       cursor: pointer;
     }
     .more-commit-count {
-      font-size: 12px;
       text-align: right;
       width: 60px;
+      font-size: 10px;
     }
   }
 }

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -1,16 +1,16 @@
 import { useRef, useEffect } from "react";
 
 import { Detail } from "components";
-import { useGlobalData } from "hooks/useGlobalData";
+import { useGlobalData } from "hooks";
 
 import { selectedDataUpdater } from "../VerticalClusterList.util";
-
-import "./Summary.scss";
 
 import type { Cluster } from "./Summary.type";
 import { Author } from "./Author";
 import { Content } from "./Content";
 import { getClusterById, getClusterIds, getInitData } from "./Summary.util";
+
+import "./Summary.scss";
 
 const Summary = () => {
   const { filteredData: data, selectedData, setSelectedData } = useGlobalData();

--- a/packages/view/src/hooks/index.ts
+++ b/packages/view/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from "./useGetTotalData";
+export * from "./useGlobalData";

--- a/packages/view/src/hooks/useGetTotalData.tsx
+++ b/packages/view/src/hooks/useGetTotalData.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 
 import type { ClusterNode, GlobalProps } from "types";
 
-import fakeData from "./fake-assets/cluster-nodes.json";
+import fakeData from "../fake-assets/cluster-nodes.json";
 
 export const useGetTotalData = (): GlobalProps => {
   const [data, setData] = useState<ClusterNode[]>([]);

--- a/packages/view/src/hooks/useGlobalData.tsx
+++ b/packages/view/src/hooks/useGlobalData.tsx
@@ -7,7 +7,7 @@ import React, {
   useState,
 } from "react";
 
-import type { ClusterNode } from "../types";
+import type { ClusterNode } from "types";
 
 import { useGetTotalData } from "./useGetTotalData";
 
@@ -47,6 +47,7 @@ export const GlobalDataProvider = ({ children }: { children: ReactNode }) => {
     [data, filteredData, selectedData]
   );
   if (!data.length || !filteredData.length) return null;
+
   return (
     <GlobalDataContext.Provider value={value}>
       {children}

--- a/packages/view/src/hooks/useGlobalData.tsx
+++ b/packages/view/src/hooks/useGlobalData.tsx
@@ -8,7 +8,8 @@ import React, {
 } from "react";
 
 import type { ClusterNode } from "../types";
-import { useGetTotalData } from "../App.hook";
+
+import { useGetTotalData } from "./useGetTotalData";
 
 type GlobalDataState = {
   data: ClusterNode[];

--- a/packages/view/src/index.tsx
+++ b/packages/view/src/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 
-import { GlobalDataProvider } from "hooks/useGlobalData";
+import { GlobalDataProvider } from "hooks";
 
 import App from "./App";
 


### PR DESCRIPTION
## Related Issue
- close #203 

## WorkList
-  author 클릭 시 해당 author 정보 보여주는 기능 구현 0cb7d01e8dd2c4ba3c9210e8a275e23cf657655f
- 스타일 통일
  - line chart background color, color 통일 16cc177f539d8f8cd854956e11c170cedf9259a6
  - author bar chart와 summary 툴팁 스타일 통일 725e92a002883d0cc194222e89f01cb09666339a
  - summary 내 font-size 통일 725e92a002883d0cc194222e89f01cb09666339a
- 리팩토링 및 코드 정리
  - TemporalFilter 내부로 lineChart 컴포넌트 이동 및 불필요한 파일 제거 f56a3d93dac92f0383095e4ea3583ab0845abdc3
  - hooks 폴더 내로 hook 옮기기 78346f0003c72eacb780f8450f6b44ed849c3149
  - line chart y축 제거 66d94a69f29c1c276fd66a77d2fe5065f9c75815
  - detail 내 summary 리팩토링 및 단수 네이밍 적용 44825d90ed1b0674ac981f7f62db01a4f5372aeb
    - ex) `0 authors -> 0 author / 1 commits -> 1 commit`


## Result

https://user-images.githubusercontent.com/69497936/193555262-add33e47-36e8-49f6-871e-8e67cb90525d.mov

## Description
- UX 상 option 옆에 새로운 refresh 아이콘을 추가해 왔다갔다 하는 것보다 해당 bar를 다시 클릭해 refresh 되는 것이 더 자연스러운 것 같아 그렇게 적용해 놓았습니다. 이와 관련해 다른 좋은 의견 말씀 주시면 반영해보겠습니다. 

