### PR TITLE
feat(view): add clusterNode Tooltip closed #227

### DIFF
--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.hook.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.hook.tsx
@@ -84,6 +84,9 @@ const drawClusterGraph = (
     .attr("transform", (d, i) =>
       getClusterPosition(d, i, detailElementHeight, true)
     );
+
+  group.append("title").text((d) => d.clusterSize);
+
   group
     .transition()
     .duration(300)


### PR DESCRIPTION
# Related Issue 

- closed #227 

# WorkList

clusterNode별 Tooltip을 추가하였습니다.
div태그를 사용하지않고, title tag를 append하여 내부 text를 clusterSize를 제공하였습니다.

rect는 2개가 존재하여 상단인 g tag에 추가하였습니다.

# ScreenShot

![화면_기록_2022-11-13_오후_10_57_02_AdobeExpress](https://user-images.githubusercontent.com/70205497/201525745-83a22756-0faf-4f01-aa6d-1d984910d0c8.gif)

