### PR TITLE
feat: implementing fetchBranchList

### DIFF
--- a/packages/view/src/App.tsx
+++ b/packages/view/src/App.tsx
@@ -20,22 +20,24 @@ import type { IDESentEvents } from "types/IDESentEvents";
 const App = () => {
   const initRef = useRef<boolean>(false);
 
-  const { filteredData, fetchAnalyzedData, loading, setLoading } = useGlobalData();
+  const { filteredData, fetchAnalyzedData, fetchBranchList, loading, setLoading } = useGlobalData();
 
   const ideAdapter = container.resolve<IDEPort>("IDEAdapter");
 
   useEffect(() => {
     if (initRef.current === false) {
       const callbacks: IDESentEvents = {
-        fetchAnalyzedData: fetchAnalyzedData,
+        fetchAnalyzedData,
+        fetchBranchList,
       };
 
       setLoading(true);
       ideAdapter.addIDESentEventListener(callbacks);
       ideAdapter.sendFetchAnalyzedDataMessage();
+      ideAdapter.sendGetBranchListMessage();
       initRef.current = true;
     }
-  }, [fetchAnalyzedData, ideAdapter, setLoading]);
+  }, [fetchBranchList, fetchAnalyzedData, ideAdapter, setLoading]);
 
   if (loading) {
     return (

--- a/packages/view/src/components/BranchSelector/BranchSelector.tsx
+++ b/packages/view/src/components/BranchSelector/BranchSelector.tsx
@@ -1,16 +1,13 @@
-import type { ChangeEventHandler } from "react";
+import { type ChangeEventHandler } from "react";
 import "./BranchSelector.scss";
 
-// TODO - webview로 sendBranchList command 호출
-const getDataList = () => {
-  return ["dev", "feat", "edit"];
-};
+import { useGlobalData } from "hooks";
 
 const BranchSelector = () => {
-  const branchList = getDataList();
-
-  const handleChangeSelect: ChangeEventHandler<HTMLSelectElement> = () => {
+  const { branchList, selectedBranch } = useGlobalData();
+  const handleChangeSelect: ChangeEventHandler<HTMLSelectElement> = (e) => {
     // TODO - webview로 선택된 branch을 payload에 실어 sendFetchAnalyzedDataCommand 호출
+    console.log(e.target.value);
   };
 
   return (
@@ -19,6 +16,7 @@ const BranchSelector = () => {
       <select
         className="select-box"
         onChange={handleChangeSelect}
+        value={selectedBranch}
       >
         {branchList.map((option) => (
           <option

--- a/packages/view/src/context/GlobalDataProvider.tsx
+++ b/packages/view/src/context/GlobalDataProvider.tsx
@@ -5,11 +5,20 @@ import { GlobalDataContext, type DateFilterRange } from "hooks";
 import type { ClusterNode } from "types";
 
 export const GlobalDataProvider = ({ children }: PropsWithChildren) => {
+  const [loading, setLoading] = useState(false);
+
   const [data, setData] = useState<ClusterNode[]>([]);
   const [filteredData, setFilteredData] = useState<ClusterNode[]>(data);
   const [selectedData, setSelectedData] = useState<ClusterNode[]>([]);
   const [filteredRange, setFilteredRange] = useState<DateFilterRange>(undefined);
-  const [loading, setLoading] = useState(false);
+
+  const [branchList, setBranchList] = useState<string[]>([]);
+  // TODO 초기에 base branch를 fetch해서 적용
+  const [selectedBranch, setSelectedBranch] = useState<string>("main");
+
+  const fetchBranchList = (branchList: string[]) => {
+    setBranchList(branchList);
+  };
 
   const fetchAnalyzedData = (analyzedData: ClusterNode[]) => {
     setData(analyzedData);
@@ -27,11 +36,16 @@ export const GlobalDataProvider = ({ children }: PropsWithChildren) => {
       setFilteredData,
       selectedData,
       setSelectedData,
-      fetchAnalyzedData,
       loading,
       setLoading,
+      branchList,
+      setBranchList,
+      selectedBranch,
+      setSelectedBranch,
+      fetchAnalyzedData,
+      fetchBranchList,
     }),
-    [data, filteredRange, filteredData, selectedData, loading]
+    [data, filteredRange, filteredData, selectedData, branchList, selectedBranch, loading]
   );
 
   return <GlobalDataContext.Provider value={value}>{children}</GlobalDataContext.Provider>;

--- a/packages/view/src/fake-assets/branch-list.json
+++ b/packages/view/src/fake-assets/branch-list.json
@@ -1,0 +1,1 @@
+["main", "develop", "release", "origin/HEAD"]

--- a/packages/view/src/hooks/useGlobalData.ts
+++ b/packages/view/src/hooks/useGlobalData.ts
@@ -1,8 +1,7 @@
-import type { Dispatch } from "react";
-import type React from "react";
+import type { Dispatch, SetStateAction } from "react";
 import { createContext, useContext } from "react";
 
-import type { ClusterNode } from "types";
+import type { ClusterNode, IDESentEvents } from "types";
 
 export type DateFilterRange =
   | {
@@ -16,13 +15,16 @@ type GlobalDataState = {
   filteredRange: DateFilterRange;
   filteredData: ClusterNode[];
   selectedData: ClusterNode[];
-  setFilteredData: Dispatch<React.SetStateAction<ClusterNode[]>>;
-  setSelectedData: Dispatch<React.SetStateAction<ClusterNode[]>>;
-  setFilteredRange: Dispatch<React.SetStateAction<DateFilterRange>>;
-  fetchAnalyzedData: (analyzedData: ClusterNode[]) => void;
+  setFilteredData: Dispatch<SetStateAction<ClusterNode[]>>;
+  setSelectedData: Dispatch<SetStateAction<ClusterNode[]>>;
+  setFilteredRange: Dispatch<SetStateAction<DateFilterRange>>;
   loading: boolean;
-  setLoading: Dispatch<React.SetStateAction<boolean>>;
-};
+  setLoading: Dispatch<SetStateAction<boolean>>;
+  branchList: string[];
+  setBranchList: Dispatch<SetStateAction<string[]>>;
+  selectedBranch: string;
+  setSelectedBranch: Dispatch<SetStateAction<string>>;
+} & IDESentEvents;
 
 export const GlobalDataContext = createContext<GlobalDataState | undefined>(undefined);
 

--- a/packages/view/src/ide/VSCodeIDEAdapter.ts
+++ b/packages/view/src/ide/VSCodeIDEAdapter.ts
@@ -1,6 +1,6 @@
 ﻿import { injectable } from "tsyringe";
 
-import type { ClusterNode, IDEMessage, IDEMessageEvent } from "types";
+import type { IDEMessage, IDEMessageEvent } from "types";
 import type { IDESentEvents } from "types/IDESentEvents";
 
 import type IDEPort from "./IDEPort";
@@ -11,11 +11,14 @@ export default class VSCodeIDEAdapter implements IDEPort {
   public addIDESentEventListener(events: IDESentEvents) {
     const onReceiveMessage = (e: IDEMessageEvent): void => {
       const responseMessage = e.data;
-      switch (responseMessage.command) {
+      const { command, payload } = responseMessage;
+      const payloadData = payload ? JSON.parse(payload) : undefined;
+
+      switch (command) {
         case "fetchAnalyzedData":
-          events.fetchAnalyzedData(JSON.parse(responseMessage.payload || "") as unknown as ClusterNode[]);
-          break;
+          return events.fetchAnalyzedData(payloadData);
         case "getBranchList":
+          return events.fetchBranchList(payloadData);
         default:
           console.log("Unknown Message");
       }

--- a/packages/view/src/types/IDESentEvents.ts
+++ b/packages/view/src/types/IDESentEvents.ts
@@ -3,4 +3,5 @@ import type { ClusterNode } from "types";
 // triggered by ide response
 export type IDESentEvents = {
   fetchAnalyzedData: (analyzedData: ClusterNode[]) => void;
+  fetchBranchList: (branchList: string[]) => void;
 };


### PR DESCRIPTION
## Related issue
- #276, #278

## Result
- 현 git repo의 branch list를 가져와 select box에 렌더링합니다.

![githru-pr](https://github.com/githru/githru-vscode-ext/assets/31684481/1cf190e4-1ecb-4b97-ba87-fd54200e79f4)

## Work list
- 초기 렌더링시 sendGetBranchListMessage 호출을 통해, BranchSelector options 값 렌더링
- FakeIDEAdaptor (view dev mode)에 필요한 branchList mock data 생성
- fetchBranchList에도 workspaceStore 적용
- 기타 vscode 리팩토링
  - storedAnalyzedData가 덮어쓰기 되는 부분 수정
  - 모든 parsing 함수는 특정 값을 return 하도록 하고, respondToMessage 메소드에서 일괄적으로 JSON.stringify를 적용하도록 수정
## Discussion
- base branch(처음 선택할 브랜치) 기준 -> default branch or HEAD?
- select box css...?