### PR TITLE
Feat/copy hash

### DIFF
--- a/packages/view/src/components/Detail/Detail.scss
+++ b/packages/view/src/components/Detail/Detail.scss
@@ -77,6 +77,13 @@
     }
     .commit-id {
       padding-left: 50px;
+      position: relative;
+      span:hover {
+        cursor: pointer;
+        .commit-id__tooltip {
+          display: inline-block;
+        }
+      }
     }
   }
 }
@@ -92,4 +99,17 @@
   &:hover {
     color: $gray-300;
   }
+}
+
+.commit-id__tooltip {
+  display: none;
+  position: absolute;
+  background: $white;
+  padding: 8px 16px;
+  text-align: center;
+  font-size: 10px;
+  line-height: 1.5;
+  border-radius: 5px;
+  color: $gray-900;
+  transform: translateY(20%) translateX(-120%);
 }

--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -43,6 +43,9 @@ const Detail = ({ selectedData, clusterId }: DetailProps) => {
     commitNodeListInCluster
   );
   const isShow = commitNodeListInCluster.length > FIRST_SHOW_NUM;
+  const handleHashCodeCopy = (id: string) => async () => {
+    navigator.clipboard.writeText(id);
+  };
 
   if (!selectedData) return null;
 
@@ -62,7 +65,14 @@ const Detail = ({ selectedData, clusterId }: DetailProps) => {
                 </span>
               </div>
               <div className="commit-id">
-                <span>{id.slice(0, 6)}</span>
+                <span
+                  onClick={handleHashCodeCopy(id)}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={handleHashCodeCopy(id)}
+                >
+                  {id.slice(0, 6)}
+                </span>
               </div>
             </li>
           );

--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -43,7 +43,7 @@ const Detail = ({ selectedData, clusterId }: DetailProps) => {
     commitNodeListInCluster
   );
   const isShow = commitNodeListInCluster.length > FIRST_SHOW_NUM;
-  const handleHashCodeCopy = (id: string) => async () => {
+  const handleCommitIdCopy = (id: string) => async () => {
     navigator.clipboard.writeText(id);
   };
 
@@ -66,10 +66,10 @@ const Detail = ({ selectedData, clusterId }: DetailProps) => {
               </div>
               <div className="commit-id">
                 <span
-                  onClick={handleHashCodeCopy(id)}
+                  onClick={handleCommitIdCopy(id)}
                   role="button"
                   tabIndex={0}
-                  onKeyDown={handleHashCodeCopy(id)}
+                  onKeyDown={handleCommitIdCopy(id)}
                 >
                   {id.slice(0, 6)}
                   <span className="commit-id__tooltip">{id}</span>

--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -72,6 +72,7 @@ const Detail = ({ selectedData, clusterId }: DetailProps) => {
                   onKeyDown={handleHashCodeCopy(id)}
                 >
                   {id.slice(0, 6)}
+                  <span className="commit-id__tooltip">{id}</span>
                 </span>
               </div>
             </li>


### PR DESCRIPTION
# Related Issue
- closed #213 

# WorkList
- commit id를 click 할 때 commit id를 복사하는 기능을 추가하였습니다.
- commit id를 hover 할 때 commit full id 를 tooltip으로 만들었습니다.

# ScreenShot

https://user-images.githubusercontent.com/70205497/202235586-9136549d-b624-4b11-bdc5-e476e8a20813.mov

