### PR TITLE
fix(view): Author Image

### DIFF
--- a/packages/view/src/components/VerticalClusterList/Summary/Author/Author.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Author/Author.tsx
@@ -15,7 +15,7 @@ const Author = ({ name }: AuthorProps) => {
 
   return (
     <div className="name" data-tooltip-text={name}>
-      <img ref={imgRef} src={src} onError={onError} alt="profileImage" />
+      <img ref={imgRef} src={src} onError={onError} alt="" />
     </div>
   );
 };

--- a/packages/view/src/components/VerticalClusterList/Summary/Author/Author.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Author/Author.tsx
@@ -1,19 +1,21 @@
-import { useState } from "react";
+import { useRef } from "react";
 import md5 from "md5";
 
 import type { AuthorProps } from "../Summary.type";
 import { GITHUB_URL, GRAVATA_URL } from "../Summary.const";
 
 const Author = ({ name }: AuthorProps) => {
-  const src = `${GITHUB_URL}/${name}.png`;
+  const src = `${GITHUB_URL}/${name}.png?size=30`;
   const fallback = `${GRAVATA_URL}/${md5(name)}?d=identicon&f=y`;
+  const imgRef = useRef<HTMLImageElement>(null);
 
-  const [imgSrc, setImgSrc] = useState<string>(src);
-  const onError = () => setImgSrc(fallback);
+  const onError = () => {
+    if (imgRef.current) imgRef.current.src = fallback;
+  };
 
   return (
     <div className="name" data-tooltip-text={name}>
-      <img src={imgSrc} onError={onError} alt="" />
+      <img ref={imgRef} src={src} onError={onError} alt="profileImage" />
     </div>
   );
 };

--- a/packages/view/src/components/VerticalClusterList/Summary/Author/Author.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Author/Author.tsx
@@ -1,21 +1,9 @@
-import { useRef } from "react";
-import md5 from "md5";
-
 import type { AuthorProps } from "../Summary.type";
-import { GITHUB_URL, GRAVATA_URL } from "../Summary.const";
 
-const Author = ({ name }: AuthorProps) => {
-  const src = `${GITHUB_URL}/${name}.png?size=30`;
-  const fallback = `${GRAVATA_URL}/${md5(name)}?d=identicon&f=y`;
-  const imgRef = useRef<HTMLImageElement>(null);
-
-  const onError = () => {
-    if (imgRef.current) imgRef.current.src = fallback;
-  };
-
+const Author = ({ name, src }: AuthorProps) => {
   return (
     <div className="name" data-tooltip-text={name}>
-      <img ref={imgRef} src={src} onError={onError} alt="" />
+      <img src={src} alt="" />
     </div>
   );
 };

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.hook.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.hook.tsx
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+
+import { useGlobalData } from "hooks";
+
+import { getAuthSrcMap } from "./Summary.util";
+
+export const usePreLoadAuthorImg = () => {
+  const { data } = useGlobalData();
+  const [authSrcMap, setAuthSrcMap] = useState({});
+
+  useEffect(() => {
+    getAuthSrcMap(data)
+      .then(setAuthSrcMap)
+      .catch(() => setAuthSrcMap({}));
+  }, [data]);
+
+  return authSrcMap;
+};

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -5,18 +5,18 @@ import { useGlobalData } from "hooks";
 
 import { selectedDataUpdater } from "../VerticalClusterList.util";
 
-import type { Cluster } from "./Summary.type";
-import { Author } from "./Author";
-import { Content } from "./Content";
-import { getClusterById, getClusterIds, getInitData } from "./Summary.util";
-
 import "./Summary.scss";
+import { usePreLoadAuthorImg } from "./Summary.hook";
+import { getInitData, getClusterIds, getClusterById } from "./Summary.util";
+import { Content } from "./Content";
+import { Author } from "./Author";
+import type { Cluster } from "./Summary.type";
 
 const Summary = () => {
   const { filteredData: data, selectedData, setSelectedData } = useGlobalData();
   const clusters = getInitData({ data });
   const scrollRef = useRef<HTMLDivElement>(null);
-
+  const authSrcMap = usePreLoadAuthorImg();
   const selectedClusterId = getClusterIds(selectedData);
   const onClickClusterSummary = (clusterId: number) => () => {
     const selected = getClusterById(data, clusterId);
@@ -49,7 +49,11 @@ const Summary = () => {
                   {cluster.summary.authorNames.map(
                     (authorArray: Array<string>) => {
                       return authorArray.map((authorName: string) => (
-                        <Author key={authorName} name={authorName} />
+                        <Author
+                          key={authorName}
+                          name={authorName}
+                          src={authSrcMap[authorName]}
+                        />
                       ));
                     }
                   )}

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.type.ts
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.type.ts
@@ -1,5 +1,6 @@
 export type AuthorProps = {
   name: string;
+  src: string;
 };
 
 export type Content = {
@@ -21,4 +22,9 @@ export type Summary = {
 export type Cluster = {
   clusterId: number;
   summary: Summary;
+};
+
+export type SrcInfo = {
+  key: string;
+  value: string;
 };


### PR DESCRIPTION
# related Issue

- #258 

# Description

## 이미지 최적화

해당 이슈 #258 에서 profile Image의 error 발생시 fallback 이미지가 느리게 로딩되는 이슈가 존재하였습니다.
하지만 네트워크 요청 속도를 '제한없음' , '빠른 3g' , '느린 3g'를 사용하여 측정해보아도 fallback 이미지가 느리게 로딩되는 이슈를 발견할 수 없었습니다.

하지만, fallback 이미지라 하면, 기존 로딩 이후 에러 발생하여 요청하는 이미지인데, 오히려 성공적으로 요청하는 이미지의 요청 속도가 느린 결과를 확인하게 되었습니다.

아래 gif 영상은 빠른 3g 요청으로 네트워크 속도를 조절하여 확인한 영상입니다.

![빠른_AdobeExpress](https://user-images.githubusercontent.com/70205497/201530483-9444ce6d-4f79-4dd1-8cef-fa720fd7db9d.gif)

네트워크 탭과 성능 측정을 확인한 결과, ( 네트워크 환경은 빠른 3g 입니다. )

![network요청2](https://user-images.githubusercontent.com/70205497/201530679-14ebb2be-371d-4b2b-a254-f157ea523b4a.png)

![빠른3g1](https://user-images.githubusercontent.com/70205497/201530681-46f1143f-9a8c-4c5f-81d3-e1769e47fb4a.png)

위 이미지를 통해 실패한 이미지 로딩에 대한 fallback을 불러오나, 성공한 이미지 로딩에 대해서는 redirect를 시켜 한번더 요청을 보내는 것을 확인하실 수 있습니다.

동시에 ```md5```를 사용한 fallback src의 갯수 또한 커넥션 수의 부족 발생이 큰 문제를 야기하지 않음을 알 수 있습니다.

이미지 로딩을 최적화 하기 위해서는 fallback 갯수 제한 또한 도움이 되겠지만, redirect하는 profile Image를 최적화 하는게 시급하다 느꼈습니다.

그 결과, redirect를 방지하기 위해서는 user 고유 값이 필요하나 값이 존재하지 않아 ```이미지 사이즈 최적화```를 통해 이미지 로딩 최적화를 진행하였습니다.

기존 사용자의 profile Image의 크기는 460px이나 view에 보이는 이미지의 크기는 30px로 고정된 크기 였기에
```?size=30```을 추가하여 이미지 크기를 리사이징 하였습니다.

해당 결과는 아래 이미지와 같습니다.


![460px 시간](https://user-images.githubusercontent.com/70205497/201530916-671520a0-5590-42f4-a5b6-b861718886c3.png)

![30px 시간](https://user-images.githubusercontent.com/70205497/201530917-bb042782-3c56-4699-8c87-310f9d579949.png)


![image size 최적화](https://user-images.githubusercontent.com/70205497/201531045-57c841ed-d66a-4e28-ae36-4e9c91c4bb52.png)

결과적으로 11개의 onError 발생과 13개의 redirect 요청에 대하여 '빠른 3g' 환경에서
2300ms 에서 1800ms로 감축하는 효과를 확인할 수 있었습니다.

---

## useState 제거 후 useRef 적용

author image src 값을 상태로 관리하였습니다.
해당 로직을 useRef로 변경하여
onError 발생시 리렌더링을 방지하였습니다.

결과는 아래 이미지와 같습니다.

![상태사용](https://user-images.githubusercontent.com/70205497/201531233-8d10f091-0331-4309-a46d-2d33d6917968.png)

![ref 렌더링](https://user-images.githubusercontent.com/70205497/201531244-fdfff593-b0bf-4d51-9505-957c71f880b1.png)

---

## 추가 내용 22.11.17

![화면_기록_2022-11-17_오전_12_33_55_AdobeExpress](https://user-images.githubusercontent.com/70205497/202224661-3a57dcc7-a9cd-4f0d-9031-abb77f31cde3.gif)

기존 `fallback src`의 이미지는 profile image 보다 느리게 렌더링되는 이슈에 대해서
`Author Component`에서 리렌더링 시, onError를 호출하여 fallback src를 렌더링하기때문에 더 느리게 렌더링되는 이슈를 확인하였습니다.

캐시가 되지 않는 것이 아니라, load를 늦게 하는 것으로 확인하였습니다. ( gravatar 의 이미지의 경우 disk cache로 300s 진행되는 것을 확인할 수 있습니다. )

따라서, `Author Component`에 렌더링할 `src`값을 주입하고자
`Summary Component`에서 사용자에 대한 img src 를 찾기 위해 `usePreLoadAuthorImg` 을 구현하여 위 문제를 해결하였습니다.


