### PR TITLE
feat(view): show entire detail hovering (#322)

### DIFF
--- a/packages/view/src/components/Detail/Detail.scss
+++ b/packages/view/src/components/Detail/Detail.scss
@@ -66,6 +66,7 @@
 
     .commit-detail {
       overflow: hidden;
+      color: $white;
       .message {
         display: -webkit-box;
         -webkit-box-orient: vertical;
@@ -73,6 +74,11 @@
         overflow: hidden;
         color: $white;
         margin-right: 4px;
+        &:hover {
+          display: block;
+          cursor: pointer;
+          overflow: visible;
+        }
       }
     }
     .commit-id {


### PR DESCRIPTION
## Related issue
#322 

## Work list
길어서 생략된 커밋 내용에 hover 시 전체 내용 보여주기

## Result
생략된 문장 hover하면 전체 문장이 나오도록 하였습니다.
![Githru-Chrome-2023-05-13-17-05-00](https://github.com/githru/githru-vscode-ext/assets/74572293/b78fed1b-1fd5-4b27-aa48-43793db1d902)

## Discussion
hover하여 전제 내용을 뜨게 할 때, 아래에 문장을 밀리게 하면서 내용이 나타나도록 하였는데, 옆의 commit log처럼 흰 박스에 따로  뜨는 것이 더 좋은지 의논이 필요할 것 같습니다.