### PR TITLE
test(engine): git log를 commitRaw로 바꾸기(parer), code refactoring

### DIFF
--- a/packages/analysis-engine/src/parser.spec.ts
+++ b/packages/analysis-engine/src/parser.spec.ts
@@ -1,5 +1,6 @@
 import { getCommitMessageType } from "./commit.util";
-import getCommitRaws from "./parser"; // 파일의 상대 경로에 따라 수정하세요
+import getCommitRaws from "./parser"; 
+import { CommitRaw, DifferenceStatistic } from "./types";
 
 describe("commit message type", () => {
   it.each([
@@ -37,7 +38,6 @@ describe("commit message type", () => {
   });
 });
 
-//branch와 tag test
 describe('getCommitRaws', () => {
   const testCommitLines = [
     "commit a b (HEAD)",
@@ -55,59 +55,22 @@ describe('getCommitRaws', () => {
     ['HEAD']
   ];
 
-  const expectedTags=[
+  const expectedTags = [
     [],
     [],
     ['v1.0.0'],
     ['v2.0.0'],
-    ['v2.0.0','v1.4']
-  ]
+    ['v2.0.0', 'v1.4']
+  ];
 
-  testCommitLines.forEach((mockLog, index) => {
-    it(`should parse gitlog to commitRaw(branch, tag)`, () => {
-      const mock = `${mockLog}
-Author: John Park <mail@gmail.com>
-AuthorDate: Sun Sep 4 20:17:59 2022 +0900
-Commit: John Park <mail@gmail.com>
-CommitDate: Sun Sep 4 20:17:59 2022 +0900
-\n\tcommit message
-`;
-      const result = getCommitRaws(mock);
-
-      expect(result).toEqual([
-        {
-          sequence: 0,
-          id: 'a',
-          parents: ['b'],
-          branches: expectedBranches[index],
-          tags: expectedTags[index],
-          author: { name: 'John Park', email: 'mail@gmail.com' },
-          authorDate: new Date('Sun Sep 4 20:17:59 2022 +0900'),
-          committer: { name: 'John Park', email: 'mail@gmail.com' },
-          committerDate: new Date('Sun Sep 4 20:17:59 2022 +0900'),
-          message: 'commit message',
-          differenceStatistic: {
-            totalInsertionCount: 0,
-            totalDeletionCount: 0,
-            fileDictionary: {},
-          },
-          commitMessageType: ""
-        },
-      ]);
-    });
-  });
-});
-
-//total file changed, deletion, addition test
-describe('getCommitRaws', () => {
-  const testCommitLines = [
+  const testCommitFileChanges = [
     "10\t0\ta.ts\n1\t0\tREADME.md",
     "3\t3\ta.ts",
     "4\t0\ta.ts",
     "0\t6\ta.ts\n2\t0\tb.ts\n3\t3\tc.ts"
   ];
 
-  const expectedBranches = [
+  const expectedFileChanged:DifferenceStatistic[] = [
     {
       totalInsertionCount: 11,
       totalDeletionCount: 0,
@@ -137,7 +100,42 @@ describe('getCommitRaws', () => {
     }
   ];
 
+  const commonExpectatedResult: CommitRaw={
+    sequence: 0,
+    id: 'a',
+    parents: ['b'],
+    branches: ['HEAD'],
+    tags: [],
+    author: { name: 'John Park', email: 'mail@gmail.com' },
+    authorDate: new Date('Sun Sep 4 20:17:59 2022 +0900'),
+    committer: { name: 'John Park', email: 'mail@gmail.com' },
+    committerDate: new Date('Sun Sep 4 20:17:59 2022 +0900'),
+    message: 'commit message',
+    differenceStatistic: {
+      totalInsertionCount: 0,
+      totalDeletionCount: 0,
+      fileDictionary: {},
+    },
+    commitMessageType: ""
+  };
+
   testCommitLines.forEach((mockLog, index) => {
+    it(`should parse gitlog to commitRaw(branch, tag)`, () => {
+      const mock = `${mockLog}
+Author: John Park <mail@gmail.com>
+AuthorDate: Sun Sep 4 20:17:59 2022 +0900
+Commit: John Park <mail@gmail.com>
+CommitDate: Sun Sep 4 20:17:59 2022 +0900
+\n\tcommit message
+`;
+      const result = getCommitRaws(mock);
+      const expectedResult = { ...commonExpectatedResult, branches: expectedBranches[index], tags: expectedTags[index] };
+      
+      expect(result).toEqual([expectedResult]);
+    });
+  });
+
+  testCommitFileChanges.forEach((mockLog, index) => {
     it(`should parse gitlog to commitRaw(file changed)`, () => {
       const mock = `commit a b (HEAD)
 Author: John Park <mail@gmail.com>
@@ -148,23 +146,9 @@ CommitDate: Sun Sep 4 20:17:59 2022 +0900
 \n${mockLog}
 `;
       const result = getCommitRaws(mock);
+      const expectedResult = { ...commonExpectatedResult, differenceStatistic: expectedFileChanged[index] };
 
-      expect(result).toEqual([
-        {
-          sequence: 0,
-          id: 'a',
-          parents: ['b'],
-          branches: ['HEAD'],
-          tags: [],
-          author: { name: 'John Park', email: 'mail@gmail.com' },
-          authorDate: new Date('Sun Sep 4 20:17:59 2022 +0900'),
-          committer: { name: 'John Park', email: 'mail@gmail.com' },
-          committerDate: new Date('Sun Sep 4 20:17:59 2022 +0900'),
-          message: 'commit message',
-          differenceStatistic: expectedBranches[index],
-          commitMessageType: ""
-        },
-      ]);
+      expect(result).toEqual([expectedResult]);
     });
   });
 });


### PR DESCRIPTION
## Related issue
#128

## Result
![image](https://github.com/githru/githru-vscode-ext/assets/107672313/480e7be8-fcc6-431e-9dbd-238e76eed59d)


## Work list
- git log에서 branches/ tags의 정보가 바뀔 경우, commit raw 테스트
(#169 에서 언급된 HEAD가 포인팅할 경우, HEAD값이 branch에 포함이 되는지에 대한 테스트도 포함하고 있습니다.)

- differenceStatistic(insert 되거나 delete된 파일들의 정보 모음)에 대한 테스트