### PR TITLE
feat(view): ClusterGraph.const.ts의 DETAIL_HEIGHT 값 수정

### DIFF
--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.const.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.const.ts
@@ -1,6 +1,6 @@
 export const NODE_GAP = 10;
 export const CLUSTER_HEIGHT = 40;
-export const DETAIL_HEIGHT = 220;
+export const DETAIL_HEIGHT = 245;
 export const GRAPH_WIDTH = 80;
 export const SVG_WIDTH = GRAPH_WIDTH + 4;
 export const SVG_MARGIN = {


### PR DESCRIPTION
## Related issue
resolve #347

## Result
![first_PR](https://github.com/githru/githru-vscode-ext/assets/115632555/088797c0-218d-4f84-a96e-4c992f8491b4)

## Work list
Summary : DETAIL_HEIGHT을  245로 수정

Detail : clusterGraph.hook의 135번째 줄에서 drawClusterGraph가 DETAIL_HEIGHT을 인자로 받고 있는데 이 값이 ClusterGraph.const에서 220으로 지정되어 있었습니다.
그런데 summary의 detail_container에는 height 220px에 추가로 위, 아래 padding 값이 5px, 20px로 지정되어 있어 detail 오픈 시 높이가 어긋나는 현상이 있던 것으로 확인했습니다.

## Discussion
