### PR TITLE
feat(view): commit-item 요소를 한줄로 출력

### DIFF
--- a/packages/view/src/components/Detail/Detail.scss
+++ b/packages/view/src/components/Detail/Detail.scss
@@ -67,6 +67,10 @@
     .commit-detail {
       overflow: hidden;
       color: $white;
+      display: flex;
+      justify-content: space-between;
+      width: 100%;
+
       .message {
         display: -webkit-box;
         -webkit-box-orient: vertical;
@@ -74,14 +78,21 @@
         overflow: hidden;
         color: $white;
         margin-right: 4px;
+
         &:hover {
           display: block;
           cursor: pointer;
           overflow: visible;
         }
       }
+
+      .author-date {
+        display: block;
+        white-space: nowrap;
+      }
     }
     .commit-id {
+      width: 90px;
       padding-left: 50px;
       position: relative;
       span:hover {


### PR DESCRIPTION
## Related issue
resolve #291 
## Result
<img width="1728" alt="스크린샷 2023-08-02 오후 7 32 52" src="https://github.com/githru/githru-vscode-ext/assets/84486674/e52ef203-4af7-464c-a89e-1de731de8ede">

## Work list
.commit-item의 display를 flex로, justify-content를 space-between으로 설정하여 .author-date가 우측에 정렬되도록 설정.
.author-date가 한줄로 출력되도록 설정
.commit-id의 폭을 고정된 값으로 설정하여 .author-date가 보기 좋게 정렬 되도록 설정
## Discussion
