### PR TITLE
enhance(view): improve TemporalFilter Component

### DIFF
--- a/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.scss
+++ b/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.scss
@@ -1,7 +1,7 @@
 @import "styles/_pallete";
 
 .cloc-line-chart-wrap {
-  height: 100%;
+  height: 50%;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -11,8 +11,5 @@
 
 .cloc-line-chart {
   overflow: visible;
-  background: #212121;
-  margin: 10px;
-  padding-bottom: 5px;
-  padding-top: 20px;
+  fill: #0077aa;
 }

--- a/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.tsx
+++ b/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.tsx
@@ -1,17 +1,18 @@
-import { extent, scaleBand, scaleLinear, scaleTime, select } from "d3";
+import * as d3 from "d3";
 import { useEffect, useMemo, useRef } from "react";
 
 import { useGlobalData } from "hooks";
 
+import "./ClocLineChart.scss";
+// TODO margin 추가하기
+// timeFormatter
+
+import type { CommitNode } from "../TemporalFilter.type";
 import {
   getCloc,
   getMinMaxDate,
   sortBasedOnCommitNode,
 } from "../TemporalFilter.util";
-
-import "./ClocLineChart.scss";
-// TODO margin 추가하기
-// timeFormatter
 
 import { CLOC_STYLING } from "./ClocLineChart.const";
 
@@ -28,7 +29,8 @@ const ClocLineChart = () => {
     if (!wrapperRef.current || !ref.current) return;
 
     const { width, height } = wrapperRef.current.getBoundingClientRect();
-    const svg = select(ref.current)
+    const svg = d3
+      .select(ref.current)
       .attr("width", width - CLOC_STYLING.padding.left)
       .attr(
         "height",
@@ -39,43 +41,39 @@ const ClocLineChart = () => {
     svg.selectAll("*").remove();
 
     const [xMin, xMax] = getMinMaxDate(data);
+    const [yMin, yMax] = d3.extent(data, (d) => getCloc(d)) as [number, number];
 
-    const [yMin, yMax] = extent(data, (d) => getCloc(d)) as [number, number];
-
-    const xScale = scaleTime()
+    const xScale = d3
+      .scaleTime()
       .domain([new Date(xMin), new Date(xMax)])
       .range([0, width]);
 
-    const xScaleBand = scaleBand<string>()
-      .domain(data.map((commitNode) => commitNode.commit.commitDate))
-      .range([0, width]);
+    const yScale = d3.scaleLinear().domain([yMin, yMax]).range([height, 0]);
 
-    // const xAxis = axisBottom<Date>(xScale);
-    const yScale = scaleLinear().domain([yMin, yMax]).range([height, 0]);
+    const xAxis = d3.axisBottom<Date>(xScale).tickSize(0).ticks(0);
 
-    // const yAxis = axisLeft(yScale).tickValues(ticks(yMin, yMax, 5));
-    // svg.append("g").call(yAxis);
-    // svg.append("g").attr("transform", `translate(${width},0)`);
+    const area = d3
+      .area<CommitNode>()
+      .curve(d3.curveBasis)
+      .x((d) => xScale(new Date(d.commit.commitDate)))
+      .y0(yScale(1))
+      .y1((d) => yScale(getCloc(d)));
+
+    svg.append("g").call(xAxis).attr("transform", `translate(0,${height})`);
+    svg.append("g").attr("transform", `translate(${width},0)`);
 
     svg
-      .selectAll(".cloc")
-      .data(data)
-      .join("rect")
-      .classed("cloc", true)
-      .attr("x", (d) => xScale(new Date(d.commit.commitDate)))
-      .attr("y", (d) => yScale(getCloc(d)))
-      .attr("height", (d) => height - yScale(getCloc(d)))
-      .attr("width", xScaleBand.bandwidth())
-      .attr("fill", "#0077aa");
+      .append("path")
+      .datum(data)
+      .attr("class", "cloc-line-chart")
+      .attr("d", area);
 
     svg
       .append("text")
       .text("CLOC #")
-      .attr("x", "5px")
-      .attr("y", "15px")
-      .attr("font-size", "10px")
-      .attr("font-weight", "500")
-      .attr("fill", "white");
+      .attr("class", "temporal-filter__label")
+      .attr("x", 5)
+      .attr("y", 15);
   }, [data]);
 
   return (

--- a/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.tsx
+++ b/packages/view/src/components/TemporalFilter/ClocLineChart/ClocLineChart.tsx
@@ -13,6 +13,8 @@ import {
   getMinMaxDate,
   sortBasedOnCommitNode,
 } from "../TemporalFilter.util";
+import { useWindowResize } from "../TemporalFilter.hook";
+import { COMMIT_STYLING } from "../CommitLineChart/CommitLineChart.const";
 
 import { CLOC_STYLING } from "./ClocLineChart.const";
 
@@ -22,13 +24,18 @@ const ClocLineChart = () => {
     () => sortBasedOnCommitNode(filteredData),
     [filteredData]
   );
+  const windowSize = useWindowResize();
   const wrapperRef = useRef<HTMLDivElement>(null);
   const ref = useRef<SVGSVGElement>(null);
 
   useEffect(() => {
     if (!wrapperRef.current || !ref.current) return;
 
-    const { width, height } = wrapperRef.current.getBoundingClientRect();
+    const width =
+      windowSize.width -
+      COMMIT_STYLING.margin.left -
+      COMMIT_STYLING.margin.right;
+    const { height } = wrapperRef.current.getBoundingClientRect();
     const svg = d3
       .select(ref.current)
       .attr("width", width - CLOC_STYLING.padding.left)
@@ -60,7 +67,6 @@ const ClocLineChart = () => {
       .y1((d) => yScale(getCloc(d)));
 
     svg.append("g").call(xAxis).attr("transform", `translate(0,${height})`);
-    svg.append("g").attr("transform", `translate(${width},0)`);
 
     svg
       .append("path")
@@ -74,7 +80,7 @@ const ClocLineChart = () => {
       .attr("class", "temporal-filter__label")
       .attr("x", 5)
       .attr("y", 15);
-  }, [data]);
+  }, [data, windowSize]);
 
   return (
     <div className="cloc-line-chart-wrap " ref={wrapperRef}>

--- a/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.const.ts
+++ b/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.const.ts
@@ -12,10 +12,10 @@ export const COMMIT_STYLING = {
     bottom: 0.1,
     left: 0.5,
   },
-  //   margin: {
-  //     top: 50,
-  //     right: 15,
-  //     bottom: 15,
-  //     left: 10,
-  //   },
+  margin: {
+    top: 50,
+    right: 15,
+    bottom: 15,
+    left: 10,
+  },
 };

--- a/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.scss
+++ b/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.scss
@@ -11,5 +11,5 @@
 
 .commit-line-chart {
   overflow: visible;
-  background: #212121;
+  fill: #0077aa;
 }

--- a/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.tsx
+++ b/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.tsx
@@ -3,9 +3,11 @@ import { useEffect, useMemo, useRef } from "react";
 
 import { useGlobalData } from "hooks";
 
+import "./CommitLineChart.scss";
+import { useWindowResize } from "../TemporalFilter.hook";
 import { getMinMaxDate, sortBasedOnCommitNode } from "../TemporalFilter.util";
 
-import "./CommitLineChart.scss";
+import { COMMIT_STYLING } from "./CommitLineChart.const";
 
 const timeFormatter = d3.timeFormat("%Y %m %d");
 
@@ -15,13 +17,18 @@ const CommitLineChart = () => {
     () => sortBasedOnCommitNode(filteredData),
     [filteredData]
   );
+  const windowSize = useWindowResize();
   const wrapperRef = useRef<HTMLDivElement>(null);
   const ref = useRef<SVGSVGElement>(null);
 
   useEffect(() => {
     if (!wrapperRef.current || !ref.current || !data) return;
 
-    const { width, height } = wrapperRef.current.getBoundingClientRect();
+    const width =
+      windowSize.width -
+      COMMIT_STYLING.margin.left -
+      COMMIT_STYLING.margin.right;
+    const { height } = wrapperRef.current.getBoundingClientRect();
 
     const svg = d3
       .select(ref.current)
@@ -80,7 +87,7 @@ const CommitLineChart = () => {
       .attr("class", "temporal-filter__label")
       .attr("x", 5)
       .attr("y", 15);
-  }, [data]);
+  }, [data, windowSize]);
 
   return (
     <div className="commit-line-chart-wrap" ref={wrapperRef}>

--- a/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.tsx
+++ b/packages/view/src/components/TemporalFilter/CommitLineChart/CommitLineChart.tsx
@@ -1,15 +1,4 @@
-import {
-  axisBottom,
-  // axisLeft,
-  extent,
-  scaleBand,
-  scaleLinear,
-  scaleTime,
-  select,
-  // ticks,
-  timeFormat,
-  timeTicks,
-} from "d3";
+import * as d3 from "d3";
 import { useEffect, useMemo, useRef } from "react";
 
 import { useGlobalData } from "hooks";
@@ -18,7 +7,7 @@ import { getMinMaxDate, sortBasedOnCommitNode } from "../TemporalFilter.util";
 
 import "./CommitLineChart.scss";
 
-const timeFormatter = timeFormat("%Y %m %d");
+const timeFormatter = d3.timeFormat("%Y %m %d");
 
 const CommitLineChart = () => {
   const { filteredData } = useGlobalData();
@@ -34,7 +23,10 @@ const CommitLineChart = () => {
 
     const { width, height } = wrapperRef.current.getBoundingClientRect();
 
-    const svg = select(ref.current).attr("width", width).attr("height", height);
+    const svg = d3
+      .select(ref.current)
+      .attr("width", width)
+      .attr("height", height);
 
     // TODO cleanup으로 옮기기
     svg.selectAll("*").remove();
@@ -42,7 +34,6 @@ const CommitLineChart = () => {
 
     data.forEach(({ commit }) => {
       const formattedDate = timeFormatter(new Date(commit.commitDate));
-
       const mapItem = map.get(formattedDate);
 
       map.set(formattedDate, mapItem ? mapItem + 1 : 1);
@@ -53,56 +44,42 @@ const CommitLineChart = () => {
     }));
 
     const [xMin, xMax] = getMinMaxDate(data);
+    const [yMin, yMax] = d3.extent(
+      commitData.map((commit) => commit.commit)
+    ) as [number, number];
 
-    const [yMin, yMax] = extent(commitData.map((commit) => commit.commit)) as [
-      number,
-      number
-    ];
-
-    const xScaleBand = scaleBand<Date>()
-      .domain(commitData.map(({ date }) => new Date(date)))
-      .range([0, width]);
-
-    const xScale = scaleTime()
+    const xScale = d3
+      .scaleTime()
       .domain([new Date(xMin), new Date(xMax)])
       .range([0, width]);
+    const yScale = d3.scaleLinear().domain([yMin, yMax]).range([height, 0]);
 
-    const yScale = scaleLinear().domain([yMin, yMax]).range([height, 0]);
-
-    const xAxis = axisBottom<Date>(xScale)
-      .tickValues(timeTicks(new Date(xMin), new Date(xMax), 7))
+    const xAxis = d3
+      .axisBottom<Date>(xScale)
+      .tickValues(d3.timeTicks(new Date(xMin), new Date(xMax), 7))
       .tickFormat((d) => timeFormatter(new Date(d)));
 
-    // const yAxis = axisLeft(yScale).tickValues(ticks(yMin, yMax, 5));
+    const area = d3
+      .area<{ date: string; commit: number }>()
+      .curve(d3.curveBasis)
+      .x((d) => xScale(new Date(d.date)))
+      .y0(yScale(1))
+      .y1((d) => yScale(d.commit));
 
     svg.append("g").call(xAxis).attr("transform", `translate(0,${height})`);
 
-    svg.append("g").attr("transform", `translate(${width},0)`);
-
     svg
-      .selectAll(".commit")
-      .data(commitData)
-      .join("rect")
-      .classed("commit", true)
-      // .attr("x", (d) => {
-      //   console.log(xScale(new Date(d.date)));
-      //   return xScale(new Date(d.date));
-      // })
-      .attr("x", (d) => xScale(new Date(d.date)))
-      // .attr("x", (d) => xScale(new Date(d.commit.commitDate)))
-      .attr("y", (d) => yScale(d.commit))
-      .attr("height", (d) => height - yScale(d.commit))
-      .attr("width", xScaleBand.bandwidth())
-      .attr("fill", "#0077aa");
+      .append("path")
+      .datum(commitData)
+      .attr("class", "commit-line-chart")
+      .attr("d", area);
 
     svg
       .append("text")
       .text("COMMIT #")
-      .attr("x", "5px")
-      .attr("y", "15px")
-      .attr("font-size", "10px")
-      .attr("font-weight", "500")
-      .attr("fill", "white");
+      .attr("class", "temporal-filter__label")
+      .attr("x", 5)
+      .attr("y", 15);
   }, [data]);
 
   return (

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.hook.tsx
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.hook.tsx
@@ -1,0 +1,23 @@
+import { useState, useEffect } from "react";
+
+export const useWindowResize = () => {
+  const [windowSize, setWindowSize] = useState({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  });
+  const handleResizeWindow = () => {
+    setWindowSize({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    });
+  };
+
+  useEffect(() => {
+    window.addEventListener("resize", handleResizeWindow);
+    return () => {
+      window.removeEventListener("resize", handleResizeWindow);
+    };
+  }, []);
+
+  return windowSize;
+};

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.scss
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.scss
@@ -30,6 +30,8 @@
     height: 120px;
     width: 100%;
     align-content: space-around;
+    position: relative;
+    top: 30px;
   }
 }
 
@@ -48,4 +50,10 @@
     font-weight: 300;
     font-size: 0.825rem;
   }
+}
+
+.temporal-filter__label {
+  font-size: 10px;
+  font-weight: 500;
+  fill: white;
 }


### PR DESCRIPTION
## Related Issue

- close https://github.com/githru/githru-vscode-ext/issues/259
- close #166

## WorkList

aa1d0240fa6d4535b7c9e85ae594489e2b7c4c3b
- Bar Chart 로 구현되어 있던 기존 TemporalFilter를 Area Chart 로 변경하였습니다.
- CLOC와 COMMIT 차트 간 경계가 모호한 것 같아 중간에 Boundary 역할을 수행하는 축을 추가하였습니다.

0a0245a37ec0131677f4fbc0318172c802256c10
- window resize 시 TemporalFilter의 width가 유동적으로 변경되도록 구현했습니다.

## Result

(before)
![resize_before](https://user-images.githubusercontent.com/49841765/194397927-1d0d2e69-3b6f-4a9b-924e-bdf1d57050cb.gif)

(after)
![resize_after](https://user-images.githubusercontent.com/49841765/194397982-df6ae849-40da-4fc2-a02f-7d9b26cbce5c.gif)
