### PR TITLE
feat(vscode): retry github auth if fails

### DIFF
--- a/packages/vscode/src/errors/ExtensionError.ts
+++ b/packages/vscode/src/errors/ExtensionError.ts
@@ -6,10 +6,7 @@ class WorkspacePathUndefinedError extends Error {
 }
 
 class GithubTokenUndefinedError extends Error {
-  constructor(
-    message: string,
-    public helpUrl: string
-  ) {
+  constructor(message: string) {
     super(message);
     this.name = "GithubTokenUndefinedError";
   }

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -37,7 +37,7 @@ export async function activate(context: vscode.ExtensionContext) {
       const initialBaseBranchName = getBaseBranchName(branchNames);
 
       const githubToken: string | undefined = await getGithubToken(secrets);
-      if (githubToken) {
+      if (!githubToken) {
         throw new GithubTokenUndefinedError("Cannot find your GitHub token. Retrying github authentication...");
       }
 

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -37,11 +37,8 @@ export async function activate(context: vscode.ExtensionContext) {
       const initialBaseBranchName = getBaseBranchName(branchNames);
 
       const githubToken: string | undefined = await getGithubToken(secrets);
-      if (!githubToken) {
-        throw new GithubTokenUndefinedError(
-          "Cannot find your GitHub token. For more details, please refer to",
-          "https://docs.github.com/en/enterprise-server@3.6/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens"
-        );
+      if (githubToken) {
+        throw new GithubTokenUndefinedError("Cannot find your GitHub token. Retrying github authentication...");
       }
 
       const fetchClusterNodes = async (baseBranchName = initialBaseBranchName) => {
@@ -68,11 +65,8 @@ export async function activate(context: vscode.ExtensionContext) {
       vscode.window.showInformationMessage("Hello Githru");
     } catch (error) {
       if (error instanceof GithubTokenUndefinedError) {
-        vscode.window.showInformationMessage(error.message, error.helpUrl).then((selection) => {
-          if (selection === (error as GithubTokenUndefinedError).helpUrl) {
-            vscode.env.openExternal(vscode.Uri.parse((error as GithubTokenUndefinedError).helpUrl));
-          }
-        });
+        vscode.window.showErrorMessage(error.message);
+        vscode.commands.executeCommand(COMMAND_LOGIN_WITH_GITHUB);
       } else if (error instanceof WorkspacePathUndefinedError) {
         vscode.window.showErrorMessage(error.message);
       } else {


### PR DESCRIPTION
## Related issue
#339 

## Result
<img width="524" alt="image" src="https://github.com/githru/githru-vscode-ext/assets/26860466/2eda12b9-50d1-4eb6-9575-18e3cf1a0f09">

- launch 과정에서 깃허브 토큰을 가져오는 동작이 실패할 경우 단순히 에러 메시지를 보여주는 것이 아닌 깃허브 인증 과정을 재시도 하도록 변경했습니다.