### PR TITLE
Revert "feat(view): cluster node를 펼쳤을 때 avatar 보여주기 (#404)"

### DIFF
--- a/packages/view/src/components/@common/Author/Author.scss
+++ b/packages/view/src/components/@common/Author/Author.scss
@@ -1,8 +1,6 @@
 @import "styles/_pallete";
 @mixin animation {
-  transition:
-    bottom 0.3s ease-in-out,
-    opacity 0.3s ease-in-out;
+  transition: bottom 0.3s ease-in-out, opacity 0.3s ease-in-out;
 }
 @mixin shadow {
   box-shadow: 0px 0px 3px 1px rgba(100, 100, 100, 0.4);
@@ -33,7 +31,6 @@
   margin: 0 -5px;
 
   img {
-    width: 30px;
     border-radius: 50px;
   }
 

--- a/packages/view/src/components/@common/Author/Author.tsx
+++ b/packages/view/src/components/@common/Author/Author.tsx
@@ -10,6 +10,7 @@ const Author = ({ name, src }: AuthorInfo) => {
       <img
         src={src}
         alt=""
+        width="30"
       />
     </div>
   );

--- a/packages/view/src/components/Detail/Detail.scss
+++ b/packages/view/src/components/Detail/Detail.scss
@@ -46,42 +46,34 @@
 }
 
 .detail__commit-list__container {
-  display: flex;
-  flex-direction: column;
-  row-gap: 7px;
   padding: 0 20px;
   font-size: 12px;
 
   .commit-item {
     display: flex;
     justify-content: space-between;
+    margin: 7px 0px;
     color: $gray-600;
 
     .commit-detail {
+      overflow: hidden;
       color: $white;
       display: flex;
       justify-content: space-between;
-      align-items: center;
       width: 100%;
-      padding-left: 5px;
 
-      .avatar-message {
-        display: flex;
-        align-items: center;
+      .message {
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 1;
+        overflow: hidden;
+        color: $white;
+        margin-right: 4px;
 
-        .message {
-          display: -webkit-box;
-          -webkit-box-orient: vertical;
-          -webkit-line-clamp: 1;
-          overflow: hidden;
-          color: $white;
-          margin: 0 4px 0 15px;
-
-          &:hover {
-            display: block;
-            cursor: pointer;
-            overflow: visible;
-          }
+        &:hover {
+          display: block;
+          cursor: pointer;
+          overflow: visible;
         }
       }
 
@@ -91,12 +83,9 @@
       }
     }
     .commit-id {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      width: 140px;
+      width: 90px;
+      padding-left: 50px;
       position: relative;
-
       span:hover {
         cursor: pointer;
         .commit-id__tooltip {

--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -1,13 +1,5 @@
 import dayjs from "dayjs";
 
-
-import { ReactComponent as AuthorIcon } from "assets/author.svg";
-import { ReactComponent as ChangedFileIcon } from "assets/changed-file.svg";
-import { ReactComponent as CommitIcon } from "assets/commit.svg";
-import { ReactComponent as DiffAddIcon } from "assets/diff-add.svg";
-import { ReactComponent as DiffDeleteIcon } from "assets/diff-delete.svg";
-import { Author } from "components/@common/Author";
-
 import AuthorIcon from "assets/author.svg";
 import ChangedFileIcon from "assets/changed-file.svg";
 import CommitIcon from "assets/commit.svg";
@@ -52,7 +44,7 @@ const DetailSummary = ({ commitNodeListInCluster }: DetailSummaryProps) => {
     </div>
   );
 };
-const Detail = ({ selectedData, clusterId, authSrcMap }: DetailProps) => {
+const Detail = ({ selectedData, clusterId }: DetailProps) => {
   const commitNodeListInCluster =
     selectedData?.filter((selected) => selected.commitNodeList[0].clusterId === clusterId)[0].commitNodeList ?? [];
   const { commitNodeList, toggle, handleToggle } = useCommitListHide(commitNodeListInCluster);
@@ -75,15 +67,7 @@ const Detail = ({ selectedData, clusterId, authSrcMap }: DetailProps) => {
               className="commit-item"
             >
               <div className="commit-detail">
-                <div className="avatar-message">
-                  {authSrcMap && (
-                    <Author
-                      name={author.names.toString()}
-                      src={authSrcMap[author.names.toString()]}
-                    />
-                  )}
-                  <span className="message">{message}</span>
-                </div>
+                <span className="message">{message} </span>
                 <span className="author-date">
                   {author.names[0]}, {dayjs(commitDate).format("YY. M. DD. a h:mm")}
                 </span>

--- a/packages/view/src/components/Detail/Detail.type.ts
+++ b/packages/view/src/components/Detail/Detail.type.ts
@@ -1,12 +1,10 @@
 import type { ReactNode } from "react";
 
 import type { ClusterNode, SelectedDataProps } from "types";
-import type { AuthSrcMap } from "components/VerticalClusterList/Summary/Summary.type";
 
 export type DetailProps = {
   selectedData: SelectedDataProps;
   clusterId: number;
-  authSrcMap: AuthSrcMap | null;
 };
 export type DetailSummaryProps = {
   commitNodeListInCluster: ClusterNode["commitNodeList"];

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.const.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.const.ts
@@ -1,6 +1,6 @@
 export const NODE_GAP = 10;
 export const CLUSTER_HEIGHT = 40;
-export const DETAIL_HEIGHT = 220;
+export const DETAIL_HEIGHT = 245;
 export const GRAPH_WIDTH = 80;
 export const SVG_WIDTH = GRAPH_WIDTH + 4;
 export const SVG_MARGIN = {

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -73,7 +73,6 @@ const Summary = () => {
                 <Detail
                   selectedData={selectedData}
                   clusterId={cluster.clusterId}
-                  authSrcMap={authSrcMap}
                 />
               </div>
             )}


### PR DESCRIPTION
This reverts commit f0bc40e75621a3668b61ccf2de8612950bf95838.

## Related issue

## Result

## Work list
아래 import 제거
```javascript
import { ReactComponent as AuthorIcon } from "assets/author.svg";
import { ReactComponent as ChangedFileIcon } from "assets/changed-file.svg";
import { ReactComponent as CommitIcon } from "assets/commit.svg";
import { ReactComponent as DiffAddIcon } from "assets/diff-add.svg";
import { ReactComponent as DiffDeleteIcon } from "assets/diff-delete.svg";
import { Author } from "components/@common/Author";
```

## Discussion
merge 시 Detail.tsx에서 build fail이 발생하는 부분이 있어 수정했습니다.