### PR TITLE
fix(view): hover not styling correctly under 850px viewport (#225)

### DIFF
--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -75,7 +75,7 @@
 }
 @media (max-width: 850px) {
   .cluster-summary__cluster {
-    width: 200px !important;
+    width: 300px !important;
 
     .commit-message {
       width: 100px !important;


### PR DESCRIPTION
## Related Issue
- #225 

## Content

850px viewport 이하에서 `vertical cluster list summary`의 `toggle-contents-button`의 호버 스타일링이 잘리는 것을 개선하였습니다.

### AS-IS

<img width="363" alt="Screenshot 2023-03-25 at 15 32 58" src="https://user-images.githubusercontent.com/48273875/227701086-471d0ed0-2eac-4daf-8c38-e016b9d75af4.png">

### TO-BE

<img width="429" alt="Screenshot 2023-03-25 at 15 32 19" src="https://user-images.githubusercontent.com/48273875/227701098-e3c26358-1591-4be6-ab2e-2808b9c9d876.png">

## Discussion

### Flex-Box나 Grid를 이용한 쉬운 반응형 디자인

해당 문제 자체는 값 하나만 바꾸는 것으로 해결하였습니다.

다양한 viewport에 대한 style을 hard coded value로 지정하다보니 생긴 Human Error였던 것 같습니다. ㅎㅎ

viewport에 대해서 width를 지정해주기보다 flex-box나 grid를 이용하는 건 어떨지 의견을 추가해봅니다.

flex-box나 grid로 채울 수 있는 남은 공간을 차지하게 한다면 쉽게, 실수 없이 반응형 디자인을 할 수 있을 것 같습니다!! 😁

### 850px viewport 이하에 대한 Layout / Design

### AS-IS

<img width="601" alt="Screenshot 2023-03-25 at 15 39 41" src="https://user-images.githubusercontent.com/48273875/227701414-b36f12d0-98f5-4486-a49b-17e8da0f8469.png">

위 사진은 600px viewport에서의 화면입니다.

600px 미만의 size에 대해 어떻게 지원하면 좋을지도 생각해보면 좋을 것 같습니다!! 😁
