### PR TITLE
feat[view]: Summary.scss (className:detail__container) padding 수정

### DIFF
--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -166,5 +166,5 @@
   overflow: overlay;
   max-height: 280px;
   height: 220px;
-  padding: 5px 30px 20px;
+  padding: 0px 30px;
 }


### PR DESCRIPTION
## Related issue
resolve #358 
## Result
![image](https://github.com/githru/githru-vscode-ext/assets/79373803/31d5b91d-c04d-4e3b-8a66-c4149c28c590)

## Work list
Summary를 펼칠 때 마다 Node사이가 벌어지는 이유는 Node에 위 아래로 불필요한 padding값이 있기 때문이라고 판단하였습니다. 

## Discussion
