### PR TITLE
fix(view): show author and date info always(#211)

### DIFF
--- a/packages/view/src/components/Detail/Detail.scss
+++ b/packages/view/src/components/Detail/Detail.scss
@@ -61,16 +61,16 @@
   .commit-item {
     display: flex;
     justify-content: space-between;
-    margin-top: 4px;
+    margin: 7px 0px;
     color: $gray-600;
 
     .commit-detail {
-      display: -webkit-box;
-      -webkit-box-orient: vertical;
-      -webkit-line-clamp: 1;
       overflow: hidden;
-
       .message {
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 1;
+        overflow: hidden;
         color: $white;
         margin-right: 4px;
       }


### PR DESCRIPTION
### 관련 이슈

- #211

## 수정 내용

디테일 컴포넌트에서, commit log가 길 경우 author와 시간이 잘리는 현상을 개선했습니다.

### 이전 사진

![image](https://user-images.githubusercontent.com/78261574/227703766-089c804b-ea47-47d5-9991-a99bb27cf328.png)

### 수정 후, 사진


![image](https://user-images.githubusercontent.com/78261574/227703625-e14c7156-8676-48e9-a99b-1e06353bae25.png)


### 상세 수정 내용

커밋 로그는 한줄로 표현하기 위해 내용이 길 경우 ...으로 표현되게 유지했습니다.

author와 시간이 잘리는 것을 방지하기 위해 commit log 밑에 보여지게 변경했습니다.
추가적으로 commit-item이 한줄에서 두줄로 변경이 되어 마진을 좀 더 주었습니다.

### 추가적 논의

현재는 커밋 로그가 길면 ...으로 표현됩니다. 그래서 상세 커밋 로그를 확인할 수 있게 지원할 수 있게 추가적으로 구현이 되면 좋을 듯 생각합니다.

관련이슈는
- #212
입니다..!



