### PR TITLE
fix(view): better responsiveness with flexbox

### DIFF
--- a/packages/view/src/components/Statistics/Statistics.scss
+++ b/packages/view/src/components/Statistics/Statistics.scss
@@ -5,3 +5,9 @@
   padding: 0 20px;
   width: 300px;
 }
+
+@media (max-width: 850px) {
+  .statistics {
+    display: none;
+  }
+}

--- a/packages/view/src/components/VerticalClusterList/Summary/Content/Content.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Content/Content.tsx
@@ -9,10 +9,12 @@ const Content = ({ content, clusterId, selectedClusterId }: ContentProps) => {
   return (
     <>
       <div className="cluster-summary__contents">
-        <span className="commit-message">{content.message}</span>
-        <span className="more-commit-count">
-          {content.count > 0 && `+ ${content.count} more`}
-        </span>
+        <div className="commit-message__wrapper">
+          <div className="commit-message">{content.message}</div>
+        </div>
+        {content.count > 0 && (
+          <span className="more-commit-count">+ {content.count} more</span>
+        )}
       </div>
       <div className="collapsible-icon">
         {selectedClusterId.includes(clusterId) ? (

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -137,15 +137,21 @@
       display: flex;
       justify-content: space-between;
       font-size: 12px;
+      gap: 10px;
 
-      .commit-message {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        margin-left: 15px;
+      .commit-message__wrapper {
+        flex-grow: 1;
+        padding-left: 15px;
         text-align: left;
-        width: 700px;
         cursor: pointer;
+        // "width: 0" makes the "commit-message" ellipsis reponsive
+        width: 0;
+
+        .commit-message {
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
       }
 
       .more-commit-count {

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -28,77 +28,23 @@
   }
 }
 
-@media (max-width: 1440px) {
-  .cluster-summary__cluster {
-    width: 850px !important;
-
-    .commit-message {
-      width: 600px !important;
-    }
-  }
-}
-@media (max-width: 1300px) {
-  .cluster-summary__cluster {
-    width: 700px !important;
-
-    .commit-message {
-      width: 500px !important;
-    }
-  }
-}
-@media (max-width: 1130px) {
-  .cluster-summary__cluster {
-    width: 600px !important;
-
-    .commit-message {
-      width: 400px !important;
-    }
-  }
-}
-@media (max-width: 1024px) {
-  .cluster-summary__cluster {
-    width: 500px !important;
-
-    .commit-message {
-      width: 300px !important;
-    }
-  }
-}
-@media (max-width: 930px) {
-  .cluster-summary__cluster {
-    width: 400px !important;
-
-    .commit-message {
-      width: 200px !important;
-    }
-  }
-}
-@media (max-width: 850px) {
-  .cluster-summary__cluster {
-    width: 300px !important;
-
-    .commit-message {
-      width: 100px !important;
-    }
-  }
-}
-
 .cluster-summary__container {
-  width: 85%;
-  margin-left: 20px;
-  margin-top: 5px;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  padding-left: 20px;
+  padding-top: 5px;
 
   .cluster-summary__cluster {
     padding: 5px 0;
-    width: 950px;
 
     .toggle-contents-button {
-      width: 100%;
       padding: 5px 15px;
       border: none;
       background-color: transparent;
       cursor: pointer;
       color: $white;
+      width: 100%;
 
       &:hover {
         border-radius: 40px;
@@ -109,7 +55,6 @@
     .toggle-contents-container {
       display: flex;
       align-items: center;
-      width: 100%;
     }
 
     :hover .collapsible-icon {
@@ -124,7 +69,6 @@
       background-color: transparent;
       border: none;
       font-size: 24px;
-      // color: $blue-light-600;
       color: #ff8272;
       visibility: hidden;
       cursor: pointer;
@@ -189,9 +133,9 @@
     }
 
     .cluster-summary__contents {
+      flex-grow: 1;
       display: flex;
       justify-content: space-between;
-      width: 100%;
       font-size: 12px;
 
       .commit-message {
@@ -206,7 +150,6 @@
 
       .more-commit-count {
         text-align: right;
-        width: 60px;
         font-size: 10px;
       }
     }

--- a/packages/view/src/components/VerticalClusterList/VerticalClusterList.scss
+++ b/packages/view/src/components/VerticalClusterList/VerticalClusterList.scss
@@ -4,7 +4,7 @@
   height: 100%;
   overflow-x: hidden;
   overflow-y: scroll;
-  width: 75%;
+  flex-grow: 1;
 
   svg.cluster-graph {
     min-width: 84px;


### PR DESCRIPTION
## Related issue
- #225 
- #288

## Result

### AS-IS

<table>
<tr>
<td>
viewport가 가로로 길 때 모습
</td>
<td>

![hover not good large](https://user-images.githubusercontent.com/48273875/227721361-c1cbe1e4-ae33-49ef-a650-3a6f46cc4df5.gif)

</td>
</tr>

<tr>
<td>
viewport가 가로로 좁을 때 모습
</td>
<td>

![hover not good small](https://user-images.githubusercontent.com/48273875/227721422-2c6c6d19-6d5a-48f3-8e88-17aaf59fb489.gif)

</td>
</tr>

<tr>
<td>
viewport가 좁을 때 chart가 커밋 리스트를 가림
</td>
<td>

![chart cover (1)](https://user-images.githubusercontent.com/48273875/227721692-23c12bc4-e014-49da-a99c-19298c478a2f.gif)

</td>
</tr>
</table>

### TO-BE

<table>

<tr>
<td>
viewport가 가로로 길 때 모습
</td>
<td>

![new hover large](https://user-images.githubusercontent.com/48273875/227721703-ef039525-9b49-4dd6-ae7c-10bd346dbebd.gif)

</td>
</tr>

<tr>
<td>
viewport가 가로로 좁을 때 모습
</td>
<td>

![new hover small](https://user-images.githubusercontent.com/48273875/227721579-61d9b59c-f61c-4e57-8243-5546ff2cb99f.gif)

</td>
</tr>

<tr>
<td>
viewport가 좁을 때 chart를 숨김
</td>

<td>

![chart cover solved](https://user-images.githubusercontent.com/48273875/227721849-a6527a3e-e116-49d1-9117-a04cbbbc3d60.gif)

</td>
</tr>
</table>


## Work list

hard coded 된 width value들을 flex 기반으로 수정하였습니다.

commit-message에 대한 responsiveness도 수정/반영하였습니다.

## Discussion

850px 미만의 viewport width에 대해서는 chart를 숨기는 방식으로 진행하였습니다.

flex direction을 바꾸거나 slide over로 바꾸는 등 다양한 방식으로 추가로 수정 가능할 것 같습니다.

