### PR TITLE
feat(view): 선택된 사용자 로직 컴포넌트로 분리

### DIFF
--- a/packages/view/src/App.tsx
+++ b/packages/view/src/App.tsx
@@ -4,7 +4,14 @@ import { useRef } from "react";
 import type { CSSProperties } from "react";
 import BounceLoader from "react-spinners/BounceLoader";
 
-import { BranchSelector, Statistics, TemporalFilter, ThemeSelector, VerticalClusterList } from "components";
+import {
+  BranchSelector,
+  Statistics,
+  TemporalFilter,
+  ThemeSelector,
+  VerticalClusterList,
+  FilteredAuthors,
+} from "components";
 import "./App.scss";
 import type IDEPort from "ide/IDEPort";
 import { useGlobalData } from "hooks";
@@ -48,6 +55,7 @@ const App = () => {
       </div>
       <div className="top-container">
         <TemporalFilter />
+        <FilteredAuthors />
       </div>
       <div className="middle-container">
         {filteredData.length !== 0 ? (

--- a/packages/view/src/components/FilteredAuthors/FilteredAuthors.scss
+++ b/packages/view/src/components/FilteredAuthors/FilteredAuthors.scss
@@ -1,0 +1,9 @@
+.selected-container {
+  position: relative;
+  top: 30px;
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+  padding: 4px 6px;
+  box-sizing: border-box;
+}

--- a/packages/view/src/components/FilteredAuthors/FilteredAuthors.tsx
+++ b/packages/view/src/components/FilteredAuthors/FilteredAuthors.tsx
@@ -1,0 +1,31 @@
+import { Author } from "components/VerticalClusterList/Summary/Author";
+import { usePreLoadAuthorImg } from "components/VerticalClusterList/Summary/Summary.hook";
+import { getInitData } from "components/VerticalClusterList/Summary/Summary.util";
+import { useGlobalData } from "hooks";
+
+import "./FilteredAuthors.scss";
+
+const FilteredAuthors = () => {
+  const { selectedData } = useGlobalData();
+  const authSrcMap = usePreLoadAuthorImg();
+  const selectedClusters = getInitData(selectedData);
+
+  return (
+    <div className="selected-container">
+      {authSrcMap &&
+        selectedClusters.map((selectedCluster) => {
+          return selectedCluster.summary.authorNames.map((authorArray: string[]) => {
+            return authorArray.map((authorName: string) => (
+              <Author
+                key={authorName}
+                name={authorName}
+                src={authSrcMap[authorName]}
+              />
+            ));
+          });
+        })}
+    </div>
+  );
+};
+
+export default FilteredAuthors;

--- a/packages/view/src/components/FilteredAuthors/index.ts
+++ b/packages/view/src/components/FilteredAuthors/index.ts
@@ -1,0 +1,1 @@
+export { default as FilteredAuthors } from "./FilteredAuthors";

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.scss
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.scss
@@ -102,13 +102,3 @@
     color: black;
   }
 }
-
-.selected-cluster {
-  position: relative;
-  top: 30px;
-  display: flex;
-  flex-wrap: wrap;
-  width: 100%;
-  padding: 4px 6px;
-  box-sizing: border-box;
-}

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
@@ -9,9 +9,6 @@ import BounceLoader from "react-spinners/BounceLoader";
 import { useGlobalData } from "hooks";
 import { throttle } from "utils";
 import type IDEPort from "ide/IDEPort";
-import { getInitData } from "components/VerticalClusterList/Summary/Summary.util";
-import { usePreLoadAuthorImg } from "components/VerticalClusterList/Summary/Summary.hook";
-import { Author } from "components/VerticalClusterList/Summary/Author";
 
 import { filterDataByDate, getMinMaxDate, lineChartTimeFormatter, sortBasedOnCommitNode } from "./TemporalFilter.util";
 import "./TemporalFilter.scss";
@@ -23,19 +20,8 @@ import { drawBrush } from "./LineChartBrush";
 import { BRUSH_MARGIN, TEMPORAL_FILTER_LINE_CHART_STYLES } from "./LineChart.const";
 
 const TemporalFilter = () => {
-  const {
-    data,
-    filteredData,
-    selectedData,
-    setFilteredData,
-    filteredRange,
-    setFilteredRange,
-    setSelectedData,
-    loading,
-    setLoading,
-  } = useGlobalData();
-  const authSrcMap = usePreLoadAuthorImg();
-  const selectedClusters = getInitData(selectedData);
+  const { data, filteredData, setFilteredData, filteredRange, setFilteredRange, setSelectedData, loading, setLoading } =
+    useGlobalData();
 
   const loaderStyle: CSSProperties = {
     position: "fixed",
@@ -180,21 +166,6 @@ const TemporalFilter = () => {
           className="line-charts-svg"
           ref={ref}
         />
-      </div>
-
-      <div className="selected-cluster">
-        {authSrcMap &&
-          selectedClusters.map((selectedCluster) => {
-            return selectedCluster.summary.authorNames.map((authorArray: string[]) => {
-              return authorArray.map((authorName: string) => (
-                <Author
-                  key={authorName}
-                  name={authorName}
-                  src={authSrcMap[authorName]}
-                />
-              ));
-            });
-          })}
       </div>
     </article>
   );

--- a/packages/view/src/components/index.ts
+++ b/packages/view/src/components/index.ts
@@ -4,3 +4,4 @@ export * from "./TemporalFilter";
 export * from "./ThemeSelector";
 export * from "./VerticalClusterList";
 export * from "./BranchSelector";
+export * from "./FilteredAuthors";


### PR DESCRIPTION
## Related issue

https://github.com/githru/githru-vscode-ext/issues/370

## Result

![스크린샷 2023-08-08 오후 11 43 19](https://github.com/githru/githru-vscode-ext/assets/79692272/396a646b-dd0d-4803-99c0-0c627ed208ef)

## Work list

기존에는 `TemporalFilter` 컴포넌트 내부에 위치해있던 로직을 컴포넌트로 분리했습니다.

## Discussion
