### PR TITLE
feat/issue#278: add payload to fetchAnalyzedData command for changing base branch and refetching

### DIFF
--- a/packages/view/src/components/BranchSelector/BranchSelector.tsx
+++ b/packages/view/src/components/BranchSelector/BranchSelector.tsx
@@ -1,16 +1,25 @@
+import type { ChangeEventHandler } from "react";
 import "./BranchSelector.scss";
 
-// TODO - UI구현을 위한 mock data입니다.
+// TODO - webview로 sendBranchList command 호출
 const getDataList = () => {
   return ["dev", "feat", "edit"];
 };
 
 const BranchSelector = () => {
   const branchList = getDataList();
+
+  const handleChangeSelect: ChangeEventHandler<HTMLSelectElement> = () => {
+    // TODO - webview로 선택된 branch을 payload에 실어 sendFetchAnalyzedDataCommand 호출
+  };
+
   return (
     <section className="branch-selector">
       <span>Branches:</span>
-      <select className="select-box">
+      <select
+        className="select-box"
+        onChange={handleChangeSelect}
+      >
         {branchList.map((option) => (
           <option
             key={option}

--- a/packages/view/src/ide/FakeIDEAdapter.ts
+++ b/packages/view/src/ide/FakeIDEAdapter.ts
@@ -21,13 +21,21 @@ export default class FakeIDEAdapter implements IDEPort {
     window.addEventListener("message", onReceiveMessage);
   }
 
-  public sendFetchAnalyzedDataMessage() {
+  public sendFetchAnalyzedDataMessage(payload?: string) {
     const message: IDEMessage = {
       command: "fetchAnalyzedData",
+      payload,
     };
     setTimeout(() => {
       this.sendMessageToMe(message);
     }, 3000);
+  }
+
+  public sendGetBranchListMessage() {
+    const message: IDEMessage = {
+      command: "getBranchList",
+    };
+    this.sendMessageToMe(message);
   }
 
   public setPrimaryColor(color: string) {

--- a/packages/view/src/ide/IDEPort.ts
+++ b/packages/view/src/ide/IDEPort.ts
@@ -7,6 +7,7 @@ export type IDEMessage = {
 
 export default interface IDEPort {
   addIDESentEventListener: (apiCallbacks: IDESentEvents) => void;
-  sendFetchAnalyzedDataMessage: () => void;
+  sendFetchAnalyzedDataMessage: (payload?: string) => void;
+  sendGetBranchListMessage: () => void;
   setPrimaryColor: (color: string) => void;
 }

--- a/packages/view/src/ide/VSCodeIDEAdapter.ts
+++ b/packages/view/src/ide/VSCodeIDEAdapter.ts
@@ -23,9 +23,17 @@ export default class VSCodeIDEAdapter implements IDEPort {
     window.addEventListener("message", onReceiveMessage);
   }
 
-  public sendFetchAnalyzedDataMessage() {
+  public sendFetchAnalyzedDataMessage(payload?: string) {
     const message: IDEMessage = {
       command: "fetchAnalyzedData",
+      payload,
+    };
+    this.sendMessageToIDE(message);
+  }
+
+  public sendGetBranchListMessage() {
+    const message: IDEMessage = {
+      command: "getBranchList",
     };
     this.sendMessageToIDE(message);
   }

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -35,15 +35,15 @@ export function activate(context: vscode.ExtensionContext) {
     console.debug(currentWorkspacePath);
 
     const branchNames = await getBranchNames(gitPath, currentWorkspacePath);
+    const initialBaseBranchName = getBaseBranchName(branchNames);
 
     const githubToken: string | undefined = await getGithubToken();
     console.log("GitHubToken: ", githubToken);
 
-    const fetchClusterNodes = async () => {
+    const fetchClusterNodes = async (baseBranchName = initialBaseBranchName) => {
       const gitLog = await getGitLog(gitPath, currentWorkspacePath);
       const gitConfig = await getGitConfig(gitPath, currentWorkspacePath, "origin");
       const { owner, repo } = getRepo(gitConfig);
-      const baseBranchName = getBaseBranchName(branchNames);
       const engine = new AnalysisEngine({
         isDebugMode: true,
         gitLog,

--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -239,7 +239,7 @@ export async function getBranchNames(path: string, repo: string): Promise<string
             name
               .replace("*", "") // delete * prefix
               .replace("remotes/", "") // delete remotes/ prifix
-              .replace(/(origin\/HEAD.*) -> (?:.*)/g, "$1") // origin/HEAD parsing
+              .replace(/(.*) -> (?:.*)/g, "$1") // remote HEAD parsing
               .trim()
           )
           .filter((name) => !!name);

--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -172,9 +172,7 @@ export async function getGitLog(gitPath: string, currentWorkspacePath: string): 
         env: Object.assign({}, process.env),
       })
     ).then((values) => {
-      const status = values[0],
-        stdout = values[1],
-        stderr = values[2];
+      const [status, stdout, stderr] = values;
       if (status.code === 0) {
         resolve(stdout.toString());
       } else {
@@ -198,9 +196,7 @@ export async function getGitConfig(
         env: Object.assign({}, process.env),
       })
     ).then((values) => {
-      const status = values[0],
-        stdout = values[1],
-        stderr = values[2];
+      const [status, stdout, stderr] = values;
       if (status.code === 0) {
         resolve(stdout.toString());
       } else {
@@ -229,19 +225,24 @@ export const getRepo = (gitRemoteConfig: string) => {
 export async function getBranchNames(path: string, repo: string): Promise<string[]> {
   return new Promise((resolve, reject) => {
     resolveSpawnOutput(
-      cp.spawn(path, ["branch"], {
+      cp.spawn(path, ["branch", "-a"], {
         cwd: repo,
         env: Object.assign({}, process.env),
       })
     ).then((values) => {
-      const status = values[0],
-        stdout = values[1],
-        stderr = values[2];
+      const [status, stdout, stderr] = values;
       if (status.code === 0) {
         const branches = stdout
           .toString()
           .split("\n")
-          .map((name) => name.replace("*", "").trim());
+          .map((name) =>
+            name
+              .replace("*", "") // delete * prefix
+              .replace("remotes/", "") // delete remotes/ prifix
+              .replace(/(origin\/HEAD.*) -> (?:.*)/g, "$1") // origin/HEAD parsing
+              .trim()
+          )
+          .filter((name) => !!name);
         resolve(branches);
       } else {
         reject(stderr);


### PR DESCRIPTION
## Related issue
related: #278, #341, #277 

## Work list
#### vscode
- 기존 get branch list 함수에서 빈 문자열까지 함께 반환하는 내용 수정
- 기존 get branch list 함수에서 remote branch까지 가져올 수 있도록 기능 확장
- Webview에서 fetchAnalyzedData command 요청을 받아 baseBranch를 engine 함수에 전달할 수 있도록 함수 수정

#### view
- view에서 선택된 base branch를 payload에 실어 fetchAnalyzedData command로 보낼 수 있도록 IDEAdaptor method 수정
- IDEAdaptor에 sendGetBranchListCommand method 추가

## Result
- main 작업(payload 추가)은 select-box 연동 후 확인 가능
- get branch list command refactor -> remote branch까지 가져올 수 있도록 업데이트. (캡쳐 내용은 개인 test git repo대상으로 진행하였습니다.)
#### git branch -all
<img width="394" alt="image" src="https://github.com/githru/githru-vscode-ext/assets/31684481/80b844f3-c95f-4f35-853d-81a9559de05c">

#### 해당 repo branch parsing해온 내용
<img width="1015" alt="image" src="https://github.com/githru/githru-vscode-ext/assets/31684481/66f7ff9b-5b9f-4feb-bffa-91adbc4e9db7">


## Discussion
- git remote branch 확장에 대한 의견..?