### PR TITLE
fix(vscode): do not send initialData to view

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,13 +1,13 @@
-import { AnalysisEngine } from "@githru-vscode-ext/analysis-engine";
+import {AnalysisEngine} from "@githru-vscode-ext/analysis-engine";
 import * as vscode from "vscode";
-import { COMMAND_GET_ACCESS_TOKEN, COMMAND_LAUNCH } from "./commands";
-import { findGit, getBaseBranchName, getBranchNames, getGitConfig, getGitLog, getRepo } from "./utils/git.util";
-import { mapClusterNodesFrom } from "./utils/csm.mapper";
+import {COMMAND_GET_ACCESS_TOKEN, COMMAND_LAUNCH} from "./commands";
+import {findGit, getBaseBranchName, getBranchNames, getGitConfig, getGitLog, getRepo} from "./utils/git.util";
+import {mapClusterNodesFrom} from "./utils/csm.mapper";
 import WebviewLoader from "./webview-loader";
 
 let myStatusBarItem: vscode.StatusBarItem;
 
-const getGithubToken = () : string | undefined => {
+const getGithubToken = (): string | undefined => {
     const configuration = vscode.workspace.getConfiguration();
     return configuration.get("githru.github.token");
 }
@@ -31,7 +31,7 @@ export function activate(context: vscode.ExtensionContext) {
         const fetchClusterNodes = async () => {
             const gitLog = await getGitLog(gitPath, currentWorkspacePath);
             const gitConfig = await getGitConfig(gitPath, currentWorkspacePath, "origin");
-            const { owner, repo } = getRepo(gitConfig);
+            const {owner, repo} = getRepo(gitConfig);
             const branchNames = await getBranchNames(gitPath, currentWorkspacePath);
             const baseBranchName = getBaseBranchName(branchNames);
             const engine = new AnalysisEngine({
@@ -47,8 +47,7 @@ export function activate(context: vscode.ExtensionContext) {
             const data = JSON.stringify(clusterNodes);
             return data;
         };
-        const initialData = await fetchClusterNodes();
-        const webLoader = new WebviewLoader(extensionUri, extensionPath, initialData, fetchClusterNodes);
+        const webLoader = new WebviewLoader(extensionUri, extensionPath, fetchClusterNodes);
 
         subscriptions.push(webLoader);
 
@@ -66,10 +65,10 @@ export function activate(context: vscode.ExtensionContext) {
             value: defaultGithubToken ?? ''
         });
 
-        if (!newGithubToken) 
+        if (!newGithubToken)
             throw new Error("Cannot get users' access token properly");
 
-        config.update('githru.github.token',newGithubToken, vscode.ConfigurationTarget.Global);
+        config.update('githru.github.token', newGithubToken, vscode.ConfigurationTarget.Global);
     });
 
     subscriptions.concat([disposable, getAccessToken]);

--- a/packages/vscode/src/webview-loader.ts
+++ b/packages/vscode/src/webview-loader.ts
@@ -8,7 +8,6 @@ export default class WebviewLoader implements vscode.Disposable {
     constructor(
         private readonly fileUri: vscode.Uri,
         private readonly extensionPath: string,
-        data: string,
         parseCommit: () => Promise<string>
     ) {
         const viewColumn = vscode.ViewColumn.One;
@@ -31,7 +30,7 @@ export default class WebviewLoader implements vscode.Disposable {
             }
         });
 
-        this._panel.webview.html = this.getWebviewContent(this._panel.webview, data);
+        this._panel.webview.html = this.getWebviewContent(this._panel.webview);
     }
 
     dispose() {
@@ -46,7 +45,7 @@ export default class WebviewLoader implements vscode.Disposable {
         });
     }
 
-    private getWebviewContent(webview: vscode.Webview, data: string): string {
+    private getWebviewContent(webview: vscode.Webview): string {
         const reactAppPathOnDisk = vscode.Uri.file(path.join(this.extensionPath, "dist", "webviewApp.js"));
         const reactAppUri = webview.asWebviewUri(reactAppPathOnDisk);
         // const reactAppUri = reactAppPathOnDisk.with({ scheme: "vscode-resource" });
@@ -60,7 +59,6 @@ export default class WebviewLoader implements vscode.Disposable {
                     <title>githru-vscode-ext webview</title>
                     <script>
                         window.isProduction = true;
-                        window.githruData = ${data};
                     </script>
                 </head>
                 <body>


### PR DESCRIPTION
## Related issue
#331 

## Work list

- view 초기화 시 초기 데이터를 보내지 않도록 변경

## Result

이미 view에서는 초기에 넘겨준 initialData를 사용하지 않고 있어서, vscode에서도 웹뷰를 열 때 initialData를 가져오지 않도록 수정했습니다.
githru 실행 시 웹뷰가 열리는 시간이 빨라졌습니다

as-is
![Kapture 2023-05-13 at 16 43 04](https://github.com/githru/githru-vscode-ext/assets/40057032/ab70e016-7f3f-40ce-a697-5567520d6bd7)

to-be
![Kapture 2023-05-13 at 16 43 42](https://github.com/githru/githru-vscode-ext/assets/40057032/f16590da-1a6c-4e0f-909f-9b5c0a9657a8)


## Discussion

웹뷰가 열리는 시간이 빨라진 대신 패널에 데이터가 그려지기 전까지의 시간이 길어졌습니다
데이터를 불러오는 동안 로딩 UI가 필요합니다 - #332