### PR TITLE
fix(view, vscode): "suppressImplicitAnyIndexErrors" ts rule error in tsconfig.json

### DIFF
--- a/packages/analysis-engine/src/csm.spec.ts
+++ b/packages/analysis-engine/src/csm.spec.ts
@@ -130,8 +130,9 @@ describe("csm", () => {
           const squashCommitIds = csmNode.source.map(
             (commitNode) => commitNode.commit.id
           );
+
           expect(squashCommitIds).toEqual(
-            expectedSquashCommitIds[csmNode.base.commit.id]
+            expectedSquashCommitIds[csmNode.base.commit.id as "2" | "3"]
           );
         });
       });
@@ -177,7 +178,7 @@ describe("csm", () => {
           (commitNode) => commitNode.commit.id
         );
         expect(squashCommitIds).toEqual(
-          expectedSquashCommitIds[csmNode.base.commit.id]
+          expectedSquashCommitIds[csmNode.base.commit.id as "8" | "11"]
         );
       });
     });

--- a/packages/analysis-engine/src/csm.spec.ts
+++ b/packages/analysis-engine/src/csm.spec.ts
@@ -122,7 +122,7 @@ describe("csm", () => {
 
         // 2 commit has squash-commits(8,13,12,7,6)
         // 3 commit has squash-commits(11,16,15,14,10,9)
-        const expectedSquashCommitIds = {
+        const expectedSquashCommitIds: Record<string, string[]> = {
           "2": ["8", "13", "12", "7", "6"],
           "3": ["11", "16", "15", "14", "10", "9"],
         };
@@ -132,7 +132,7 @@ describe("csm", () => {
           );
 
           expect(squashCommitIds).toEqual(
-            expectedSquashCommitIds[csmNode.base.commit.id as "2" | "3"]
+            expectedSquashCommitIds[csmNode.base.commit.id]
           );
         });
       });
@@ -169,7 +169,7 @@ describe("csm", () => {
         expectedMergeCommitIds
       );
 
-      const expectedSquashCommitIds = {
+      const expectedSquashCommitIds: Record<string, string[]> = {
         "8": ["13", "12"],
         "11": ["16", "15", "14"],
       };
@@ -178,7 +178,7 @@ describe("csm", () => {
           (commitNode) => commitNode.commit.id
         );
         expect(squashCommitIds).toEqual(
-          expectedSquashCommitIds[csmNode.base.commit.id as "8" | "11"]
+          expectedSquashCommitIds[csmNode.base.commit.id]
         );
       });
     });

--- a/packages/analysis-engine/tsconfig.json
+++ b/packages/analysis-engine/tsconfig.json
@@ -99,7 +99,7 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true,                                /* Skip type checking all .d.ts files. */
-    "suppressImplicitAnyIndexErrors": true,
+    // "suppressImplicitAnyIndexErrors": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },

--- a/packages/analysis-engine/tsconfig.json
+++ b/packages/analysis-engine/tsconfig.json
@@ -99,7 +99,6 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true,                                /* Skip type checking all .d.ts files. */
-    // "suppressImplicitAnyIndexErrors": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.type.ts
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.type.ts
@@ -7,7 +7,7 @@ export type AuthorDataType = {
   deletion: number;
 };
 
-export type MetricType = typeof METRIC_TYPE[number];
+export type MetricType = (typeof METRIC_TYPE)[0 | 1 | 2];
 
 export type SrcInfo = {
   key: string;

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.type.ts
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.type.ts
@@ -13,3 +13,12 @@ export type SrcInfo = {
   key: string;
   value: string;
 };
+
+export type AuthorDataObj = {
+  [key: string]: {
+    name: string;
+    commit: number;
+    insertion: number;
+    deletion: number;
+  };
+};

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.type.ts
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.type.ts
@@ -7,7 +7,7 @@ export type AuthorDataType = {
   deletion: number;
 };
 
-export type MetricType = (typeof METRIC_TYPE)[0 | 1 | 2];
+export type MetricType = (typeof METRIC_TYPE)[number];
 
 export type SrcInfo = {
   key: string;

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
@@ -51,7 +51,7 @@ export const sortDataByName = (a: string, b: string) => {
 export const convertNumberFormat = (
   d: number | { valueOf(): number }
 ): string => {
-  if (d < 1 && d >= 0) {
+  if (typeof d === "number" && d < 1 && d >= 0) {
     return `${d}`;
   }
   return d3.format("~s")(d);

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
@@ -22,15 +22,20 @@ export const getDataByAuthor = (data: ClusterNode[]): AuthorDataType[] => {
       const { insertions, deletions } = commit.diffStatistics;
 
       if (!acc[author]) {
-        acc[author] = { name: author };
+        acc[author] = {
+          name: author,
+          commit: 1,
+          insertion: insertions,
+          deletion: deletions,
+        };
+      } else {
+        acc[author] = {
+          ...acc[author],
+          commit: (acc[author].commit || 0) + 1,
+          insertion: (acc[author].insertion || 0) + insertions,
+          deletion: (acc[author].deletion || 0) + deletions,
+        };
       }
-
-      acc[author] = {
-        ...acc[author],
-        commit: (acc[author].commit || 0) + 1,
-        insertion: (acc[author].insertion || 0) + insertions,
-        deletion: (acc[author].deletion || 0) + deletions,
-      };
 
       return acc;
     }, authorDataObj);

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
@@ -17,28 +17,26 @@ export const getDataByAuthor = (data: ClusterNode[]): AuthorDataType[] => {
   const authorDataObj: AuthorDataObj = {};
 
   data.forEach(({ commitNodeList }) => {
-    commitNodeList.reduce((acc, { commit }) => {
+    commitNodeList.forEach(({ commit }) => {
       const author = commit.author.names[0];
       const { insertions, deletions } = commit.diffStatistics;
 
-      if (!acc[author]) {
-        acc[author] = {
+      if (!authorDataObj[author]) {
+        authorDataObj[author] = {
           name: author,
           commit: 1,
           insertion: insertions,
           deletion: deletions,
         };
       } else {
-        acc[author] = {
-          ...acc[author],
-          commit: (acc[author].commit || 0) + 1,
-          insertion: (acc[author].insertion || 0) + insertions,
-          deletion: (acc[author].deletion || 0) + deletions,
+        authorDataObj[author] = {
+          ...authorDataObj[author],
+          commit: (authorDataObj[author].commit || 0) + 1,
+          insertion: (authorDataObj[author].insertion || 0) + insertions,
+          deletion: (authorDataObj[author].deletion || 0) + deletions,
         };
       }
-
-      return acc;
-    }, authorDataObj);
+    });
   });
 
   return Object.values(authorDataObj);

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
@@ -5,12 +5,16 @@ import type { ClusterNode, CommitNode } from "types";
 
 import { GITHUB_URL, GRAVATA_URL } from "../../../constants/constants";
 
-import type { AuthorDataType, SrcInfo } from "./AuthorBarChart.type";
+import type {
+  AuthorDataObj,
+  AuthorDataType,
+  SrcInfo,
+} from "./AuthorBarChart.type";
 
 export const getDataByAuthor = (data: ClusterNode[]): AuthorDataType[] => {
   if (!data.length) return [];
 
-  const authorDataObj = {};
+  const authorDataObj: AuthorDataObj = {};
 
   data.forEach(({ commitNodeList }) => {
     commitNodeList.reduce((acc, { commit }) => {

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.hook.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.hook.tsx
@@ -7,7 +7,7 @@ import type { AuthSrcMap } from "./Summary.type";
 
 export const usePreLoadAuthorImg = () => {
   const { data } = useGlobalData();
-  const [authSrcMap, setAuthSrcMap] = useState<AuthSrcMap>(null);
+  const [authSrcMap, setAuthSrcMap] = useState<AuthSrcMap | null>(null);
 
   useEffect(() => {
     getAuthSrcMap(data)

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.hook.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.hook.tsx
@@ -3,15 +3,16 @@ import { useEffect, useState } from "react";
 import { useGlobalData } from "hooks";
 
 import { getAuthSrcMap } from "./Summary.util";
+import type { AuthSrcMap } from "./Summary.type";
 
 export const usePreLoadAuthorImg = () => {
   const { data } = useGlobalData();
-  const [authSrcMap, setAuthSrcMap] = useState({});
+  const [authSrcMap, setAuthSrcMap] = useState<AuthSrcMap>(null);
 
   useEffect(() => {
     getAuthSrcMap(data)
       .then(setAuthSrcMap)
-      .catch(() => setAuthSrcMap({}));
+      .catch(() => setAuthSrcMap(null));
   }, [data]);
 
   return authSrcMap;

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -46,8 +46,8 @@ const Summary = () => {
             >
               <div className="toggle-contents-container">
                 <div className="name-box">
-                  {cluster.summary.authorNames.map(
-                    (authorArray: Array<string>) => {
+                  {authSrcMap &&
+                    cluster.summary.authorNames.map((authorArray: string[]) => {
                       return authorArray.map((authorName: string) => (
                         <Author
                           key={authorName}
@@ -55,8 +55,7 @@ const Summary = () => {
                           src={authSrcMap[authorName]}
                         />
                       ));
-                    }
-                  )}
+                    })}
                 </div>
                 <Content
                   content={cluster.summary.content}

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.type.ts
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.type.ts
@@ -29,6 +29,4 @@ export type SrcInfo = {
   value: string;
 };
 
-export type AuthSrcMap = {
-  [key: string]: string;
-} | null;
+export type AuthSrcMap = Record<string, string>;

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.type.ts
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.type.ts
@@ -28,3 +28,7 @@ export type SrcInfo = {
   key: string;
   value: string;
 };
+
+export type AuthSrcMap = {
+  [key: string]: string;
+} | null;

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.util.ts
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.util.ts
@@ -8,7 +8,7 @@ import type {
 } from "types";
 
 import { GITHUB_URL, GRAVATA_URL } from "./Summary.const";
-import type { Cluster, SrcInfo } from "./Summary.type";
+import type { AuthSrcMap, Cluster, SrcInfo } from "./Summary.type";
 
 export function getInitData(data: GlobalProps["data"]) {
   const clusters: Cluster[] = [];
@@ -105,12 +105,12 @@ function getAuthorProfileImgSrc(authorName: string) {
 }
 
 export async function getAuthSrcMap(data: ClusterNode[]) {
-  const authSrcMap = {};
   const authorNames = getAuthorNames(data);
   const promiseAuthSrc = authorNames.map(getAuthorProfileImgSrc);
   const authSrcs = await Promise.all(promiseAuthSrc);
+  const authSrcMap: AuthSrcMap = {};
   authSrcs.forEach((srcInfo) => {
-    const { key, value } = srcInfo as SrcInfo;
+    const { key, value } = srcInfo;
     authSrcMap[key] = value;
   });
   return authSrcMap;

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.util.ts
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.util.ts
@@ -81,13 +81,13 @@ function getAuthorNames(data: ClusterNode[]) {
   return Array.from(setAuthorNames);
 }
 
-function getAuthorProfileImgSrc(authorName: string) {
+function getAuthorProfileImgSrc(authorName: string): Promise<SrcInfo> {
   return new Promise((resolve) => {
     const img = new Image();
 
     img.onload = () => {
       const { src } = img;
-      const srcInfo: SrcInfo = {
+      const srcInfo = {
         key: authorName,
         value: src,
       };
@@ -95,12 +95,10 @@ function getAuthorProfileImgSrc(authorName: string) {
     };
 
     img.onerror = () => {
-      const fallback = `${GRAVATA_URL}/${md5(authorName)}}?d=identicon&f=y`;
-      img.src = fallback;
+      img.src = `${GRAVATA_URL}/${md5(authorName)}}?d=identicon&f=y`;
     };
 
-    const src = `${GITHUB_URL}/${authorName}.png?size=30`;
-    img.src = src;
+    img.src = `${GITHUB_URL}/${authorName}.png?size=30`;
   });
 }
 

--- a/packages/view/tsconfig.json
+++ b/packages/view/tsconfig.json
@@ -106,7 +106,7 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */,
-    "suppressImplicitAnyIndexErrors": true
+    // "suppressImplicitAnyIndexErrors": true
   },
   "include": ["**/*"],
   "exclude": ["./node_modules", "./build", "./dist"]

--- a/packages/view/tsconfig.json
+++ b/packages/view/tsconfig.json
@@ -106,7 +106,6 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */,
-    // "suppressImplicitAnyIndexErrors": true
   },
   "include": ["**/*"],
   "exclude": ["./node_modules", "./build", "./dist"]


### PR DESCRIPTION
## Related issue
별도의 이슈가 존재하지 않아서 본 PR에 작성합니다.

view와 vscode 패키지의 tsconfig에 존재하는 "suppressImplicitAnyIndexErrors"규칙은 다음과 같은 에러를 발생하고 있습니다.
<img width="682" alt="image" src="https://user-images.githubusercontent.com/81841082/230094860-9019f979-08a2-4365-a7b8-7a1128819b02.png">

에러에서는 "ignoreDeprecations" 처리를 해주면 된다고 하지만 별도의 상태 추적이 필요할 것 같기도하고, [typescript 공식문서](https://www.typescriptlang.org/tsconfig#suppressImplicitAnyIndexErrors)에서도 Using suppressImplicitAnyIndexErrors is quite a drastic approach. It is recommended to use a @ts-ignore comment instead 와 같이 언급하고 있기 때문에 해당 룰은 comment 처리했습니다.

## Result
- 여러 문제(auth와 author등의 변수명 통일 부족)들이 보이긴 하는데, 우선은 타입 에러 해결에 초점을 맞추어서 작업했습니다.

## Work list

## Discussion
1. 이슈를 먼저 작성해야 했나? 싶네요
2. 맨 마지막 commit 작업 내용이 다음과 같은데요.
<img width="570" alt="image" src="https://user-images.githubusercontent.com/81841082/230126362-e7a228dc-6a4a-49d8-b6c1-08df9513bf1a.png">
  테스트를 작성해본 경험이 전무한 상태에서, 해결할 방법이 마땅히 떠오르지 않아서 타입 단언썼습니다. 혹시 다른 해결 방법이 있을까요?