### PR TITLE
feat(engine): add pr based csm

### DIFF
--- a/packages/analysis-engine/src/csm.ts
+++ b/packages/analysis-engine/src/csm.ts
@@ -1,23 +1,95 @@
 /* eslint-disable import/prefer-default-export */
-import type { CommitNode, Stem, CSMDictionary, CSMNode } from "./types";
+import type {
+  CommitRaw,
+  CommitNode,
+  Stem,
+  CSMDictionary,
+  CSMNode,
+} from "./types";
+import type { PullRequest } from "./types/Github";
+
+/**
+ * PR 기반 CSM-Source 생성
+ */
+const buildCSMSourceFromPRCommits = (baseCSMNode: CSMNode, pr: PullRequest) =>
+  pr.commitDetails.data.map((commitDetail) => {
+    const {
+      sha,
+      parents,
+      commit: { author, committer, message },
+      files,
+    } = commitDetail;
+
+    let totalInsertionCount = 0;
+    let totalDeletionCount = 0;
+    const fileDictionary =
+      files?.reduce((dict, f) => {
+        totalInsertionCount += f.additions;
+        totalDeletionCount += f.deletions;
+        return {
+          ...dict,
+          [f.filename]: {
+            insertionCount: f.additions,
+            deletionCount: f.deletions,
+          },
+        };
+      }, {}) ?? {};
+
+    const prCommitRaw: CommitRaw = {
+      sequence: -1, // ignore
+      id: sha,
+      parents: parents.map((p) => p.sha),
+      branches: [], // ignore
+      tags: [], // ignore
+      author: {
+        name: author?.name ?? "",
+        email: author?.email ?? "",
+      },
+      authorDate: author?.date
+        ? new Date(author.date)
+        : baseCSMNode.base.commit.authorDate,
+      committer: {
+        name: committer?.name ?? "",
+        email: committer?.email ?? "",
+      },
+      committerDate: committer?.date
+        ? new Date(committer.date)
+        : baseCSMNode.base.commit.committerDate,
+      message,
+      differenceStatistic: {
+        fileDictionary,
+        totalInsertionCount,
+        totalDeletionCount,
+      },
+    };
+
+    return { commit: prCommitRaw };
+  });
 
 /**
  * CSM 생성
  *
  * @param {Map<string, CommitNode>} commitDict
  * @param {Map<string, Stem>} stemDict
- * @param baseBranchName
+ * @param {string} baseBranchName
+ * @param {Array<PullRequest>} pullRequests
  * @returns {CSMDictionary}
  */
 export const buildCSMDict = (
   commitDict: Map<string, CommitNode>,
   stemDict: Map<string, Stem>,
-  baseBranchName: string
+  baseBranchName: string,
+  pullRequests: Array<PullRequest> = []
 ): CSMDictionary => {
   if (stemDict.size === 0) {
     throw new Error("no stem");
     // return {};
   }
+
+  const prDictByMergedCommitSha = pullRequests.reduce(
+    (dict, pr) => dict.set(`${pr.detail.data.merge_commit_sha}`, pr),
+    new Map<string, PullRequest>()
+  );
 
   const csmDict: CSMDictionary = {};
 
@@ -37,7 +109,7 @@ export const buildCSMDict = (
       source: [],
     };
 
-    const mergeParentCommit = commitDict.get(commitNode.commit.parents[1]);
+    const mergeParentCommit = commitDict.get(csmNode.base.commit.parents[1]);
     if (mergeParentCommit) {
       const squashCommitNodes: CommitNode[] = [];
 
@@ -89,6 +161,24 @@ export const buildCSMDict = (
       squashCommitNodes.sort((a, b) => a.commit.sequence - b.commit.sequence);
 
       csmNode.source = squashCommitNodes;
+    }
+
+    // check pr based merged-commit
+    const pr = prDictByMergedCommitSha.get(csmNode.base.commit.id);
+    if (pr) {
+      const {
+        data: { title, body, additions, deletions },
+      } = pr.detail;
+
+      // csm.base 커밋내용을 pr.detail 으로 교체
+      csmNode.base.commit.message = `${title}\n\n${body}`;
+      csmNode.base.commit.differenceStatistic.totalInsertionCount = additions;
+      csmNode.base.commit.differenceStatistic.totalDeletionCount = deletions;
+
+      // if squash-merge-commit
+      if (csmNode.source.length === 0) {
+        csmNode.source = buildCSMSourceFromPRCommits(csmNode, pr);
+      }
     }
 
     csmNodes.push(csmNode);

--- a/packages/analysis-engine/src/index.ts
+++ b/packages/analysis-engine/src/index.ts
@@ -51,7 +51,12 @@ export class AnalysisEngine {
     if (this.isDebugMode) console.log("pullRequests: ", pullRequests);
     const stemDict = buildStemDict(commitDict, this.baseBranchName);
     if (this.isDebugMode) console.log("stemDict: ", stemDict);
-    const csmDict = buildCSMDict(commitDict, stemDict, this.baseBranchName);
+    const csmDict = buildCSMDict(
+      commitDict,
+      stemDict,
+      this.baseBranchName,
+      pullRequests
+    );
     if (this.isDebugMode) console.log("csmDict: ", csmDict);
 
     return csmDict;

--- a/packages/analysis-engine/src/types/Github.ts
+++ b/packages/analysis-engine/src/types/Github.ts
@@ -1,0 +1,10 @@
+import type { RestEndpointMethodTypes } from "@octokit/rest";
+
+export interface PullRequest {
+  detail: RestEndpointMethodTypes["pulls"]["get"]["response"];
+  commitDetails: RestEndpointMethodTypes["pulls"]["listCommits"]["response"];
+}
+
+export interface PullRequestDictionary {
+  [prNumber: string]: PullRequest;
+}


### PR DESCRIPTION
CSM 생성시 PR 정보를 반영하는 기능을 추가했습니다.

Squash And Merge 를 통해 만들어진 머지커밋에 대한 CSMNode 의 source 를
Github API 를 통해 내려받은 PR정보를 기반으로 채워넣게 됩니다. (=squash 된 커밋정보 추가 표시)

- ASIS:
![image](https://user-images.githubusercontent.com/8488507/193642257-3a297dad-845c-4289-94f1-d256598e12c1.png)

- TOBE: 
![image](https://user-images.githubusercontent.com/8488507/193642274-87dbecfc-9ecf-4fc9-977c-498623553f07.png)



