### PR TITLE
fix(vscode): window 환경에서의 spawn ENOENT 이슈 수정

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -12,6 +12,10 @@ const getGithubToken = (): string | undefined => {
     return configuration.get("githru.github.token");
 }
 
+function normalizeFsPath(fsPath: string) {
+	return fsPath.replace(/\\/g, '/');
+}
+
 export function activate(context: vscode.ExtensionContext) {
     const { subscriptions, extensionUri, extensionPath } = context;
 
@@ -19,11 +23,16 @@ export function activate(context: vscode.ExtensionContext) {
 
     const disposable = vscode.commands.registerCommand(COMMAND_LAUNCH, async () => {
         const gitPath = (await findGit()).path;
-        const currentWorkspacePath = vscode.workspace.workspaceFolders?.[0].uri.path;
 
-        if (currentWorkspacePath === undefined) {
+        const currentWorkspaceUri = vscode.workspace.workspaceFolders?.[0].uri;
+        if (currentWorkspaceUri === undefined) {
             throw new Error("Cannot find current workspace path");
         }
+
+
+        const currentWorkspacePath = normalizeFsPath(currentWorkspaceUri.fsPath);
+        console.debug(vscode.workspace.workspaceFolders);
+        console.debug(currentWorkspacePath);
 
         const githubToken: string | undefined = await getGithubToken();
         console.log("GitHubToken: ", githubToken);


### PR DESCRIPTION
## Related issue

## Result
- window 환경에서 child_process.spawn 가 경로를 못찾는 문제 발생 (ENOENT)
- workspaceFolders.uri.path 가 window 에서의 `/c:/...` 형태의 경로를 반환함
  - spawn에서 사용x
- workspaceFolders.uri.fsPath 는 window 에서의 `\\` 가 포함되어 있는 경로를 반환함
  - `\\` 를 `/` 로 변경해주는 처리 추가
  - spawn에서 사용o


## Work list

vscode.workspace 에서 아래와 같은 방식으로 현재 경로정보를 제공함
```
console.debug(vscode.workspace.workspaceFolders)
[
  {
    uri: v {
      scheme: 'file',
      authority: '',
      path: '/c:/Users/test/workspace/githru-vscode-ext/packages/view',
      query: '',
      fragment: '',
      _formatted: 'file:///c%3A/Users/test/workspace/githru-vscode-ext/packages/view',
      _fsPath: 'c:\\Users\\test\\workspace\\githru-vscode-ext\\packages\\view'
    },
    name: 'view',
    index: 0
  }
]
```

`path: '/c:/Users/test/workspace/githru-vscode-ext/packages/view'`
=> spawn에서 해당 경로를 못찾는 이슈 발생 (ENOENT)

`_fsPath: 'c:\\Users\\test\\workspace\\githru-vscode-ext\\packages\\view'`
=> 상동

`c:/Users/test/workspace/githru-vscode-ext/packages/view`
=> spawn 에서 처리가능한 경로형식으로 변경 (unix like 환경에서는 해당사항 없음)


## Discussion
