### PR TITLE
feat(vscode): git tag 정보 view에게 전달

### DIFF
--- a/packages/analysis-engine/src/parser.spec.ts
+++ b/packages/analysis-engine/src/parser.spec.ts
@@ -1,4 +1,5 @@
 import { getCommitMessageType } from "./commit.util";
+import getCommitRaws from "./parser"; // 파일의 상대 경로에 따라 수정하세요
 
 describe("commit message type", () => {
   it.each([
@@ -33,5 +34,137 @@ describe("commit message type", () => {
   ])("has no valid commit message type", (message) => {
     const commitType = getCommitMessageType(message);
     expect(commitType).toBe("");
+  });
+});
+
+//branch와 tag test
+describe('getCommitRaws', () => {
+  const testCommitLines = [
+    "commit a b (HEAD)",
+    "commit a b (HEAD -> main, origin/main, origin/HEAD)",
+    "commit a b (HEAD, tag: v1.0.0)",
+    "commit a b (HEAD -> main, origin/main, origin/HEAD, tag: v2.0.0)",
+    "commit a b (HEAD, tag: v2.0.0, tag: v1.4)"
+  ];
+
+  const expectedBranches = [
+    ['HEAD'],
+    ['HEAD', 'main', 'origin/main', 'origin/HEAD'],
+    ['HEAD'],
+    ['HEAD', 'main', 'origin/main', 'origin/HEAD'],
+    ['HEAD']
+  ];
+
+  const expectedTags=[
+    [],
+    [],
+    ['v1.0.0'],
+    ['v2.0.0'],
+    ['v2.0.0','v1.4']
+  ]
+
+  testCommitLines.forEach((mockLog, index) => {
+    it(`should parse gitlog to commitRaw(branch, tag)`, () => {
+      const mock = `${mockLog}
+Author: John Park <mail@gmail.com>
+AuthorDate: Sun Sep 4 20:17:59 2022 +0900
+Commit: John Park <mail@gmail.com>
+CommitDate: Sun Sep 4 20:17:59 2022 +0900
+\n\tcommit message
+`;
+      const result = getCommitRaws(mock);
+
+      expect(result).toEqual([
+        {
+          sequence: 0,
+          id: 'a',
+          parents: ['b'],
+          branches: expectedBranches[index],
+          tags: expectedTags[index],
+          author: { name: 'John Park', email: 'mail@gmail.com' },
+          authorDate: new Date('Sun Sep 4 20:17:59 2022 +0900'),
+          committer: { name: 'John Park', email: 'mail@gmail.com' },
+          committerDate: new Date('Sun Sep 4 20:17:59 2022 +0900'),
+          message: 'commit message',
+          differenceStatistic: {
+            totalInsertionCount: 0,
+            totalDeletionCount: 0,
+            fileDictionary: {},
+          },
+          commitMessageType: ""
+        },
+      ]);
+    });
+  });
+});
+
+//total file changed, deletion, addition test
+describe('getCommitRaws', () => {
+  const testCommitLines = [
+    "10\t0\ta.ts\n1\t0\tREADME.md",
+    "3\t3\ta.ts",
+    "4\t0\ta.ts",
+    "0\t6\ta.ts\n2\t0\tb.ts\n3\t3\tc.ts"
+  ];
+
+  const expectedBranches = [
+    {
+      totalInsertionCount: 11,
+      totalDeletionCount: 0,
+      fileDictionary: {
+        'a.ts': { insertionCount: 10, deletionCount: 0 },
+        'README.md': { insertionCount: 1, deletionCount: 0 },
+      }
+    },
+    {
+      totalInsertionCount: 3,
+      totalDeletionCount: 3,
+      fileDictionary: { 'a.ts': { insertionCount: 3, deletionCount: 3 } }
+    },
+    {
+      totalInsertionCount: 4,
+      totalDeletionCount: 0,
+      fileDictionary: { 'a.ts': { insertionCount: 4, deletionCount: 0 } }
+    },
+    {
+      totalInsertionCount: 5,
+      totalDeletionCount: 9,
+      fileDictionary: {
+        'a.ts': { insertionCount: 0, deletionCount: 6 },
+        'b.ts': { insertionCount: 2, deletionCount: 0 },
+        'c.ts': { insertionCount: 3, deletionCount: 3 },
+      }
+    }
+  ];
+
+  testCommitLines.forEach((mockLog, index) => {
+    it(`should parse gitlog to commitRaw(file changed)`, () => {
+      const mock = `commit a b (HEAD)
+Author: John Park <mail@gmail.com>
+AuthorDate: Sun Sep 4 20:17:59 2022 +0900
+Commit: John Park <mail@gmail.com>
+CommitDate: Sun Sep 4 20:17:59 2022 +0900
+\n\tcommit message
+\n${mockLog}
+`;
+      const result = getCommitRaws(mock);
+
+      expect(result).toEqual([
+        {
+          sequence: 0,
+          id: 'a',
+          parents: ['b'],
+          branches: ['HEAD'],
+          tags: [],
+          author: { name: 'John Park', email: 'mail@gmail.com' },
+          authorDate: new Date('Sun Sep 4 20:17:59 2022 +0900'),
+          committer: { name: 'John Park', email: 'mail@gmail.com' },
+          committerDate: new Date('Sun Sep 4 20:17:59 2022 +0900'),
+          message: 'commit message',
+          differenceStatistic: expectedBranches[index],
+          commitMessageType: ""
+        },
+      ]);
+    });
   });
 });

--- a/packages/vscode/src/utils/NodeTypes.temps.ts
+++ b/packages/vscode/src/utils/NodeTypes.temps.ts
@@ -45,6 +45,8 @@ export type Commit = {
   commitDate: string;
   diffStatistics: DiffStatistics;
   message: string;
+  tags: string[];
+  releaseTags: string[];
   // fill necessary properties...
 };
 

--- a/packages/vscode/src/utils/csm.mapper.ts
+++ b/packages/vscode/src/utils/csm.mapper.ts
@@ -33,33 +33,38 @@ const mapDiffStatisticsFrom = (params: { differenceStatistic: DifferenceStatisti
  */
 const mapCommitNodeListFrom = (params: { commits: StemCommitNode[]; clusterId: number }): CommitNode[] => {
   const { commits, clusterId } = params;
-  return commits.map(({ commit }) => ({
-    nodeTypeName: "COMMIT" as const,
-    commit: {
-      id: commit.id,
-      parentIds: commit.parents,
-      author: {
-        id: "no-id",
-        names: [commit.author.name],
-        emails: [commit.author.email],
+  return commits.map(({ commit }) => {
+    const releaseTags=commit.tags.filter(tag=>tag.startsWith('v')||/^[0-9.]+$/.test(tag));
+    return {
+      nodeTypeName: "COMMIT" as const,
+      commit: {
+        id: commit.id,
+        parentIds: commit.parents,
+        author: {
+          id: "no-id",
+          names: [commit.author.name],
+          emails: [commit.author.email],
+        },
+        committer: {
+          id: "no-id",
+          names: [commit.committer.name],
+          emails: [commit.committer.email],
+        },
+        authorDate: commit.authorDate.toString(),
+        commitDate: commit.committerDate.toString(),
+        diffStatistics: mapDiffStatisticsFrom({ differenceStatistic: commit.differenceStatistic }),
+        message: commit.message,
+        tags: commit.tags,
+        releaseTags: releaseTags,
       },
-      committer: {
-        id: "no-id",
-        names: [commit.committer.name],
-        emails: [commit.committer.email],
-      },
-      authorDate: commit.authorDate.toString(),
-      commitDate: commit.committerDate.toString(),
-      diffStatistics: mapDiffStatisticsFrom({ differenceStatistic: commit.differenceStatistic }),
-      message: commit.message,
-    },
-    // seq: 0,
-    // implicitBranchNo: 0,
-    // isMergeCommit: false,
-    // hasMajorTag: false,
-    // hasMinorTag: false,
-    clusterId,
-  }));
+      // seq: 0,
+      // implicitBranchNo: 0,
+      // isMergeCommit: false,
+      // hasMajorTag: false,
+      // hasMinorTag: false,
+      clusterId,
+    }
+  });
 };
 
 /**


### PR DESCRIPTION
## Related issue
#361

## Result
```
export type Commit = {
  id: string;
  parentIds: string[];
  author: GitHubUser;
  committer: GitHubUser;
  authorDate: string;
  commitDate: string;
  diffStatistics: DiffStatistics;
  message: string;
  tags: string[];
  releaseTags: string[];
};
```

## Work list
commit마다 engine에서 받은 tag 정보를 토대로 view에 tags와 releaseTags의 정보를 넘겨줍니다. 
releaseTags에는 tag들 중 'v'로 시작하거나 숫자 또는 '.'으로만 이루어진 것들을 version에 관한 정보라고 판단하고 분류해주었습니다.

## Discussion
view에서 사용하기 위해서는 view내의 정의된 commit의 type을  vscode의 commit type과 동일하게 변경해주어야 합니다.

후에 tag관련 처리 부분을 엔진에서 하는 것도 고려해봐도 좋을 것 같습니다.

