### PR TITLE
fix(vscode): patch for changed vscode webview load API

### DIFF
--- a/packages/vscode/src/webview-loader.ts
+++ b/packages/vscode/src/webview-loader.ts
@@ -18,7 +18,7 @@ export default class WebviewLoader implements vscode.Disposable {
             this.respondToMessage(message)
         );
 
-        this._panel.webview.html = this.getWebviewContent(data);
+        this._panel.webview.html = this.getWebviewContent(this._panel.webview, data);
     }
 
     dispose() {
@@ -35,9 +35,10 @@ export default class WebviewLoader implements vscode.Disposable {
         }
     }
 
-    private getWebviewContent(data: string): string {
+    private getWebviewContent(webview:vscode.Webview, data: string): string {
         const reactAppPathOnDisk = vscode.Uri.file(path.join(this.extensionPath, "dist", "webviewApp.js"));
-        const reactAppUri = reactAppPathOnDisk.with({ scheme: "vscode-resource" });
+        const reactAppUri = webview.asWebviewUri(reactAppPathOnDisk);
+        // const reactAppUri = reactAppPathOnDisk.with({ scheme: "vscode-resource" });
 
         const returnString = `
             <!DOCTYPE html>


### PR DESCRIPTION
vscode 최근 버전에서 webview load 하는 방식이 바뀌어서 (갑자기 ㅜ.ㅜ) 동작하지 않는 문제가 있었습니다.
해당 문제 patch 버전입니다.

@jin-Pro 아마 지난번에 말씀해주신 에러 이슈가 저것 때문일 것 같습니다. 한번 재확인 부탁드립니다.