### PR TITLE
feat(vscode): add refresh handler

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -29,12 +29,24 @@ export function activate(context: vscode.ExtensionContext) {
         const branchNames = await getBranchNames(gitPath, currentWorkspacePath);
         const baseBranchName = getBaseBranchName(branchNames);
 
-        const engine = new AnalysisEngine({ isDebugMode: true, gitLog, owner, repo, auth: githubToken, baseBranchName });
-        const csmDict = await engine.analyzeGit();
-        const clusterNodes = mapClusterNodesFrom(csmDict);
-        const data = JSON.stringify(clusterNodes);
+        const commitParse = async () => {
+            const engine = new AnalysisEngine({
+                isDebugMode: true,
+                gitLog,
+                owner,
+                repo,
+                auth: githubToken,
+                baseBranchName,
+            });
+            const csmDict = await engine.analyzeGit();
+            const clusterNodes = mapClusterNodesFrom(csmDict);
+            const data = JSON.stringify(clusterNodes);
+            return data;
+        };
+        const initialData = await commitParse();
+        const webLoader = new WebviewLoader(extensionUri, extensionPath, initialData, commitParse);
 
-        subscriptions.push(new WebviewLoader(extensionUri, extensionPath, data));
+        subscriptions.push(webLoader);
 
         vscode.window.showInformationMessage("Hello Githru");
     });

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -23,13 +23,13 @@ export function activate(context: vscode.ExtensionContext) {
         const configuration = vscode.workspace.getConfiguration();
         const githubToken: string | undefined = configuration.get("githru.github.token");
         console.log("GitHubToken: ", githubToken);
-        const gitLog = await getGitLog(gitPath, currentWorkspacePath);
-        const gitConfig = await getGitConfig(gitPath, currentWorkspacePath, "origin");
-        const { owner, repo } = getRepo(gitConfig);
-        const branchNames = await getBranchNames(gitPath, currentWorkspacePath);
-        const baseBranchName = getBaseBranchName(branchNames);
 
-        const commitParse = async () => {
+        const fetchClusterNodes = async () => {
+            const gitLog = await getGitLog(gitPath, currentWorkspacePath);
+            const gitConfig = await getGitConfig(gitPath, currentWorkspacePath, "origin");
+            const { owner, repo } = getRepo(gitConfig);
+            const branchNames = await getBranchNames(gitPath, currentWorkspacePath);
+            const baseBranchName = getBaseBranchName(branchNames);
             const engine = new AnalysisEngine({
                 isDebugMode: true,
                 gitLog,
@@ -43,8 +43,8 @@ export function activate(context: vscode.ExtensionContext) {
             const data = JSON.stringify(clusterNodes);
             return data;
         };
-        const initialData = await commitParse();
-        const webLoader = new WebviewLoader(extensionUri, extensionPath, initialData, commitParse);
+        const initialData = await fetchClusterNodes();
+        const webLoader = new WebviewLoader(extensionUri, extensionPath, initialData, fetchClusterNodes);
 
         subscriptions.push(webLoader);
 


### PR DESCRIPTION
## Related Issue
- #282 

## WorkList
**refresh 기능 추가**
- 클러스터 노드를 불러오는 작업을 함수로 추출했습니다. 
  - `extension.ts > fetchCluseterNodes()` 

- `webview-loader.ts > panel.webview.onDidReceiveMessage()`에서 받은 메시지의 커멘드에 매칭되는 서비스 수행합니다.
  - `refresh` 메시지를 받은 경우,`fetchCluseterNodes()`를 호출해 최신화된 클러스터 노드를 반환합니다.

## Discussion
- `WebviewLoader` 구현체에 각 이벤트에 따른 비즈니스 로직을 주입하는 방식으로 구현되어 있습니다. 이벤트의 타입이 늘어날수록 의존성이 커지는 구조인데, `webview-loader.ts` 파일과 `extension.ts` 파일을 병합해 flat한 구조로 관리하는 방법을 제안합니다.
- 최초 랜더링 때, 전역객체에 data를 바인딩 하는 방식으로 `view`에 data를 전달하고 있습니다. 통일된 데이터 전달 방식 위해 최초 랜더링 역시 메시지 기반으로 받은 데이터를 사용 하도록 리팩토링 하는 것을 제안합니다.