### PR TITLE
feat(vscode): replace auth with octokit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6916,6 +6916,14 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/dateformat": {
       "version": "4.6.3",
       "license": "MIT",
@@ -9797,6 +9805,28 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/figures": {
       "version": "1.7.0",
       "license": "MIT",
@@ -10247,6 +10277,17 @@
       },
       "engines": {
         "node": ">= 0.12"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -13910,6 +13951,24 @@
       "version": "3.1.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.9",
@@ -19173,6 +19232,14 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "license": "BSD-2-Clause"
@@ -22736,7 +22803,9 @@
       "name": "githru-vscode-ext",
       "version": "0.3.0",
       "dependencies": {
-        "@githru-vscode-ext/analysis-engine": "^0.3.0"
+        "@githru-vscode-ext/analysis-engine": "^0.3.0",
+        "@octokit/rest": "^20.0.1",
+        "node-fetch": "^3.3.2"
       },
       "devDependencies": {
         "@types/glob": "^7.2.0",
@@ -22764,6 +22833,151 @@
       },
       "engines": {
         "vscode": "^1.67.0"
+      }
+    },
+    "packages/vscode/node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/vscode/node_modules/@octokit/core": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.0.0.tgz",
+      "integrity": "sha512-YbAtMWIrbZ9FCXbLwT9wWB8TyLjq9mxpKdgB3dUNxQcIVTf9hJ70gRPwAcqGZdY6WdJPZ0I7jLaaNDCiloGN2A==",
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.0.0",
+        "@octokit/request": "^8.0.2",
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^11.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/vscode/node_modules/@octokit/endpoint": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.0.tgz",
+      "integrity": "sha512-szrQhiqJ88gghWY2Htt8MqUDO6++E/EIXqJ2ZEp5ma3uGS46o7LZAzSLt49myB7rT+Hfw5Y6gO3LmOxGzHijAQ==",
+      "dependencies": {
+        "@octokit/types": "^11.0.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/vscode/node_modules/@octokit/graphql": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.1.tgz",
+      "integrity": "sha512-T5S3oZ1JOE58gom6MIcrgwZXzTaxRnxBso58xhozxHpOqSTgDS6YNeEUvZ/kRvXgPrRz/KHnZhtb7jUMRi9E6w==",
+      "dependencies": {
+        "@octokit/request": "^8.0.1",
+        "@octokit/types": "^11.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/vscode/node_modules/@octokit/openapi-types": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
+      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
+    },
+    "packages/vscode/node_modules/@octokit/plugin-paginate-rest": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-8.0.0.tgz",
+      "integrity": "sha512-2xZ+baZWUg+qudVXnnvXz7qfrTmDeYPCzangBVq/1gXxii/OiS//4shJp9dnCCvj1x+JAm9ji1Egwm1BA47lPQ==",
+      "dependencies": {
+        "@octokit/types": "^11.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=5"
+      }
+    },
+    "packages/vscode/node_modules/@octokit/plugin-request-log": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.0.tgz",
+      "integrity": "sha512-2uJI1COtYCq8Z4yNSnM231TgH50bRkheQ9+aH8TnZanB6QilOnx8RMD2qsnamSOXtDj0ilxvevf5fGsBhBBzKA==",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=5"
+      }
+    },
+    "packages/vscode/node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-9.0.0.tgz",
+      "integrity": "sha512-KquMF/VB1IkKNiVnzJKspY5mFgGyLd7HzdJfVEGTJFzqu9BRFNWt+nwTCMuUiWc72gLQhRWYubTwOkQj+w/1PA==",
+      "dependencies": {
+        "@octokit/types": "^11.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=5"
+      }
+    },
+    "packages/vscode/node_modules/@octokit/request": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.1.tgz",
+      "integrity": "sha512-8N+tdUz4aCqQmXl8FpHYfKG9GelDFd7XGVzyN8rc6WxVlYcfpHECnuRkgquzz+WzvHTK62co5di8gSXnzASZPQ==",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.0",
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^11.1.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/vscode/node_modules/@octokit/request-error": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.0.tgz",
+      "integrity": "sha512-1ue0DH0Lif5iEqT52+Rf/hf0RmGO9NWFjrzmrkArpG9trFfDM/efx00BJHdLGuro4BR/gECxCU2Twf5OKrRFsQ==",
+      "dependencies": {
+        "@octokit/types": "^11.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/vscode/node_modules/@octokit/rest": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.0.1.tgz",
+      "integrity": "sha512-wROV21RwHQIMNb2Dgd4+pY+dVy1Dwmp85pBrgr6YRRDYRBu9Gb+D73f4Bl2EukZSj5hInq2Tui9o7gAQpc2k2Q==",
+      "dependencies": {
+        "@octokit/core": "^5.0.0",
+        "@octokit/plugin-paginate-rest": "^8.0.0",
+        "@octokit/plugin-request-log": "^4.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^9.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/vscode/node_modules/@octokit/types": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
+      "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
+      "dependencies": {
+        "@octokit/openapi-types": "^18.0.0"
       }
     },
     "packages/vscode/node_modules/@types/node": {
@@ -23015,6 +23229,23 @@
         "@typescript-eslint/eslint-plugin": {
           "optional": true
         }
+      }
+    },
+    "packages/vscode/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     }
   },
@@ -28656,6 +28887,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
+    },
     "dateformat": {
       "version": "4.6.3",
       "optional": true,
@@ -30542,6 +30778,15 @@
         "bser": "2.1.1"
       }
     },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "figures": {
       "version": "1.7.0",
       "requires": {
@@ -30831,6 +31076,14 @@
         "mime-types": "^2.1.12"
       }
     },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
+      }
+    },
     "forwarded": {
       "version": "0.2.0",
       "dev": true,
@@ -30982,6 +31235,7 @@
       "version": "file:packages/vscode",
       "requires": {
         "@githru-vscode-ext/analysis-engine": "^0.3.0",
+        "@octokit/rest": "^20.0.1",
         "@types/glob": "^7.2.0",
         "@types/mocha": "^9.1.1",
         "@types/node": "14.x",
@@ -30999,6 +31253,7 @@
         "eslint-plugin-unused-imports": "^3.0.0",
         "glob": "^8.0.1",
         "mocha": "^9.2.2",
+        "node-fetch": "*",
         "prettier": "^3.0.1",
         "ts-loader": "^9.2.8",
         "typescript": "^4.6.4",
@@ -31006,6 +31261,113 @@
         "webpack-cli": "^4.9.2"
       },
       "dependencies": {
+        "@octokit/auth-token": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+          "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA=="
+        },
+        "@octokit/core": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.0.0.tgz",
+          "integrity": "sha512-YbAtMWIrbZ9FCXbLwT9wWB8TyLjq9mxpKdgB3dUNxQcIVTf9hJ70gRPwAcqGZdY6WdJPZ0I7jLaaNDCiloGN2A==",
+          "requires": {
+            "@octokit/auth-token": "^4.0.0",
+            "@octokit/graphql": "^7.0.0",
+            "@octokit/request": "^8.0.2",
+            "@octokit/request-error": "^5.0.0",
+            "@octokit/types": "^11.0.0",
+            "before-after-hook": "^2.2.0",
+            "universal-user-agent": "^6.0.0"
+          }
+        },
+        "@octokit/endpoint": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.0.tgz",
+          "integrity": "sha512-szrQhiqJ88gghWY2Htt8MqUDO6++E/EIXqJ2ZEp5ma3uGS46o7LZAzSLt49myB7rT+Hfw5Y6gO3LmOxGzHijAQ==",
+          "requires": {
+            "@octokit/types": "^11.0.0",
+            "is-plain-object": "^5.0.0",
+            "universal-user-agent": "^6.0.0"
+          }
+        },
+        "@octokit/graphql": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.1.tgz",
+          "integrity": "sha512-T5S3oZ1JOE58gom6MIcrgwZXzTaxRnxBso58xhozxHpOqSTgDS6YNeEUvZ/kRvXgPrRz/KHnZhtb7jUMRi9E6w==",
+          "requires": {
+            "@octokit/request": "^8.0.1",
+            "@octokit/types": "^11.0.0",
+            "universal-user-agent": "^6.0.0"
+          }
+        },
+        "@octokit/openapi-types": {
+          "version": "18.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
+          "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
+        },
+        "@octokit/plugin-paginate-rest": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-8.0.0.tgz",
+          "integrity": "sha512-2xZ+baZWUg+qudVXnnvXz7qfrTmDeYPCzangBVq/1gXxii/OiS//4shJp9dnCCvj1x+JAm9ji1Egwm1BA47lPQ==",
+          "requires": {
+            "@octokit/types": "^11.0.0"
+          }
+        },
+        "@octokit/plugin-request-log": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.0.tgz",
+          "integrity": "sha512-2uJI1COtYCq8Z4yNSnM231TgH50bRkheQ9+aH8TnZanB6QilOnx8RMD2qsnamSOXtDj0ilxvevf5fGsBhBBzKA==",
+          "requires": {}
+        },
+        "@octokit/plugin-rest-endpoint-methods": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-9.0.0.tgz",
+          "integrity": "sha512-KquMF/VB1IkKNiVnzJKspY5mFgGyLd7HzdJfVEGTJFzqu9BRFNWt+nwTCMuUiWc72gLQhRWYubTwOkQj+w/1PA==",
+          "requires": {
+            "@octokit/types": "^11.0.0"
+          }
+        },
+        "@octokit/request": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.1.tgz",
+          "integrity": "sha512-8N+tdUz4aCqQmXl8FpHYfKG9GelDFd7XGVzyN8rc6WxVlYcfpHECnuRkgquzz+WzvHTK62co5di8gSXnzASZPQ==",
+          "requires": {
+            "@octokit/endpoint": "^9.0.0",
+            "@octokit/request-error": "^5.0.0",
+            "@octokit/types": "^11.1.0",
+            "is-plain-object": "^5.0.0",
+            "universal-user-agent": "^6.0.0"
+          }
+        },
+        "@octokit/request-error": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.0.tgz",
+          "integrity": "sha512-1ue0DH0Lif5iEqT52+Rf/hf0RmGO9NWFjrzmrkArpG9trFfDM/efx00BJHdLGuro4BR/gECxCU2Twf5OKrRFsQ==",
+          "requires": {
+            "@octokit/types": "^11.0.0",
+            "deprecation": "^2.0.0",
+            "once": "^1.4.0"
+          }
+        },
+        "@octokit/rest": {
+          "version": "20.0.1",
+          "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.0.1.tgz",
+          "integrity": "sha512-wROV21RwHQIMNb2Dgd4+pY+dVy1Dwmp85pBrgr6YRRDYRBu9Gb+D73f4Bl2EukZSj5hInq2Tui9o7gAQpc2k2Q==",
+          "requires": {
+            "@octokit/core": "^5.0.0",
+            "@octokit/plugin-paginate-rest": "^8.0.0",
+            "@octokit/plugin-request-log": "^4.0.0",
+            "@octokit/plugin-rest-endpoint-methods": "^9.0.0"
+          }
+        },
+        "@octokit/types": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
+          "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
+          "requires": {
+            "@octokit/openapi-types": "^18.0.0"
+          }
+        },
         "@types/node": {
           "version": "14.18.46",
           "dev": true
@@ -31144,6 +31506,16 @@
           "dev": true,
           "requires": {
             "eslint-rule-composer": "^0.3.0"
+          }
+        },
+        "node-fetch": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+          "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+          "requires": {
+            "data-uri-to-buffer": "^4.0.0",
+            "fetch-blob": "^3.1.4",
+            "formdata-polyfill": "^4.0.10"
           }
         }
       }
@@ -33337,6 +33709,11 @@
     "node-abort-controller": {
       "version": "3.1.1",
       "dev": true
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "node-fetch": {
       "version": "2.6.9",
@@ -36759,6 +37136,11 @@
       "requires": {
         "defaults": "^1.0.3"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
     },
     "webidl-conversions": {
       "version": "3.0.1"

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -49,8 +49,8 @@
         "category": "Githru"
       },
       {
-        "command": "githru.command.get.accessToken",
-        "title": "Set access token",
+        "command": "githru.command.login.github",
+        "title": "Login with Github",
         "category": "Githru"
       }
     ],
@@ -84,7 +84,9 @@
     "test": "node ./out/test/runTest.js"
   },
   "dependencies": {
-    "@githru-vscode-ext/analysis-engine": "^0.3.0"
+    "@githru-vscode-ext/analysis-engine": "^0.3.0",
+    "@octokit/rest": "^20.0.1",
+    "node-fetch": "^3.3.2"
   },
   "devDependencies": {
     "@types/glob": "^7.2.0",
@@ -98,8 +100,8 @@
     "copy-webpack-plugin": "^11.0.0",
     "eslint": "^8.46.0",
     "eslint-config-prettier": "^8.10.0",
-    "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-import": "^2.28.0",
+    "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-unused-imports": "^3.0.0",
     "glob": "^8.0.1",

--- a/packages/vscode/src/commands.ts
+++ b/packages/vscode/src/commands.ts
@@ -1,4 +1,4 @@
 export const COMMAND_PREFIX = "githru.command";
 export const COMMAND_LAUNCH = `${COMMAND_PREFIX}.launch`;
 export const COMMAND_RELOAD = `${COMMAND_PREFIX}.reload`;
-export const COMMAND_GET_ACCESS_TOKEN = `${COMMAND_PREFIX}.get.accessToken`;
+export const COMMAND_LOGIN_WITH_GITHUB = `${COMMAND_PREFIX}.login.github`;

--- a/packages/vscode/src/credentials.ts
+++ b/packages/vscode/src/credentials.ts
@@ -19,18 +19,20 @@ export class Credentials {
     this.setOctokit();
   }
 
+  private async createOctokit(session: vscode.AuthenticationSession) {
+    return new Octokit.Octokit({
+      auth: session.accessToken,
+      request: {
+        fetch: fetch,
+      },
+    });
+  }
+
   private async setOctokit() {
     const session = await vscode.authentication.getSession(GITHUB_AUTH_PROVIDER_ID, SCOPES, { createIfNone: false });
 
     if (session) {
-      this.octokit = new Octokit.Octokit({
-        auth: session.accessToken,
-        request: {
-          fetch: fetch,
-        },
-      });
-
-      return;
+      this.octokit = await this.createOctokit(session);
     }
 
     this.octokit = undefined;
@@ -52,12 +54,7 @@ export class Credentials {
     }
 
     const session = await vscode.authentication.getSession(GITHUB_AUTH_PROVIDER_ID, SCOPES, { createIfNone: true });
-    this.octokit = new Octokit.Octokit({
-      auth: session.accessToken,
-      request: {
-        fetch: fetch,
-      },
-    });
+    this.octokit = await this.createOctokit(session);
 
     return this.octokit;
   }
@@ -68,12 +65,7 @@ export class Credentials {
     }
 
     const session = await vscode.authentication.getSession(GITHUB_AUTH_PROVIDER_ID, SCOPES, { createIfNone: true });
-    this.octokit = new Octokit.Octokit({
-      auth: session.accessToken,
-      request: {
-        fetch: fetch,
-      },
-    });
+    this.octokit = await this.createOctokit(session);
 
     return this.octokit.auth() as Promise<OctokitAuth>;
   }

--- a/packages/vscode/src/credentials.ts
+++ b/packages/vscode/src/credentials.ts
@@ -1,0 +1,80 @@
+import * as Octokit from "@octokit/rest";
+import fetch from "node-fetch";
+import * as vscode from "vscode";
+
+interface OctokitAuth {
+  type: string;
+  token: string;
+  tokenType: string;
+}
+
+const GITHUB_AUTH_PROVIDER_ID = "github";
+const SCOPES = ["user:email"];
+
+export class Credentials {
+  private octokit: Octokit.Octokit | undefined;
+
+  async initialize(context: vscode.ExtensionContext): Promise<void> {
+    this.registerListeners(context);
+    this.setOctokit();
+  }
+
+  private async setOctokit() {
+    const session = await vscode.authentication.getSession(GITHUB_AUTH_PROVIDER_ID, SCOPES, { createIfNone: false });
+
+    if (session) {
+      this.octokit = new Octokit.Octokit({
+        auth: session.accessToken,
+        request: {
+          fetch: fetch,
+        },
+      });
+
+      return;
+    }
+
+    this.octokit = undefined;
+  }
+
+  registerListeners(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+      vscode.authentication.onDidChangeSessions(async (e) => {
+        if (e.provider.id === GITHUB_AUTH_PROVIDER_ID) {
+          await this.setOctokit();
+        }
+      })
+    );
+  }
+
+  async getOctokit(): Promise<Octokit.Octokit> {
+    if (this.octokit) {
+      return this.octokit;
+    }
+
+    const session = await vscode.authentication.getSession(GITHUB_AUTH_PROVIDER_ID, SCOPES, { createIfNone: true });
+    this.octokit = new Octokit.Octokit({
+      auth: session.accessToken,
+      request: {
+        fetch: fetch,
+      },
+    });
+
+    return this.octokit;
+  }
+
+  async getAuth(): Promise<OctokitAuth> {
+    if (this.octokit) {
+      return this.octokit.auth() as Promise<OctokitAuth>;
+    }
+
+    const session = await vscode.authentication.getSession(GITHUB_AUTH_PROVIDER_ID, SCOPES, { createIfNone: true });
+    this.octokit = new Octokit.Octokit({
+      auth: session.accessToken,
+      request: {
+        fetch: fetch,
+      },
+    });
+
+    return this.octokit.auth() as Promise<OctokitAuth>;
+  }
+}

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,7 +1,8 @@
 import { AnalysisEngine } from "@githru-vscode-ext/analysis-engine";
 import * as vscode from "vscode";
 
-import { COMMAND_GET_ACCESS_TOKEN, COMMAND_LAUNCH } from "./commands";
+import { COMMAND_LAUNCH, COMMAND_LOGIN_WITH_GITHUB } from "./commands";
+import { Credentials } from "./credentials";
 import { GithubTokenUndefinedError, WorkspacePathUndefinedError } from "./errors/ExtensionError";
 import { getGithubToken, setGithubToken } from "./setting-repository";
 import { mapClusterNodesFrom } from "./utils/csm.mapper";
@@ -14,8 +15,10 @@ function normalizeFsPath(fsPath: string) {
   return fsPath.replace(/\\/g, "/");
 }
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
   const { subscriptions, extensionUri, extensionPath, secrets } = context;
+  const credentials = new Credentials();
+  await credentials.initialize(context);
 
   console.log('Congratulations, your extension "githru" is now active!');
 
@@ -78,21 +81,17 @@ export function activate(context: vscode.ExtensionContext) {
     }
   });
 
-  const getAccessToken = vscode.commands.registerCommand(COMMAND_GET_ACCESS_TOKEN, async () => {
-    const defaultGithubToken = await getGithubToken(secrets);
+  const loginWithGithup = vscode.commands.registerCommand(COMMAND_LOGIN_WITH_GITHUB, async () => {
+    const octokit = await credentials.getOctokit();
+    const userInfo = await octokit.users.getAuthenticated();
+    const auth = await credentials.getAuth();
 
-    const newGithubToken = await vscode.window.showInputBox({
-      title: "Type or paste your Github access token value.",
-      placeHolder: "Type valid token here!",
-      value: defaultGithubToken ?? "",
-    });
+    setGithubToken(secrets, auth.token);
 
-    if (!newGithubToken) throw new Error("Cannot get users' access token properly");
-
-    setGithubToken(secrets, newGithubToken);
+    vscode.window.showInformationMessage(`Logged into GitHub as ${userInfo.data.login}`);
   });
 
-  subscriptions.concat([disposable, getAccessToken]);
+  subscriptions.concat([disposable, loginWithGithup]);
 
   myStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -10);
   myStatusBarItem.text = "githru";

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -81,7 +81,7 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   });
 
-  const loginWithGithup = vscode.commands.registerCommand(COMMAND_LOGIN_WITH_GITHUB, async () => {
+  const loginWithGithub = vscode.commands.registerCommand(COMMAND_LOGIN_WITH_GITHUB, async () => {
     const octokit = await credentials.getOctokit();
     const userInfo = await octokit.users.getAuthenticated();
     const auth = await credentials.getAuth();
@@ -91,7 +91,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.window.showInformationMessage(`Logged into GitHub as ${userInfo.data.login}`);
   });
 
-  subscriptions.concat([disposable, loginWithGithup]);
+  subscriptions.concat([disposable, loginWithGithub]);
 
   myStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -10);
   myStatusBarItem.text = "githru";


### PR DESCRIPTION
## Result

<img width="502" alt="image" src="https://github.com/githru/githru-vscode-ext/assets/26860466/12a59052-3706-454a-8c09-a3f72c6cda49">

- 기존에 직접 personal access token을 입력하는 방식 대신 `login with github` 커맨드를 실행시키면 깃허브 oauth 페이지로 연결되어 인증이 되도록 수정했습니다.

## Work list
- credential.ts

## Discussion
`loginWithGithub`이라는 별도의 커맨드가 존재하는 것보다 launch 커맨드 실행 시 token을 가져오는 과정에서 token이 없을 경우 인증 과정이 실행되도록 수정되면 좋을것 같은데 어떻게 생각하시나요?
