### PR TITLE
feat(engine): get branch names and base branch name

### DIFF
--- a/packages/analysis-engine/src/index.ts
+++ b/packages/analysis-engine/src/index.ts
@@ -11,6 +11,7 @@ type AnalysisEngineArgs = {
   gitLog: string;
   owner: string;
   repo: string;
+  baseBranchName: string;
   auth?: string;
 };
 
@@ -21,15 +22,16 @@ export class AnalysisEngine {
 
   private octokit!: PluginOctokit;
 
-  private baseBranchName = "main";
+  private baseBranchName!: string;
 
   constructor(args: AnalysisEngineArgs) {
     this.insertArgs(args);
   }
 
   private insertArgs = (args: AnalysisEngineArgs) => {
-    const { isDebugMode, gitLog, owner, repo, auth } = args;
+    const { isDebugMode, gitLog, owner, repo, auth, baseBranchName } = args;
     this.gitLog = gitLog;
+    this.baseBranchName = baseBranchName;
     this.isDebugMode = isDebugMode;
     container.register("OctokitOptions", {
       useValue: {
@@ -44,6 +46,7 @@ export class AnalysisEngine {
   };
 
   public analyzeGit = async () => {
+    if (this.isDebugMode) console.log("baseBranchName: ", this.baseBranchName);
     const commitRaws = getCommitRaws(this.gitLog);
     if (this.isDebugMode) console.log("commitRaws: ", commitRaws);
     const commitDict = buildCommitDict(commitRaws);

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,7 +1,7 @@
 import { AnalysisEngine } from "@githru-vscode-ext/analysis-engine";
 import * as vscode from "vscode";
 import { COMMAND_LAUNCH } from "./commands";
-import { findGit, getGitConfig, getGitLog, getRepo } from "./utils/git.util";
+import { findGit, getBaseBranchName, getBranchNames, getGitConfig, getGitLog, getRepo } from "./utils/git.util";
 import { mapClusterNodesFrom } from "./utils/csm.mapper";
 import WebviewLoader from "./webview-loader";
 
@@ -26,8 +26,10 @@ export function activate(context: vscode.ExtensionContext) {
         const gitLog = await getGitLog(gitPath, currentWorkspacePath);
         const gitConfig = await getGitConfig(gitPath, currentWorkspacePath, "origin");
         const { owner, repo } = getRepo(gitConfig);
+        const branchNames = await getBranchNames(gitPath, currentWorkspacePath);
+        const baseBranchName = getBaseBranchName(branchNames);
 
-        const engine = new AnalysisEngine({ isDebugMode: true, gitLog, owner, repo, auth: githubToken });
+        const engine = new AnalysisEngine({ isDebugMode: true, gitLog, owner, repo, auth: githubToken, baseBranchName });
         const csmDict = await engine.analyzeGit();
         const clusterNodes = mapClusterNodesFrom(csmDict);
         const data = JSON.stringify(clusterNodes);

--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -195,3 +195,36 @@ export const getRepo = (gitRemoteConfig: string) => {
 
 	return { owner, repo };
 }
+
+export async function getBranchNames(path: string, repo: string): Promise<string[]> {
+	return new Promise((resolve, reject) => {
+		resolveSpawnOutput(
+			cp.spawn(path, ["branch"], {
+				cwd: repo,
+				env: Object.assign({}, process.env),
+			})
+		).then((values) => {
+			const status = values[0], stdout = values[1], stderr = values[2];
+			if (status.code === 0) {
+				const branches = stdout
+					.toString()
+					.split("\n")
+					.map((name) => name.replace("*", "").trim());
+				resolve(branches);
+			} else {
+				reject(stderr);
+			}
+		});
+	});
+}
+
+export function getBaseBranchName(branchNames: string[]): string {
+	for (const name of branchNames) {
+		if (name === "main") {
+			return "main";
+		} else if (name === "master") {
+			return "master";
+		}
+	}
+	return branchNames[0];
+}


### PR DESCRIPTION
- 현재 git local repository의 branch 이름 목록을 가져옵니다.
- csm의 기준이 될 baseBranchName을 찾아옵니다.

`git branch` 커맨드로 가져온 브랜치 목록에서 baseBranchName을 찾습니다.
1. 'main' 브랜치가 있는가?
2. 'master' 브랜치가 있는가?
3. 1, 2 둘 다 없었다면, 브랜치 목록의 첫 번째 브랜치 이름을 사용


원래 `git symbolic-ref refs/remotes/origin/HEAD` 커맨드로 remotes/origin/HEAD가 가리키는 브랜치 이름을 가져오려고 했는데,
remotes가 없거나 origin이 아닌 다른 이름을 사용하면 가져올 수 없기 때문에 브랜치 이름 리스트에서 가져오는 게 가장 안전할 것 같았습니다.