### PR TITLE
refactor(engine): commit classify based type inclueded

### DIFF
--- a/packages/analysis-engine/src/commit.util.ts
+++ b/packages/analysis-engine/src/commit.util.ts
@@ -20,11 +20,14 @@ export function getCommitMessageType(message: string): CommitMessageType {
   const lowerCaseMessage = message.toLowerCase();
   let type = "";
 
-  for (let index = 0; index < CommitMessageTypeList.length; index++) {
-    if (lowerCaseMessage.includes(CommitMessageTypeList[index])) {
-      type = CommitMessageTypeList[index];
+  CommitMessageTypeList.forEach((commitMessageType) => {
+    const classifiedCommitMessageIndex = lowerCaseMessage.indexOf(commitMessageType);
+
+    if (classifiedCommitMessageIndex >= 0) {
+      if (!type.length) type = commitMessageType;
+      else if (lowerCaseMessage.indexOf(type) > classifiedCommitMessageIndex) type = commitMessageType;
     }
-  }
+  });
 
   return type;
 }

--- a/packages/analysis-engine/src/commit.util.ts
+++ b/packages/analysis-engine/src/commit.util.ts
@@ -17,18 +17,14 @@ export function getLeafNodes(commitDict: CommitDict): CommitNode[] {
 }
 
 export function getCommitMessageType(message: string): CommitMessageType {
-  let messagePrefix = message.match(/\w*(\(.*\))?!?:/)?.[0];
-  if (!messagePrefix) return "";
+  const lowerCaseMessage = message.toLowerCase();
+  let type = "";
 
-  /**
-   * commit type 직후에 세 가지 특수문자가 올 수 있음
-   * ( -> scope
-   * ! -> breaking change
-   * : -> type과 message 구분
-   */
-  const separatorIdx = messagePrefix.search(/[(!:]/);
+  for (let index = 0; index < CommitMessageTypeList.length; index++) {
+    if (lowerCaseMessage.includes(CommitMessageTypeList[index])) {
+      type = CommitMessageTypeList[index];
+    }
+  }
 
-  if (separatorIdx > 0) messagePrefix = messagePrefix.slice(0, separatorIdx);
-
-  return CommitMessageTypeList.includes(messagePrefix) ? messagePrefix : "";
+  return type;
 }

--- a/packages/analysis-engine/src/parser.spec.ts
+++ b/packages/analysis-engine/src/parser.spec.ts
@@ -26,10 +26,6 @@ describe("commit message type", () => {
   it.each([
     "Merge pull request #209 from aa/main", // no type prefix
     "pix(vscode): add logo image and publish info", // no valid type
-    "feat : some message", // no valid type
-    "feat (vscode): some message", // space
-    "feat (vscode) : some message",
-    "feat(vscode) : some message",
   ])("has no valid commit message type", (message) => {
     const commitType = getCommitMessageType(message);
     expect(commitType).toBe("");

--- a/packages/analysis-engine/src/types/CommitMessageType.ts
+++ b/packages/analysis-engine/src/types/CommitMessageType.ts
@@ -10,7 +10,6 @@ export const CommitMessageTypeList = [
   "revert",
   "style",
   "test",
-  "", // default - 명시된 타입이 없거나 commitLint rule을 따르지 않은 경우
 ];
 
 const COMMIT_MESSAGE_TYPE = [...CommitMessageTypeList] as const;


### PR DESCRIPTION
## Related issue
#187 

## Result
![스크린샷 2023-08-29 오후 4 33 46](https://github.com/githru/githru-vscode-ext/assets/66871265/504bc62a-3cc8-4ab1-8ddb-b3919883bd99)

기존에 `:` prefix로 분류하던 것을 커밋 메세지안에 특정 커밋 타입이 포함되어 있는지 아닌지로 분류하였습니다.

## Work list

commit.util.ts
CommitMessageType.ts
parser.spec.ts

## Discussion

특정 커밋 타입이 포함되어 있는지 아닌지로 분류하기 때문에 CommitMessageType 배열 순서에 의존하고 있습니다.

예를들어 "feat(engine): build stem & CSM based on passed branch name (#198)" 이 커밋 메세지가 존재하고 

저희의 커밋 메세지 타입 배열 순서가 아래와 같다면

```javascript
const CommitMessageTypeList = [
  "feat",
  "chore",
  "ci",
  "docs",
  "build",
  "fix",
  "pert",
  "refactor",
  "revert",
  "style",
  "test",
];
```
커밋 타입이 `feat`이여야 하는게 배열 순서에 의존하게 되어 `build`로 분류되어 나오게 됩니다.
