### PR TITLE
feat(view): changed author bar chart to vertical and with avatar

### DIFF
--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
@@ -39,13 +39,13 @@
     font-weight: bold;
 
     &.x-axis {
-      text {
+      .tick {
         display: none;
       }
     }
 
-    &.y-axis {
-      .y-axis-label {
+    &.x-axis {
+      .x-axis-label {
         fill: $white;
       }
     }

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
@@ -38,14 +38,14 @@
     color: $white;
     font-weight: bold;
 
-    &.y-axis {
+    &.x-axis {
       text {
         display: none;
       }
     }
 
-    &.x-axis {
-      .x-axis-label {
+    &.y-axis {
+      .y-axis-label {
         fill: $white;
       }
     }

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -172,36 +172,10 @@ const AuthorBarChart = () => {
       .attr("x", (d: AuthorDataType) => xScale(d.name) || 0)
       .attr("y", (d: AuthorDataType) => yScale(d[metric]));
 
-    //  Draw author names
+    // Draw author thumbnails
     const barElements = d3.selectAll(".bar").nodes();
     if (!barElements.length) return;
 
-    barElements.forEach((barElement, i) => {
-      const bar = d3.select(barElement).datum(data[i]);
-      bar
-        .append("text")
-        .attr("class", "name")
-        .attr("height", (d: AuthorDataType) => yScale(d[metric]))
-        .attr("width", xScale.bandwidth())
-        .attr("y", 3)
-        .attr(
-          "x",
-          (d: AuthorDataType) =>
-            (xScale(d.name) ?? 0) + xScale.bandwidth() / 2 + 5
-        )
-        .attr(
-          "transform",
-          (d: AuthorDataType) =>
-            `rotate(90 ${(xScale(d.name) ?? 0) + xScale.bandwidth() / 2}, 0)`
-        )
-        .on("mouseover", handleMouseOver)
-        .on("mousemove", handleMouseMove)
-        .on("mouseout", handleMouseOut)
-        .on("click", handleClickBar)
-        .html((d: AuthorDataType) => d.name);
-    });
-
-    // Draw author thumbnails
     barElements.forEach(async (barElement, i) => {
       const bar = d3.select(barElement).datum(data[i]);
       const profileImgSrc: string = await getAuthorProfileImgSrc(

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -181,7 +181,6 @@ const AuthorBarChart = () => {
       bar
         .append("text")
         .attr("class", "name")
-        .style("white-space", "nowrap")
         .attr("height", (d: AuthorDataType) => yScale(d[metric]))
         .attr("width", xScale.bandwidth())
         .attr("y", 3)

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.type.ts
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.type.ts
@@ -8,3 +8,8 @@ export type AuthorDataType = {
 };
 
 export type MetricType = typeof METRIC_TYPE[number];
+
+export type SrcInfo = {
+  key: string;
+  value: string;
+};

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
@@ -1,8 +1,11 @@
 import * as d3 from "d3";
+import md5 from "md5";
 
 import type { ClusterNode, CommitNode } from "types";
 
-import type { AuthorDataType } from "./AuthorBarChart.type";
+import { GITHUB_URL, GRAVATA_URL } from "../../../constants/constants";
+
+import type { AuthorDataType, SrcInfo } from "./AuthorBarChart.type";
 
 export const getDataByAuthor = (data: ClusterNode[]): AuthorDataType[] => {
   if (!data.length) return [];
@@ -66,3 +69,30 @@ export const sortDataByAuthor = (
     ];
   }, []);
 };
+
+export function getAuthorProfileImgSrc(authorName: string): Promise<SrcInfo> {
+  return new Promise((resolve) => {
+    const img = new Image();
+
+    img.onload = () => {
+      const { src } = img;
+      const srcInfo: SrcInfo = {
+        key: authorName,
+        value: src,
+      };
+      resolve(srcInfo);
+    };
+
+    img.onerror = () => {
+      const fallback = `${GRAVATA_URL}/${md5(authorName)}}?d=identicon&f=y`;
+
+      resolve({
+        key: authorName,
+        value: fallback,
+      });
+    };
+
+    const src = `${GITHUB_URL}/${authorName}.png?size=30`;
+    img.src = src;
+  });
+}

--- a/packages/view/src/constants/constants.tsx
+++ b/packages/view/src/constants/constants.tsx
@@ -1,0 +1,2 @@
+export const GITHUB_URL = "https://github.com";
+export const GRAVATA_URL = "https://www.gravatar.com/avatar";


### PR DESCRIPTION
## Related issue
- #147  
- #178 
- #220 
## Result
### Before
![227730057-a34cf18b-8355-45c0-b11d-2c3e69e16e29](https://user-images.githubusercontent.com/68739701/227734946-e243b4b4-50df-49fe-97e4-a2e6cf4f21bb.png)

### After
![이미지sdsad 3](https://user-images.githubusercontent.com/68739701/227734950-aee71687-814f-45f9-aae6-93a665e7a58b.png)


## Work list
- AuthorBarChart를 Hotizontal에서 Vertical로 변경하였습니다.
- Constants 파일을 src폴더에 생성하였습니다.
- Author name만 표기되던 Chart를 Avatar 이미지와 name이 함께 표기되게 변경하였습니다.

## Discussion
이름표기는 다른 방법으로도 가능할 것 같습니다.
