### PR TITLE
fix(engine): enhance git remote url parsing regex

### DIFF
--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -181,12 +181,17 @@ export async function getGitConfig(gitPath: string, currentWorkspacePath: string
     });
 }
 
-export const getRepo = (gitConfig: string) => {
-	const regex = /^(https|http):\/\/[\s\S]+.git$/g;
-	if(regex.test(gitConfig.trim())) {
-		const chunks = gitConfig.split('.git')[0].split('/');
-		return { owner: chunks.slice(-2)[0], repo: chunks.slice(-1)[0] };
-	} else {
-		throw new Error('git config should be: https|http://${domain}/${owner}/${repo}.git');
+export const getRepo = (gitRemoteConfig: string) => {
+	const gitRemoteConfigPattern = /(?:https?|git)(?::\/\/(?:\w+@)?|@)(?:github\.com)(?:\/|:)(?:(?<owner>.+?)\/(?<repo>.+?))(?:\.git|\/)?$/m;
+  const gitRemote = gitRemoteConfig.match(gitRemoteConfigPattern)?.groups;
+	if (!gitRemote) {
+		throw new Error('git remote config should be: [https?://|git@]${domain}/${owner}/${repo}.git');
 	}
+
+	const { owner, repo } = gitRemote;
+	if (!owner || !repo) {
+		throw new Error('no owner/repo');
+	}
+
+	return { owner, repo };
 }


### PR DESCRIPTION
#245 에서의 ssh 프로토콜 기반 remote repo 를 지원할수있도록 url 파싱 로직을 보강했습니다.

![image](https://user-images.githubusercontent.com/8488507/193853232-f60857d8-b243-485c-89e1-fa393861e539.png)

※ 현재 지원하는 remote 는 github.com 으로 제한했습니다. (추후 변경 가능)