### PR TITLE
feat(view): constant, util, hook 공용화

### DIFF
--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -2,7 +2,7 @@ import type { ChangeEvent, MouseEvent } from "react";
 import { useRef, useEffect, useState } from "react";
 import * as d3 from "d3";
 
-import type { ClusterNode, SrcInfo } from "types";
+import type { ClusterNode, AuthorInfo } from "types";
 import { useGlobalData } from "hooks";
 import { getAuthorProfileImgSrc } from "utils/author";
 
@@ -183,7 +183,7 @@ const AuthorBarChart = () => {
       const bar = d3.select(barElement).datum(data[i]);
       const profileImgSrc: string = await getAuthorProfileImgSrc(
         data[i].name
-      ).then((res: SrcInfo) => res.value);
+      ).then((res: AuthorInfo) => res.src);
       bar
         .append("image")
         .attr("class", "profile-image")

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -2,22 +2,18 @@ import type { ChangeEvent, MouseEvent } from "react";
 import { useRef, useEffect, useState } from "react";
 import * as d3 from "d3";
 
-import type { ClusterNode } from "types";
+import type { ClusterNode, SrcInfo } from "types";
 import { useGlobalData } from "hooks";
+import { getAuthorProfileImgSrc } from "utils/author";
 
 import { useGetSelectedData } from "../Statistics.hook";
 
-import type {
-  AuthorDataType,
-  MetricType,
-  SrcInfo,
-} from "./AuthorBarChart.type";
+import type { AuthorDataType, MetricType } from "./AuthorBarChart.type";
 import {
   convertNumberFormat,
   getDataByAuthor,
   sortDataByAuthor,
   sortDataByName,
-  getAuthorProfileImgSrc,
 } from "./AuthorBarChart.util";
 import { DIMENSIONS, METRIC_TYPE } from "./AuthorBarChart.const";
 

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.type.ts
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.type.ts
@@ -9,11 +9,6 @@ export type AuthorDataType = {
 
 export type MetricType = (typeof METRIC_TYPE)[number];
 
-export type SrcInfo = {
-  key: string;
-  value: string;
-};
-
 export type AuthorDataObj = {
   [key: string]: {
     name: string;

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
@@ -1,15 +1,8 @@
 import * as d3 from "d3";
-import md5 from "md5";
 
 import type { ClusterNode, CommitNode } from "types";
 
-import { GITHUB_URL, GRAVATA_URL } from "../../../constants/constants";
-
-import type {
-  AuthorDataObj,
-  AuthorDataType,
-  SrcInfo,
-} from "./AuthorBarChart.type";
+import type { AuthorDataObj, AuthorDataType } from "./AuthorBarChart.type";
 
 export const getDataByAuthor = (data: ClusterNode[]): AuthorDataType[] => {
   if (!data.length) return [];
@@ -76,30 +69,3 @@ export const sortDataByAuthor = (
     ];
   }, []);
 };
-
-export function getAuthorProfileImgSrc(authorName: string): Promise<SrcInfo> {
-  return new Promise((resolve) => {
-    const img = new Image();
-
-    img.onload = () => {
-      const { src } = img;
-      const srcInfo: SrcInfo = {
-        key: authorName,
-        value: src,
-      };
-      resolve(srcInfo);
-    };
-
-    img.onerror = () => {
-      const fallback = `${GRAVATA_URL}/${md5(authorName)}}?d=identicon&f=y`;
-
-      resolve({
-        key: authorName,
-        value: fallback,
-      });
-    };
-
-    const src = `${GITHUB_URL}/${authorName}.png?size=30`;
-    img.src = src;
-  });
-}

--- a/packages/view/src/components/VerticalClusterList/Summary/Author/Author.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Author/Author.tsx
@@ -1,6 +1,6 @@
-import type { AuthorProps } from "../Summary.type";
+import type { AuthorInfo } from "types";
 
-const Author = ({ name, src }: AuthorProps) => {
+const Author = ({ name, src }: AuthorInfo) => {
   return (
     <div className="name" data-tooltip-text={name}>
       <img src={src} alt="" width="30" />

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.type.ts
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.type.ts
@@ -1,7 +1,4 @@
-export type AuthorProps = {
-  name: string;
-  src: string;
-};
+import type { AuthorInfo } from "types";
 
 export type Content = {
   message: string;
@@ -15,7 +12,7 @@ export type ContentProps = {
 };
 
 export type Summary = {
-  authorNames: Array<Array<AuthorProps["name"]>>;
+  authorNames: Array<Array<AuthorInfo["name"]>>;
   content: Content;
 };
 

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.type.ts
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.type.ts
@@ -24,9 +24,4 @@ export type Cluster = {
   summary: Summary;
 };
 
-export type SrcInfo = {
-  key: string;
-  value: string;
-};
-
 export type AuthSrcMap = Record<string, string>;

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.util.ts
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.util.ts
@@ -1,14 +1,12 @@
-import md5 from "md5";
-
 import type {
   GlobalProps,
   CommitNode,
   ClusterNode,
   SelectedDataProps,
 } from "types";
+import { getAuthorProfileImgSrc } from "utils/author";
 
-import { GITHUB_URL, GRAVATA_URL } from "./Summary.const";
-import type { AuthSrcMap, Cluster, SrcInfo } from "./Summary.type";
+import type { AuthSrcMap, Cluster } from "./Summary.type";
 
 export function getInitData(data: GlobalProps["data"]) {
   const clusters: Cluster[] = [];
@@ -79,27 +77,6 @@ function getAuthorNames(data: ClusterNode[]) {
     .flat();
   const setAuthorNames = new Set(authorNames);
   return Array.from(setAuthorNames);
-}
-
-function getAuthorProfileImgSrc(authorName: string): Promise<SrcInfo> {
-  return new Promise((resolve) => {
-    const img = new Image();
-
-    img.onload = () => {
-      const { src } = img;
-      const srcInfo: SrcInfo = {
-        key: authorName,
-        value: src,
-      };
-      resolve(srcInfo);
-    };
-
-    img.onerror = () => {
-      img.src = `${GRAVATA_URL}/${md5(authorName)}}?d=identicon&f=y`;
-    };
-
-    img.src = `${GITHUB_URL}/${authorName}.png?size=30`;
-  });
 }
 
 export async function getAuthSrcMap(data: ClusterNode[]) {

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.util.ts
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.util.ts
@@ -87,7 +87,7 @@ function getAuthorProfileImgSrc(authorName: string): Promise<SrcInfo> {
 
     img.onload = () => {
       const { src } = img;
-      const srcInfo = {
+      const srcInfo: SrcInfo = {
         key: authorName,
         value: src,
       };

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.util.ts
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.util.ts
@@ -84,9 +84,9 @@ export async function getAuthSrcMap(data: ClusterNode[]) {
   const promiseAuthSrc = authorNames.map(getAuthorProfileImgSrc);
   const authSrcs = await Promise.all(promiseAuthSrc);
   const authSrcMap: AuthSrcMap = {};
-  authSrcs.forEach((srcInfo) => {
-    const { key, value } = srcInfo;
-    authSrcMap[key] = value;
+  authSrcs.forEach((authorInfo) => {
+    const { name, src } = authorInfo;
+    authSrcMap[name] = src;
   });
   return authSrcMap;
 }

--- a/packages/view/src/types/Author.ts
+++ b/packages/view/src/types/Author.ts
@@ -1,4 +1,4 @@
-export type SrcInfo = {
-  key: string;
-  value: string;
+export type AuthorInfo = {
+  name: string;
+  src: string;
 };

--- a/packages/view/src/types/Author.ts
+++ b/packages/view/src/types/Author.ts
@@ -1,0 +1,4 @@
+export type SrcInfo = {
+  key: string;
+  value: string;
+};

--- a/packages/view/src/types/index.ts
+++ b/packages/view/src/types/index.ts
@@ -2,3 +2,4 @@ export * from "./global";
 export * from "./NodeTypes.temp";
 export * from "./EngineCommand";
 export * from "./EngineMessage";
+export * from "./Author";

--- a/packages/view/src/utils/author.ts
+++ b/packages/view/src/utils/author.ts
@@ -1,0 +1,25 @@
+import md5 from "md5";
+
+import { GITHUB_URL, GRAVATA_URL } from "constants/constants";
+import type { SrcInfo } from "types";
+
+export function getAuthorProfileImgSrc(authorName: string): Promise<SrcInfo> {
+  return new Promise((resolve) => {
+    const img = new Image();
+
+    img.onload = () => {
+      const { src } = img;
+      const srcInfo: SrcInfo = {
+        key: authorName,
+        value: src,
+      };
+      resolve(srcInfo);
+    };
+
+    img.onerror = () => {
+      img.src = `${GRAVATA_URL}/${md5(authorName)}}?d=identicon&f=y`;
+    };
+
+    img.src = `${GITHUB_URL}/${authorName}.png?size=30`;
+  });
+}

--- a/packages/view/src/utils/author.ts
+++ b/packages/view/src/utils/author.ts
@@ -1,17 +1,20 @@
 import md5 from "md5";
 
-import { GITHUB_URL, GRAVATA_URL } from "constants/constants";
-import type { SrcInfo } from "types";
+import type { AuthorInfo } from "types";
 
-export function getAuthorProfileImgSrc(authorName: string): Promise<SrcInfo> {
+import { GITHUB_URL, GRAVATA_URL } from "../constants/constants";
+
+export function getAuthorProfileImgSrc(
+  authorName: string
+): Promise<AuthorInfo> {
   return new Promise((resolve) => {
     const img = new Image();
 
     img.onload = () => {
       const { src } = img;
-      const srcInfo: SrcInfo = {
-        key: authorName,
-        value: src,
+      const srcInfo: AuthorInfo = {
+        name: authorName,
+        src,
       };
       resolve(srcInfo);
     };


### PR DESCRIPTION
## Related issue
- https://github.com/githru/githru-vscode-ext/issues/307

## Result

<img width="1087" alt="pr" src="https://github.com/githru/githru-vscode-ext/assets/63959171/5639b0db-f36f-411e-a6bd-49a4ca37c979">

## Work list

- `Summary.tsx` 와 `VerticalClusterList.util.tsx` 에서 공통으로 사용되고 있던 profile image 가져오는 `getAuthorProfileImgSrc` 함수 분리
- 기존의 `AuthorProps` 와 `SrcInfo` 두 type이 같은 역할을 한다고 판단하여 type 중복 제거

## Discussion
- 폴더별로 다 나눠져 있어서 아마 중복된 게 더 있을 것 같습니다 !