### PR TITLE
feat(view): 선택된 사용자에 대한 클러스터만 보이도록 필터링

### DIFF
--- a/packages/view/src/components/TemporalFilter/TemporalFilter.scss
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.scss
@@ -102,3 +102,12 @@
     color: black;
   }
 }
+
+.selected-cluster {
+  position: relative;
+  top: 30px;
+  display: flex;
+  width: 100%;
+  padding: 4px 6px;
+  box-sizing: border-box;
+}

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.scss
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.scss
@@ -107,6 +107,7 @@
   position: relative;
   top: 30px;
   display: flex;
+  flex-wrap: wrap;
   width: 100%;
   padding: 4px 6px;
   box-sizing: border-box;

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
@@ -11,6 +11,7 @@ import { throttle } from "utils";
 import type IDEPort from "ide/IDEPort";
 import { getInitData } from "components/VerticalClusterList/Summary/Summary.util";
 import { usePreLoadAuthorImg } from "components/VerticalClusterList/Summary/Summary.hook";
+import { Author } from "components/VerticalClusterList/Summary/Author";
 
 import {
   filterDataByDate,
@@ -24,7 +25,6 @@ import type { LineChartDatum } from "./LineChart";
 import { useWindowResize } from "./TemporalFilter.hook";
 import type { BrushXSelection } from "./LineChartBrush";
 import { drawBrush } from "./LineChartBrush";
-import { Author } from "components/VerticalClusterList/Summary/Author";
 import {
   BRUSH_MARGIN,
   TEMPORAL_FILTER_LINE_CHART_STYLES,

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
@@ -9,6 +9,8 @@ import BounceLoader from "react-spinners/BounceLoader";
 import { useGlobalData } from "hooks";
 import { throttle } from "utils";
 import type IDEPort from "ide/IDEPort";
+import { getInitData } from "components/VerticalClusterList/Summary/Summary.util";
+import { usePreLoadAuthorImg } from "components/VerticalClusterList/Summary/Summary.hook";
 
 import {
   filterDataByDate,
@@ -22,6 +24,7 @@ import type { LineChartDatum } from "./LineChart";
 import { useWindowResize } from "./TemporalFilter.hook";
 import type { BrushXSelection } from "./LineChartBrush";
 import { drawBrush } from "./LineChartBrush";
+import { Author } from "components/VerticalClusterList/Summary/Author";
 import {
   BRUSH_MARGIN,
   TEMPORAL_FILTER_LINE_CHART_STYLES,
@@ -31,6 +34,7 @@ const TemporalFilter = () => {
   const {
     data,
     filteredData,
+    selectedData,
     setFilteredData,
     filteredRange,
     setFilteredRange,
@@ -38,6 +42,8 @@ const TemporalFilter = () => {
     loading,
     setLoading,
   } = useGlobalData();
+  const authSrcMap = usePreLoadAuthorImg();
+  const selectedClusters = getInitData(selectedData);
 
   const loaderStyle: CSSProperties = {
     position: "fixed",
@@ -99,8 +105,6 @@ const TemporalFilter = () => {
     let dateRange = filteredRange;
     if (lineChartDataList[0].length === 0 && filteredRange === undefined)
       dateRange = getMinMaxDate(sortedData);
-
-    console.log("dateRange ", filteredRange, dateRange);
 
     const axisHeight = 20;
     const chartHeight =
@@ -190,6 +194,23 @@ const TemporalFilter = () => {
       </div>
       <div className="line-charts" ref={wrapperRef}>
         <svg className="line-charts-svg" ref={ref} />
+      </div>
+
+      <div className="selected-cluster">
+        {authSrcMap &&
+          selectedClusters.map((selectedCluster) => {
+            return selectedCluster.summary.authorNames.map(
+              (authorArray: string[]) => {
+                return authorArray.map((authorName: string) => (
+                  <Author
+                    key={authorName}
+                    name={authorName}
+                    src={authSrcMap[authorName]}
+                  />
+                ));
+              }
+            );
+          })}
       </div>
     </article>
   );

--- a/packages/view/src/components/VerticalClusterList/Summary/Author/Author.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Author/Author.scss
@@ -1,0 +1,75 @@
+@import "styles/_pallete";
+@mixin animation {
+  transition: bottom 0.3s ease-in-out, opacity 0.3s ease-in-out;
+}
+@mixin shadow {
+  box-shadow: 0px 0px 3px 1px rgba(100, 100, 100, 0.4);
+}
+@mixin border($border--radius) {
+  border-radius: $border--radius;
+}
+
+@mixin animate($animation, $duration, $method, $times) {
+  -webkit-animation: $animation $duration $method $times;
+  animation: $animation $duration $method $times;
+}
+
+@mixin keyframes($name) {
+  @-webkit-keyframes #{$name} {
+    @content;
+  }
+  @keyframes #{$name} {
+    @content;
+  }
+}
+
+.author {
+  border-radius: 50px;
+  background-color: $white;
+  width: 30px;
+  height: 30px;
+  margin: 0 -5px;
+
+  img {
+    border-radius: 50px;
+  }
+
+  &:hover {
+    @include animation();
+    z-index: 9999;
+  }
+}
+
+[data-tooltip-text] {
+  &:hover {
+    position: relative;
+  }
+
+  &::after {
+    @include animation();
+    @include shadow();
+    @include border(2px);
+
+    content: attr(data-tooltip-text);
+
+    position: absolute;
+    left: 30px;
+    top: -20px;
+    color: $black;
+    font-size: 10px;
+    line-height: 1.5;
+    padding: 5px 12px;
+    min-width: -webkit-max-content;
+    min-width: -moz-max-content;
+    min-width: max-content;
+    word-wrap: break-word;
+    opacity: 0;
+    font-weight: bold;
+    z-index: 9999;
+  }
+
+  &:hover::after {
+    background-color: $white;
+    opacity: 1;
+  }
+}

--- a/packages/view/src/components/VerticalClusterList/Summary/Author/Author.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Author/Author.tsx
@@ -1,8 +1,9 @@
 import type { AuthorProps } from "../Summary.type";
+import "./Author.scss";
 
 const Author = ({ name, src }: AuthorProps) => {
   return (
-    <div className="name" data-tooltip-text={name}>
+    <div className="author" data-tooltip-text={name}>
       <img src={src} alt="" width="30" />
     </div>
   );

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -1,33 +1,5 @@
 @import "styles/_pallete";
 
-@mixin animation {
-  -webkit-transition: bottom 0.3s ease-in-out, opacity 0.3s ease-in-out;
-  -moz-transition: bottom 0.3s ease-in-out, opacity 0.3s ease-in-out;
-  transition: bottom 0.3s ease-in-out, opacity 0.3s ease-in-out;
-}
-
-@mixin shadow {
-  -webkit-box-shadow: 0px 0px 3px 1px rgba(100, 100, 100, 0.4);
-  -moz-box-shadow: 0px 0px 3px 1px rgba(100, 100, 100, 0.4);
-  box-shadow: 0px 0px 3px 1px rgba(100, 100, 100, 0.4);
-}
-
-@mixin border($border--radius) {
-  -webkit-border-radius: $border--radius;
-  -moz-border-radius: $border--radius;
-  border-radius: $border--radius;
-}
-
-@mixin animate($animation, $duration, $method, $times) {
-  animation: $animation $duration $method $times;
-}
-
-@mixin keyframes($name) {
-  @keyframes #{$name} {
-    @content;
-  }
-}
-
 .cluster-summary__container {
   display: flex;
   flex-direction: column;
@@ -81,55 +53,6 @@
     .name-box {
       display: flex;
       justify-content: center;
-    }
-
-    .name {
-      border-radius: 50px;
-      background-color: $white;
-      width: 30px;
-      height: 30px;
-      margin: 0 -5px;
-
-      img {
-        border-radius: 50px;
-      }
-
-      &:hover {
-        @include animation();
-        z-index: 9999;
-      }
-    }
-
-    [data-tooltip-text] {
-      &:hover {
-        position: relative;
-      }
-
-      &::after {
-        @include animation();
-        @include shadow();
-        @include border(2px);
-
-        content: attr(data-tooltip-text);
-
-        position: absolute;
-        left: 30px;
-        top: -20px;
-        color: $black;
-        font-size: 10px;
-        line-height: 1.5;
-        padding: 5px 12px;
-        min-width: max-content;
-        word-wrap: break-word;
-        opacity: 0;
-        font-weight: bold;
-        z-index: 9999;
-      }
-
-      &:hover::after {
-        background-color: $white;
-        opacity: 1;
-      }
     }
 
     .cluster-summary__contents {


### PR DESCRIPTION
## Related issue

resolve #323 

## Result

<img width="591" alt="스크린샷 2023-07-31 오후 1 54 05" src="https://github.com/githru/githru-vscode-ext/assets/79692272/bbab9ac8-fdb8-473c-8ac7-a55258de8a1c">

## Work list

TemperalFilter 컴포넌트에 선택된 사용자에 대한 클러스터만 보이도록 필터링하도록 하였고 Author style로직을 Summary에서 분리했습니다.

## Discussion
