### PR TITLE
feat(vscode): Custom Error Handling

### DIFF
--- a/packages/vscode/src/errors/ExtensionError.ts
+++ b/packages/vscode/src/errors/ExtensionError.ts
@@ -1,0 +1,18 @@
+class WorkspacePathUndefinedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkspacePathUndefinedError";
+  }
+}
+
+class GithubTokenUndefinedError extends Error {
+  constructor(
+    message: string,
+    public helpUrl: string
+  ) {
+    super(message);
+    this.name = "GithubTokenUndefinedError";
+  }
+}
+
+export { GithubTokenUndefinedError, WorkspacePathUndefinedError };


### PR DESCRIPTION
## Result
<img width="544" alt="image" src="https://github.com/githru/githru-vscode-ext/assets/26860466/7e5e227d-5646-4601-8224-83d800ba78db">

저장된 토큰을 찾을 수 없는 경우 이와 같은 메시지 박스를 띄우도록 수정했습니다.

## Work list
````typescript
class WorkspacePathUndefinedError extends Error {
  constructor(message: string) {
    super(message);
    this.name = "WorkspacePathUndefinedError";
  }
}

class GithubTokenUndefinedError extends Error {
  constructor(
    message: string,
    public helpUrl: string
  ) {
    super(message);
    this.name = "GithubTokenUndefinedError";
  }
}
````
이와 같이 Custom Error Class를 생성하고 `instanceof`로 에러 객체를 구분하여 처리했습니다.

## Discussion
- Custom Error Class를 src/erros/ExtensionError.ts에 정의했는데 더 나은 위치가 있을까요?
- 에러 메시지가 적절할까요? 더 나은 문구가 있다면 추천 부탁드립니다 ☺️
