### PR TITLE
fix(view): faster tree calculation #290

### DIFF
--- a/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.util.ts
+++ b/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.util.ts
@@ -15,14 +15,14 @@ export const getFileChangesMap = (data: ClusterNode[]): FileChangesMap => {
     .reduce(
       (map, { commit: { diffStatistics } }) =>
         Object.entries(diffStatistics.files).reduce(
-          (acc, [path, { insertions, deletions }]) => ({
-            ...acc,
-            [path]: {
+          (acc, [path, { insertions, deletions }]) => {
+            acc[path] = {
               insertions: (acc[path]?.insertions ?? 0) + insertions,
               deletions: (acc[path]?.deletions ?? 0) + deletions,
               commits: (acc[path]?.commits ?? 0) + 1,
-            },
-          }),
+            };
+            return acc;
+          },
           map
         ),
       {} as FileChangesMap
@@ -36,13 +36,10 @@ export const getFileScoresMap = (data: ClusterNode[]) => {
     .flatMap(({ commitNodeList }) => commitNodeList)
     .reduce(
       (map, { commit: { diffStatistics } }) =>
-        Object.keys(diffStatistics.files).reduce(
-          (acc, path) => ({
-            ...acc,
-            [path]: 1,
-          }),
-          map
-        ),
+        Object.keys(diffStatistics.files).reduce((acc, path) => {
+          acc[path] = 1;
+          return acc;
+        }, map),
       {} as FileScoresMap
     );
 };


### PR DESCRIPTION
## Related issue
- #290 

## Result

[https://github.com/chaejunlee/avss-2023](https://github.com/chaejunlee/avss-2023)를 vscode로 열어
githru를 실행했을 때 기존 코드로는 `getFileChangesTree`가 **1.7분 (약 1027000ms)** 걸립니다.

`getFileChangesTree` 내부의 reduce 성능을 개선하여 같은 작업에 대해 **31ms**로 줄였습니다.

테스트한 리포에 대해서 성능 개선은 약 3290배 입니다.

### AS-IS

<img width="813" alt="as_is" src="https://user-images.githubusercontent.com/48273875/227749277-5df3e485-6fb3-4171-8c4a-b4d6cde51a05.png">

### TO-BE

<img width="774" alt="to_be" src="https://user-images.githubusercontent.com/48273875/227749281-2b7dc0ef-2b4c-4cdf-bd2c-3eb6c4cbf613.png">

## Work list

reduce 마다 acc를 destructuring한 뒤 property를 넣는 것에서 acc에 바로 direct assign 하는 것으로 바꾸어 성능 개선을 진행했습니다.

## Discussion

### destructuring이 필요한가?

제가 봤을 때 destructuring 하는 것이나 direct assign 하는 것이나 문법적, 의미적으로 똑같다고 생각하였습니다.

그리고 view에 제공된 fake data에 대해서 출력이 똑같은 것도 확인하였습니다. (`JSON.stringify()`로 비교)

이 부분에 대해서 혹시나 모르니 한번 더 확인 부탁드립니다.

### `FileScoresMap`의 용도?

`FileScoresMap`이 존재하는 것을 확인하였습니다.

제가 확인하였을 때는 값이 1로 고정되고 딱히 사용되는 곳이 없는 것 같은데 어떤 용도로 사용하는 것인지 궁금합니다!