### PR TITLE
feat(vscode): Display Error Message on Startup #329

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -23,45 +23,51 @@ export function activate(context: vscode.ExtensionContext) {
   console.log('Congratulations, your extension "githru" is now active!');
 
   const disposable = vscode.commands.registerCommand(COMMAND_LAUNCH, async () => {
-    const gitPath = (await findGit()).path;
+    try {
+      const gitPath = (await findGit()).path;
 
-    const currentWorkspaceUri = vscode.workspace.workspaceFolders?.[0].uri;
-    if (currentWorkspaceUri === undefined) {
-      throw new Error("Cannot find current workspace path");
+      const currentWorkspaceUri = vscode.workspace.workspaceFolders?.[0].uri;
+      if (!currentWorkspaceUri) {
+        throw new Error("Cannot find current workspace path");
+      }
+
+      const currentWorkspacePath = normalizeFsPath(currentWorkspaceUri.fsPath);
+      console.debug(vscode.workspace.workspaceFolders);
+      console.debug(currentWorkspacePath);
+
+      const branchNames = await getBranchNames(gitPath, currentWorkspacePath);
+      const initialBaseBranchName = getBaseBranchName(branchNames);
+
+      const githubToken: string | undefined = await getGithubToken();
+      if (!githubToken) {
+        throw new Error("Cannot retrieve GitHub token");
+      }
+
+      const fetchClusterNodes = async (baseBranchName = initialBaseBranchName) => {
+        const gitLog = await getGitLog(gitPath, currentWorkspacePath);
+        const gitConfig = await getGitConfig(gitPath, currentWorkspacePath, "origin");
+        const { owner, repo } = getRepo(gitConfig);
+        const engine = new AnalysisEngine({
+          isDebugMode: true,
+          gitLog,
+          owner,
+          repo,
+          auth: githubToken,
+          baseBranchName,
+        });
+        const csmDict = await engine.analyzeGit();
+        const clusterNodes = mapClusterNodesFrom(csmDict);
+        const data = JSON.stringify(clusterNodes);
+        return data;
+      };
+      const fetchBranchList = () => JSON.stringify(branchNames);
+      const webLoader = new WebviewLoader(extensionUri, extensionPath, fetchClusterNodes, fetchBranchList);
+
+      subscriptions.push(webLoader);
+      vscode.window.showInformationMessage("Hello Githru");
+    } catch (error) {
+      vscode.window.showErrorMessage((error as Error).message);
     }
-
-    const currentWorkspacePath = normalizeFsPath(currentWorkspaceUri.fsPath);
-    console.debug(vscode.workspace.workspaceFolders);
-    console.debug(currentWorkspacePath);
-
-    const branchNames = await getBranchNames(gitPath, currentWorkspacePath);
-    const initialBaseBranchName = getBaseBranchName(branchNames);
-
-    const githubToken: string | undefined = await getGithubToken();
-    console.log("GitHubToken: ", githubToken);
-
-    const fetchClusterNodes = async (baseBranchName = initialBaseBranchName) => {
-      const gitLog = await getGitLog(gitPath, currentWorkspacePath);
-      const gitConfig = await getGitConfig(gitPath, currentWorkspacePath, "origin");
-      const { owner, repo } = getRepo(gitConfig);
-      const engine = new AnalysisEngine({
-        isDebugMode: true,
-        gitLog,
-        owner,
-        repo,
-        auth: githubToken,
-        baseBranchName,
-      });
-      const csmDict = await engine.analyzeGit();
-      const clusterNodes = mapClusterNodesFrom(csmDict);
-      const data = JSON.stringify(clusterNodes);
-      return data;
-    };
-    const fetchBranchList = () => JSON.stringify(branchNames);
-    const webLoader = new WebviewLoader(extensionUri, extensionPath, fetchClusterNodes, fetchBranchList);
-
-    subscriptions.push(webLoader);
-    vscode.window.showInformationMessage("Hello Githru");
   });
 
   const getAccessToken = vscode.commands.registerCommand(COMMAND_GET_ACCESS_TOKEN, async () => {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -14,7 +14,7 @@ function normalizeFsPath(fsPath: string) {
 }
 
 export function activate(context: vscode.ExtensionContext) {
-  const { subscriptions, extensionUri, extensionPath } = context;
+  const { subscriptions, extensionUri, extensionPath, secrets } = context;
 
   console.log('Congratulations, your extension "githru" is now active!');
 
@@ -28,13 +28,11 @@ export function activate(context: vscode.ExtensionContext) {
       }
 
       const currentWorkspacePath = normalizeFsPath(currentWorkspaceUri.fsPath);
-      console.debug(vscode.workspace.workspaceFolders);
-      console.debug(currentWorkspacePath);
 
       const branchNames = await getBranchNames(gitPath, currentWorkspacePath);
       const initialBaseBranchName = getBaseBranchName(branchNames);
 
-      const githubToken: string | undefined = await getGithubToken();
+      const githubToken: string | undefined = await getGithubToken(secrets);
       if (!githubToken) {
         throw new Error("Cannot retrieve GitHub token");
       }
@@ -67,7 +65,7 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   const getAccessToken = vscode.commands.registerCommand(COMMAND_GET_ACCESS_TOKEN, async () => {
-    const defaultGithubToken = await getGithubToken();
+    const defaultGithubToken = await getGithubToken(secrets);
 
     const newGithubToken = await vscode.window.showInputBox({
       title: "Type or paste your Github access token value.",
@@ -77,7 +75,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     if (!newGithubToken) throw new Error("Cannot get users' access token properly");
 
-    setGithubToken(newGithubToken);
+    setGithubToken(secrets, newGithubToken);
   });
 
   subscriptions.concat([disposable, getAccessToken]);

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -2,16 +2,12 @@ import { AnalysisEngine } from "@githru-vscode-ext/analysis-engine";
 import * as vscode from "vscode";
 
 import { COMMAND_GET_ACCESS_TOKEN, COMMAND_LAUNCH } from "./commands";
+import { getGithubToken } from "./setting-repository";
 import { mapClusterNodesFrom } from "./utils/csm.mapper";
 import { findGit, getBaseBranchName, getBranchNames, getGitConfig, getGitLog, getRepo } from "./utils/git.util";
 import WebviewLoader from "./webview-loader";
 
 let myStatusBarItem: vscode.StatusBarItem;
-
-const getGithubToken = (): string | undefined => {
-  const configuration = vscode.workspace.getConfiguration();
-  return configuration.get("githru.github.token");
-};
 
 function normalizeFsPath(fsPath: string) {
   return fsPath.replace(/\\/g, "/");

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -2,7 +2,7 @@ import { AnalysisEngine } from "@githru-vscode-ext/analysis-engine";
 import * as vscode from "vscode";
 
 import { COMMAND_GET_ACCESS_TOKEN, COMMAND_LAUNCH } from "./commands";
-import { getGithubToken } from "./setting-repository";
+import { getGithubToken, setGithubToken } from "./setting-repository";
 import { mapClusterNodesFrom } from "./utils/csm.mapper";
 import { findGit, getBaseBranchName, getBranchNames, getGitConfig, getGitLog, getRepo } from "./utils/git.util";
 import WebviewLoader from "./webview-loader";
@@ -67,8 +67,6 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   const getAccessToken = vscode.commands.registerCommand(COMMAND_GET_ACCESS_TOKEN, async () => {
-    const config = vscode.workspace.getConfiguration();
-
     const defaultGithubToken = await getGithubToken();
 
     const newGithubToken = await vscode.window.showInputBox({
@@ -79,7 +77,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     if (!newGithubToken) throw new Error("Cannot get users' access token properly");
 
-    config.update("githru.github.token", newGithubToken, vscode.ConfigurationTarget.Global);
+    setGithubToken(newGithubToken);
   });
 
   subscriptions.concat([disposable, getAccessToken]);

--- a/packages/vscode/src/setting-repository.ts
+++ b/packages/vscode/src/setting-repository.ts
@@ -5,11 +5,9 @@ const SETTING_PROPERTY_NAMES = {
   PRIMARY_COLOR: "githru.color.primary",
 };
 
-export const getGitHubToken = () => {
+export const getGithubToken = (): string | undefined => {
   const configuration = vscode.workspace.getConfiguration();
-  const githubToken = configuration.get(SETTING_PROPERTY_NAMES.GITHUB_TOKEN);
-
-  return githubToken;
+  return configuration.get(SETTING_PROPERTY_NAMES.GITHUB_TOKEN);
 };
 
 export const setPrimaryColor = (color: string) => {

--- a/packages/vscode/src/setting-repository.ts
+++ b/packages/vscode/src/setting-repository.ts
@@ -10,9 +10,9 @@ export const getGithubToken = (): string | undefined => {
   return configuration.get(SETTING_PROPERTY_NAMES.GITHUB_TOKEN);
 };
 
-export const setPrimaryColor = (color: string) => {
+export const setGithubToken = (newGithubToken: string) => {
   const configuration = vscode.workspace.getConfiguration();
-  configuration.update(SETTING_PROPERTY_NAMES.PRIMARY_COLOR, color);
+  return configuration.update(SETTING_PROPERTY_NAMES.GITHUB_TOKEN, newGithubToken, vscode.ConfigurationTarget.Global);
 };
 
 export const getPrimaryColor = (): string => {

--- a/packages/vscode/src/setting-repository.ts
+++ b/packages/vscode/src/setting-repository.ts
@@ -5,14 +5,17 @@ const SETTING_PROPERTY_NAMES = {
   PRIMARY_COLOR: "githru.color.primary",
 };
 
-export const getGithubToken = (): string | undefined => {
-  const configuration = vscode.workspace.getConfiguration();
-  return configuration.get(SETTING_PROPERTY_NAMES.GITHUB_TOKEN);
+export const getGithubToken = async (secrets: vscode.SecretStorage) => {
+  return await secrets.get(SETTING_PROPERTY_NAMES.GITHUB_TOKEN);
 };
 
-export const setGithubToken = (newGithubToken: string) => {
+export const setGithubToken = (secrets: vscode.SecretStorage, newGithubToken: string) => {
+  return secrets.store(SETTING_PROPERTY_NAMES.GITHUB_TOKEN, newGithubToken);
+};
+
+export const setPrimaryColor = (color: string) => {
   const configuration = vscode.workspace.getConfiguration();
-  return configuration.update(SETTING_PROPERTY_NAMES.GITHUB_TOKEN, newGithubToken, vscode.ConfigurationTarget.Global);
+  configuration.update(SETTING_PROPERTY_NAMES.PRIMARY_COLOR, color);
 };
 
 export const getPrimaryColor = (): string => {

--- a/packages/vscode/src/setting-repository.ts
+++ b/packages/vscode/src/setting-repository.ts
@@ -5,12 +5,11 @@ const SETTING_PROPERTY_NAMES = {
   PRIMARY_COLOR: "githru.color.primary",
 };
 
-export const getGithubToken = async (secrets: vscode.SecretStorage) => {
-  return await secrets.get(SETTING_PROPERTY_NAMES.GITHUB_TOKEN);
-};
+export const getGitHubToken = () => {
+  const configuration = vscode.workspace.getConfiguration();
+  const githubToken = configuration.get(SETTING_PROPERTY_NAMES.GITHUB_TOKEN);
 
-export const setGithubToken = (secrets: vscode.SecretStorage, newGithubToken: string) => {
-  return secrets.store(SETTING_PROPERTY_NAMES.GITHUB_TOKEN, newGithubToken);
+  return githubToken;
 };
 
 export const setPrimaryColor = (color: string) => {


### PR DESCRIPTION
## Related issue
#329 

## Result
<img width="889" alt="image" src="https://github.com/githru/githru-vscode-ext/assets/26860466/a19c86a2-0741-49b0-904a-f1c1532e3f8b">

## Work list

````typescript
      const currentWorkspaceUri = vscode.workspace.workspaceFolders?.[0].uri;
      if (!currentWorkspaceUri) {
        throw new Error("Cannot find current workspace path");
      }

	...

	  const githubToken: string | undefined = await getGithubToken();
      if (!githubToken) {
        throw new Error("Cannot retrieve GitHub token");
      }
````
workspaceFolders를 열 수 없거나 깃허브 토큰을 가져올 수 없는 경우 showErrorMessage를 통해 오류 메시지를 전달하도록 수정했습니다. 

## Discussion
당장은 type assertion을 사용했는데 추후에도 이와 같이 예외가 발생해서 사용자에게 알려줄 때가 많다면 커스텀 에러 객체를 생성해 instanceof로 처리하는 것이 좋을 것 같습니다.
