### PR TITLE
feat(vscode): Enhance Github Token Security

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -2,23 +2,19 @@ import { AnalysisEngine } from "@githru-vscode-ext/analysis-engine";
 import * as vscode from "vscode";
 
 import { COMMAND_GET_ACCESS_TOKEN, COMMAND_LAUNCH } from "./commands";
+import { getGithubToken, setGithubToken } from "./setting-repository";
 import { mapClusterNodesFrom } from "./utils/csm.mapper";
 import { findGit, getBaseBranchName, getBranchNames, getGitConfig, getGitLog, getRepo } from "./utils/git.util";
 import WebviewLoader from "./webview-loader";
 
 let myStatusBarItem: vscode.StatusBarItem;
 
-const getGithubToken = (): string | undefined => {
-  const configuration = vscode.workspace.getConfiguration();
-  return configuration.get("githru.github.token");
-};
-
 function normalizeFsPath(fsPath: string) {
   return fsPath.replace(/\\/g, "/");
 }
 
 export function activate(context: vscode.ExtensionContext) {
-  const { subscriptions, extensionUri, extensionPath } = context;
+  const { subscriptions, extensionUri, extensionPath, secrets } = context;
 
   console.log('Congratulations, your extension "githru" is now active!');
 
@@ -32,13 +28,11 @@ export function activate(context: vscode.ExtensionContext) {
       }
 
       const currentWorkspacePath = normalizeFsPath(currentWorkspaceUri.fsPath);
-      console.debug(vscode.workspace.workspaceFolders);
-      console.debug(currentWorkspacePath);
 
       const branchNames = await getBranchNames(gitPath, currentWorkspacePath);
       const initialBaseBranchName = getBaseBranchName(branchNames);
 
-      const githubToken: string | undefined = await getGithubToken();
+      const githubToken: string | undefined = await getGithubToken(secrets);
       if (!githubToken) {
         throw new Error("Cannot retrieve GitHub token");
       }
@@ -71,9 +65,7 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   const getAccessToken = vscode.commands.registerCommand(COMMAND_GET_ACCESS_TOKEN, async () => {
-    const config = vscode.workspace.getConfiguration();
-
-    const defaultGithubToken = await getGithubToken();
+    const defaultGithubToken = await getGithubToken(secrets);
 
     const newGithubToken = await vscode.window.showInputBox({
       title: "Type or paste your Github access token value.",
@@ -83,7 +75,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     if (!newGithubToken) throw new Error("Cannot get users' access token properly");
 
-    config.update("githru.github.token", newGithubToken, vscode.ConfigurationTarget.Global);
+    setGithubToken(secrets, newGithubToken);
   });
 
   subscriptions.concat([disposable, getAccessToken]);

--- a/packages/vscode/src/setting-repository.ts
+++ b/packages/vscode/src/setting-repository.ts
@@ -5,11 +5,12 @@ const SETTING_PROPERTY_NAMES = {
   PRIMARY_COLOR: "githru.color.primary",
 };
 
-export const getGitHubToken = () => {
-  const configuration = vscode.workspace.getConfiguration();
-  const githubToken = configuration.get(SETTING_PROPERTY_NAMES.GITHUB_TOKEN);
+export const getGithubToken = async (secrets: vscode.SecretStorage) => {
+  return await secrets.get(SETTING_PROPERTY_NAMES.GITHUB_TOKEN);
+};
 
-  return githubToken;
+export const setGithubToken = (secrets: vscode.SecretStorage, newGithubToken: string) => {
+  return secrets.store(SETTING_PROPERTY_NAMES.GITHUB_TOKEN, newGithubToken);
 };
 
 export const setPrimaryColor = (color: string) => {


### PR DESCRIPTION
## Related issue
#373 	

## Work list
````typescript
export const getGithubToken = async (secrets: vscode.SecretStorage) => {
  return await secrets.get(SETTING_PROPERTY_NAMES.GITHUB_TOKEN);
};

export const setGithubToken = (secrets: vscode.SecretStorage, newGithubToken: string) => {
  return secrets.store(SETTING_PROPERTY_NAMES.GITHUB_TOKEN, newGithubToken);
};
````

## Discussion

토큰을 주고 받는 방법을 SecretStorage을 사용하는 방식으로 교체했습니다. 기존의 workspace configuration은 모든 extension이 공유하는 설정 파일이기에 보안적으로 취약하여 이 PR을 제안했습니다.

https://code.visualstudio.com/updates/v1_80#_extension-authoring
