### PR TITLE
fix(vscode, view): fix fetchAnalyzedData command

### DIFF
--- a/packages/view/src/ide/FakeIDEAdapter.ts
+++ b/packages/view/src/ide/FakeIDEAdapter.ts
@@ -14,7 +14,7 @@ export default class FakeIDEAdapter implements IDEPort {
   ) {
     const onReceiveMessage = (e: EngineMessageEvent): void => {
       const response = e.data;
-      if (response.commandName === "fetchAnalyzedData") {
+      if (response.command === "fetchAnalyzedData") {
         const fetchedData = response.payload as unknown as ClusterNode[];
         fetchAnalyzedData(fetchedData);
       }
@@ -25,15 +25,15 @@ export default class FakeIDEAdapter implements IDEPort {
 
   public sendFetchAnalyzedDataCommand() {
     const command: EngineCommand = {
-      commandName: "fetchAnalyzedData",
+      command: "fetchAnalyzedData",
     };
     this.executeCommand(command);
   }
 
   private executeCommand(command: EngineCommand) {
-    if (command.commandName === "fetchAnalyzedData") {
+    if (command.command === "fetchAnalyzedData") {
       const message: EngineMessage = {
-        commandName: command.commandName,
+        command: command.command,
         payload: fakeData as unknown as string,
       };
 

--- a/packages/view/src/ide/VSCodeIDEAdapter.ts
+++ b/packages/view/src/ide/VSCodeIDEAdapter.ts
@@ -13,7 +13,7 @@ export default class VSCodeIDEAdapter implements IDEPort {
   ) {
     const onReceiveMessage = (e: EngineMessageEvent): void => {
       const response = e.data;
-      if (response.commandName === "fetchAnalyzedData") {
+      if (response.command === "fetchAnalyzedData") {
         fetchAnalyzedData(response.payload as unknown as ClusterNode[]);
       }
     };
@@ -22,7 +22,7 @@ export default class VSCodeIDEAdapter implements IDEPort {
 
   public sendFetchAnalyzedDataCommand() {
     const command: EngineCommand = {
-      commandName: "fetchAnalyzedData",
+      command: "fetchAnalyzedData",
     };
     this.executeCommand(command);
   }

--- a/packages/view/src/ide/VSCodeIDEAdapter.ts
+++ b/packages/view/src/ide/VSCodeIDEAdapter.ts
@@ -14,7 +14,9 @@ export default class VSCodeIDEAdapter implements IDEPort {
     const onReceiveMessage = (e: EngineMessageEvent): void => {
       const response = e.data;
       if (response.command === "fetchAnalyzedData") {
-        fetchAnalyzedData(response.payload as unknown as ClusterNode[]);
+        fetchAnalyzedData(
+          JSON.parse(response.payload || "") as unknown as ClusterNode[]
+        );
       }
     };
     window.addEventListener("message", onReceiveMessage);

--- a/packages/view/src/types/EngineCommand.ts
+++ b/packages/view/src/types/EngineCommand.ts
@@ -1,5 +1,5 @@
 export type EngineCommand = {
-  commandName: EngineCommandNames;
+  command: EngineCommandNames;
   message?: string;
 };
 

--- a/packages/view/src/types/EngineMessage.ts
+++ b/packages/view/src/types/EngineMessage.ts
@@ -1,7 +1,7 @@
 import type { EngineCommandNames } from "./EngineCommand";
 
 export type EngineMessage = {
-  commandName: EngineMessageCommandNames;
+  command: EngineMessageCommandNames;
   payload?: string;
 };
 

--- a/packages/vscode/src/webview-loader.ts
+++ b/packages/vscode/src/webview-loader.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import * as path from "path";
+
 export default class WebviewLoader implements vscode.Disposable {
     private readonly _panel: vscode.WebviewPanel | undefined;
     private fsPath: string;
@@ -22,8 +23,9 @@ export default class WebviewLoader implements vscode.Disposable {
         this._panel.webview.onDidReceiveMessage(async (message: { command: string; payload: unknown }) => {
             switch (message.command) {
                 case "refresh":
+                case "fetchAnalyzedData":
                     const data = await parseCommit();
-                    const resMessage = { ...message, payload: data };
+                    const resMessage = {...message, payload: data};
                     await this.respondToMessage(resMessage);
                     break;
             }


### PR DESCRIPTION
## Result

### as-is

extension 실행 시 `NO COMMIT EXISTS YET` 표시됨

### to-be

extension 정상 실행

## Work list

- EngineMessage.commandName 을 command로 rename, vscode와 같은 네이밍 사용하도록 함
- VSCodeIDEAdapter에 vscode로부터 받아온 데이터를 파싱하는 부분 추가

## Discussion

웹뷰에서 데이터를 받아오기 전까지 여전히 NO COMMIT EXISTS YET 텍스트가 표시됩니다.
데이터를 받아오는 동안 보여줄 로딩 뷰 추가가 필요합니다. #332 
