### PR TITLE
feat(view, vscode): implement branchSelector onChange handler

### DIFF
--- a/packages/view/src/App.tsx
+++ b/packages/view/src/App.tsx
@@ -20,24 +20,24 @@ import type { IDESentEvents } from "types/IDESentEvents";
 const App = () => {
   const initRef = useRef<boolean>(false);
 
-  const { filteredData, fetchAnalyzedData, fetchBranchList, loading, setLoading } = useGlobalData();
+  const { filteredData, handleChangeAnalyzedData, handleChangeBranchList, loading, setLoading } = useGlobalData();
 
   const ideAdapter = container.resolve<IDEPort>("IDEAdapter");
 
   useEffect(() => {
     if (initRef.current === false) {
       const callbacks: IDESentEvents = {
-        fetchAnalyzedData,
-        fetchBranchList,
+        handleChangeAnalyzedData,
+        handleChangeBranchList,
       };
 
       setLoading(true);
       ideAdapter.addIDESentEventListener(callbacks);
       ideAdapter.sendFetchAnalyzedDataMessage();
-      ideAdapter.sendGetBranchListMessage();
+      ideAdapter.sendFetchBranchListMessage();
       initRef.current = true;
     }
-  }, [fetchBranchList, fetchAnalyzedData, ideAdapter, setLoading]);
+  }, [handleChangeAnalyzedData, handleChangeBranchList, ideAdapter, setLoading]);
 
   if (loading) {
     return (

--- a/packages/view/src/components/BranchSelector/BranchSelector.tsx
+++ b/packages/view/src/components/BranchSelector/BranchSelector.tsx
@@ -2,12 +2,17 @@ import { type ChangeEventHandler } from "react";
 import "./BranchSelector.scss";
 
 import { useGlobalData } from "hooks";
+import { container } from "tsyringe";
+import type IDEPort from "ide/IDEPort";
 
 const BranchSelector = () => {
-  const { branchList, selectedBranch } = useGlobalData();
+  const { branchList, baseBranch, setBaseBranch, setLoading } = useGlobalData();
+
   const handleChangeSelect: ChangeEventHandler<HTMLSelectElement> = (e) => {
-    // TODO - webview로 선택된 branch을 payload에 실어 sendFetchAnalyzedDataCommand 호출
-    console.log(e.target.value);
+    setBaseBranch(e.target.value);
+    const ideAdapter = container.resolve<IDEPort>("IDEAdapter");
+    setLoading(true);
+    ideAdapter.sendFetchAnalyzedDataMessage(e.target.value);
   };
 
   return (
@@ -16,9 +21,9 @@ const BranchSelector = () => {
       <select
         className="select-box"
         onChange={handleChangeSelect}
-        value={selectedBranch}
+        value={baseBranch}
       >
-        {branchList.map((option) => (
+        {branchList?.map((option) => (
           <option
             key={option}
             value={option}

--- a/packages/view/src/components/BranchSelector/BranchSelector.tsx
+++ b/packages/view/src/components/BranchSelector/BranchSelector.tsx
@@ -2,17 +2,15 @@ import { type ChangeEventHandler } from "react";
 import "./BranchSelector.scss";
 
 import { useGlobalData } from "hooks";
-import { container } from "tsyringe";
-import type IDEPort from "ide/IDEPort";
+import { sendFetchAnalyzedDataCommand } from "services";
 
 const BranchSelector = () => {
-  const { branchList, baseBranch, setBaseBranch, setLoading } = useGlobalData();
+  const { branchList, selectedBranch, setSelectedBranch, setLoading } = useGlobalData();
 
   const handleChangeSelect: ChangeEventHandler<HTMLSelectElement> = (e) => {
-    setBaseBranch(e.target.value);
-    const ideAdapter = container.resolve<IDEPort>("IDEAdapter");
+    setSelectedBranch(e.target.value);
     setLoading(true);
-    ideAdapter.sendFetchAnalyzedDataMessage(e.target.value);
+    sendFetchAnalyzedDataCommand(e.target.value);
   };
 
   return (
@@ -21,7 +19,7 @@ const BranchSelector = () => {
       <select
         className="select-box"
         onChange={handleChangeSelect}
-        value={baseBranch}
+        value={selectedBranch}
       >
         {branchList?.map((option) => (
           <option

--- a/packages/view/src/components/RefreshButton/RefreshButton.tsx
+++ b/packages/view/src/components/RefreshButton/RefreshButton.tsx
@@ -10,13 +10,14 @@ import { useGlobalData } from "hooks";
 import "./RefreshButton.scss";
 
 const RefreshButton = () => {
-  const { loading, setLoading } = useGlobalData();
+  const { loading, setLoading, baseBranch } = useGlobalData();
 
   const refreshHandler = throttle(() => {
     setLoading(true);
 
     const ideAdapter = container.resolve<IDEPort>("IDEAdapter");
-    ideAdapter.sendFetchAnalyzedDataMessage();
+    ideAdapter.sendFetchAnalyzedDataMessage(baseBranch);
+    ideAdapter.sendFetchBranchListMessage();
   }, 3000);
 
   return (

--- a/packages/view/src/components/RefreshButton/RefreshButton.tsx
+++ b/packages/view/src/components/RefreshButton/RefreshButton.tsx
@@ -1,23 +1,19 @@
 import "reflect-metadata";
 import cn from "classnames";
-import { container } from "tsyringe";
 import { FiRefreshCcw } from "react-icons/fi";
 
 import { throttle } from "utils";
-import type IDEPort from "ide/IDEPort";
 import { useGlobalData } from "hooks";
 
 import "./RefreshButton.scss";
+import { sendRefreshDataCommand } from "services";
 
 const RefreshButton = () => {
-  const { loading, setLoading, baseBranch } = useGlobalData();
+  const { loading, setLoading, selectedBranch } = useGlobalData();
 
   const refreshHandler = throttle(() => {
     setLoading(true);
-
-    const ideAdapter = container.resolve<IDEPort>("IDEAdapter");
-    ideAdapter.sendFetchAnalyzedDataMessage(baseBranch);
-    ideAdapter.sendFetchBranchListMessage();
+    sendRefreshDataCommand(selectedBranch);
   }, 3000);
 
   return (

--- a/packages/view/src/context/GlobalDataProvider.tsx
+++ b/packages/view/src/context/GlobalDataProvider.tsx
@@ -13,10 +13,10 @@ export const GlobalDataProvider = ({ children }: PropsWithChildren) => {
   const [filteredRange, setFilteredRange] = useState<DateFilterRange>(undefined);
 
   const [branchList, setBranchList] = useState<string[]>([]);
-  const [baseBranch, setBaseBranch] = useState<string>(branchList?.[0]);
+  const [selectedBranch, setSelectedBranch] = useState<string>(branchList?.[0]);
 
   const handleChangeBranchList = (branches: { branchList: string[]; head: string | null }) => {
-    setBaseBranch((prev) => (!prev && branches.head ? branches.head : prev));
+    setSelectedBranch((prev) => (!prev && branches.head ? branches.head : prev));
     setBranchList(branches.branchList);
   };
 
@@ -40,12 +40,12 @@ export const GlobalDataProvider = ({ children }: PropsWithChildren) => {
       setLoading,
       branchList,
       setBranchList,
-      baseBranch,
-      setBaseBranch,
+      selectedBranch,
+      setSelectedBranch,
       handleChangeAnalyzedData,
       handleChangeBranchList,
     }),
-    [data, filteredRange, filteredData, selectedData, branchList, baseBranch, loading]
+    [data, filteredRange, filteredData, selectedData, branchList, selectedBranch, loading]
   );
 
   return <GlobalDataContext.Provider value={value}>{children}</GlobalDataContext.Provider>;

--- a/packages/view/src/context/GlobalDataProvider.tsx
+++ b/packages/view/src/context/GlobalDataProvider.tsx
@@ -13,14 +13,14 @@ export const GlobalDataProvider = ({ children }: PropsWithChildren) => {
   const [filteredRange, setFilteredRange] = useState<DateFilterRange>(undefined);
 
   const [branchList, setBranchList] = useState<string[]>([]);
-  // TODO 초기에 base branch를 fetch해서 적용
-  const [selectedBranch, setSelectedBranch] = useState<string>("main");
+  const [baseBranch, setBaseBranch] = useState<string>(branchList?.[0]);
 
-  const fetchBranchList = (branchList: string[]) => {
-    setBranchList(branchList);
+  const handleChangeBranchList = (branches: { branchList: string[]; head: string | null }) => {
+    setBaseBranch((prev) => (!prev && branches.head ? branches.head : prev));
+    setBranchList(branches.branchList);
   };
 
-  const fetchAnalyzedData = (analyzedData: ClusterNode[]) => {
+  const handleChangeAnalyzedData = (analyzedData: ClusterNode[]) => {
     setData(analyzedData);
     setFilteredData([...analyzedData.reverse()]);
     setSelectedData([]);
@@ -40,12 +40,12 @@ export const GlobalDataProvider = ({ children }: PropsWithChildren) => {
       setLoading,
       branchList,
       setBranchList,
-      selectedBranch,
-      setSelectedBranch,
-      fetchAnalyzedData,
-      fetchBranchList,
+      baseBranch,
+      setBaseBranch,
+      handleChangeAnalyzedData,
+      handleChangeBranchList,
     }),
-    [data, filteredRange, filteredData, selectedData, branchList, selectedBranch, loading]
+    [data, filteredRange, filteredData, selectedData, branchList, baseBranch, loading]
   );
 
   return <GlobalDataContext.Provider value={value}>{children}</GlobalDataContext.Provider>;

--- a/packages/view/src/hooks/useGlobalData.ts
+++ b/packages/view/src/hooks/useGlobalData.ts
@@ -22,8 +22,8 @@ type GlobalDataState = {
   setLoading: Dispatch<SetStateAction<boolean>>;
   branchList: string[];
   setBranchList: Dispatch<SetStateAction<string[]>>;
-  selectedBranch: string;
-  setSelectedBranch: Dispatch<SetStateAction<string>>;
+  baseBranch: string;
+  setBaseBranch: Dispatch<SetStateAction<string>>;
 } & IDESentEvents;
 
 export const GlobalDataContext = createContext<GlobalDataState | undefined>(undefined);

--- a/packages/view/src/hooks/useGlobalData.ts
+++ b/packages/view/src/hooks/useGlobalData.ts
@@ -22,8 +22,8 @@ type GlobalDataState = {
   setLoading: Dispatch<SetStateAction<boolean>>;
   branchList: string[];
   setBranchList: Dispatch<SetStateAction<string[]>>;
-  baseBranch: string;
-  setBaseBranch: Dispatch<SetStateAction<string>>;
+  selectedBranch: string;
+  setSelectedBranch: Dispatch<SetStateAction<string>>;
 } & IDESentEvents;
 
 export const GlobalDataContext = createContext<GlobalDataState | undefined>(undefined);

--- a/packages/view/src/ide/FakeIDEAdapter.ts
+++ b/packages/view/src/ide/FakeIDEAdapter.ts
@@ -18,9 +18,9 @@ export default class FakeIDEAdapter implements IDEPort {
 
       switch (command) {
         case "fetchAnalyzedData":
-          return events.fetchAnalyzedData(payloadData);
-        case "getBranchList":
-          return events.fetchBranchList(payloadData);
+          return events.handleChangeAnalyzedData(payloadData);
+        case "fetchBranchList":
+          return events.handleChangeBranchList(payloadData);
         default:
           console.log("Unknown Message");
       }
@@ -47,9 +47,9 @@ export default class FakeIDEAdapter implements IDEPort {
     }, 3000);
   }
 
-  public sendGetBranchListMessage() {
+  public sendFetchBranchListMessage() {
     const message: IDEMessage = {
-      command: "getBranchList",
+      command: "fetchBranchList",
     };
     this.sendMessageToMe(message);
   }
@@ -71,7 +71,7 @@ export default class FakeIDEAdapter implements IDEPort {
           command,
           payload: JSON.stringify(fakeData),
         };
-      case "getBranchList":
+      case "fetchBranchList":
         return {
           command,
           payload: JSON.stringify(fakeBranchList),

--- a/packages/view/src/ide/IDEPort.ts
+++ b/packages/view/src/ide/IDEPort.ts
@@ -9,6 +9,6 @@ export default interface IDEPort {
   addIDESentEventListener: (apiCallbacks: IDESentEvents) => void;
   sendRefreshDataMessage: (payload?: string) => void;
   sendFetchAnalyzedDataMessage: (payload?: string) => void;
-  sendGetBranchListMessage: () => void;
+  sendFetchBranchListMessage: () => void;
   setPrimaryColor: (color: string) => void;
 }

--- a/packages/view/src/ide/VSCodeIDEAdapter.ts
+++ b/packages/view/src/ide/VSCodeIDEAdapter.ts
@@ -16,9 +16,9 @@ export default class VSCodeIDEAdapter implements IDEPort {
 
       switch (command) {
         case "fetchAnalyzedData":
-          return events.fetchAnalyzedData(payloadData);
-        case "getBranchList":
-          return events.fetchBranchList(payloadData);
+          return events.handleChangeAnalyzedData(payloadData);
+        case "fetchBranchList":
+          return events.handleChangeBranchList(payloadData);
         default:
           console.log("Unknown Message");
       }
@@ -26,25 +26,25 @@ export default class VSCodeIDEAdapter implements IDEPort {
     window.addEventListener("message", onReceiveMessage);
   }
 
-  public sendRefreshDataMessage(payload?: string) {
+  public sendRefreshDataMessage(baseBranch?: string) {
     const message: IDEMessage = {
       command: "refresh",
-      payload,
+      payload: JSON.stringify(baseBranch),
     };
     this.sendMessageToIDE(message);
   }
 
-  public sendFetchAnalyzedDataMessage(payload?: string) {
+  public sendFetchAnalyzedDataMessage(baseBranch?: string) {
     const message: IDEMessage = {
       command: "fetchAnalyzedData",
-      payload,
+      payload: JSON.stringify(baseBranch),
     };
     this.sendMessageToIDE(message);
   }
 
-  public sendGetBranchListMessage() {
+  public sendFetchBranchListMessage() {
     const message: IDEMessage = {
-      command: "getBranchList",
+      command: "fetchBranchList",
     };
     this.sendMessageToIDE(message);
   }

--- a/packages/view/src/services/index.ts
+++ b/packages/view/src/services/index.ts
@@ -7,12 +7,18 @@ export const setPrimaryColor = (color: string) => {
   ideAdapter.setPrimaryColor(color);
 };
 
-export const sendFetchAnalyzedDataCommand = () => {
+export const sendFetchAnalyzedDataCommand = (selectedBranch?: string) => {
   const ideAdapter = container.resolve<IDEPort>("IDEAdapter");
-  ideAdapter.sendFetchAnalyzedDataMessage();
+  ideAdapter.sendFetchAnalyzedDataMessage(selectedBranch);
 };
 
-export const sendRefreshDataCommand = () => {
+export const sendRefreshDataCommand = (selectedBranch?: string) => {
   const ideAdapter = container.resolve<IDEPort>("IDEAdapter");
-  ideAdapter.sendRefreshDataMessage();
+  ideAdapter.sendRefreshDataMessage(selectedBranch);
+  ideAdapter.sendFetchBranchListMessage();
+};
+
+export const sendFetchBranchListCommand = () => {
+  const ideAdapter = container.resolve<IDEPort>("IDEAdapter");
+  ideAdapter.sendFetchBranchListMessage();
 };

--- a/packages/view/src/types/IDEMessage.ts
+++ b/packages/view/src/types/IDEMessage.ts
@@ -7,4 +7,9 @@ export interface IDEMessageEvent extends MessageEvent {
   data: IDEMessage;
 }
 
-export type IDEMessageCommandNames = "refresh" | "fetchAnalyzedData" | "getBranchList" | "updatePrimaryColor";
+export type IDEMessageCommandNames =
+  | "refresh"
+  | "fetchAnalyzedData"
+  | "fetchBranchList"
+  | "fetchCurrentBranch"
+  | "updatePrimaryColor";

--- a/packages/view/src/types/IDESentEvents.ts
+++ b/packages/view/src/types/IDESentEvents.ts
@@ -2,6 +2,6 @@ import type { ClusterNode } from "types";
 
 // triggered by ide response
 export type IDESentEvents = {
-  fetchAnalyzedData: (analyzedData: ClusterNode[]) => void;
-  fetchBranchList: (branchList: string[]) => void;
+  handleChangeAnalyzedData: (analyzedData: ClusterNode[]) => void;
+  handleChangeBranchList: (branches: { branchList: string[]; head: string | null }) => void;
 };

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -6,7 +6,15 @@ import { Credentials } from "./credentials";
 import { GithubTokenUndefinedError, WorkspacePathUndefinedError } from "./errors/ExtensionError";
 import { getGithubToken, setGithubToken } from "./setting-repository";
 import { mapClusterNodesFrom } from "./utils/csm.mapper";
-import { findGit, getBranches, getCurrentBranchName, getGitConfig, getGitLog, getRepo } from "./utils/git.util";
+import {
+  findGit,
+  getBranches,
+  getCurrentBranchName,
+  getDefaultBranchName,
+  getGitConfig,
+  getGitLog,
+  getRepo,
+} from "./utils/git.util";
 import WebviewLoader from "./webview-loader";
 
 let myStatusBarItem: vscode.StatusBarItem;
@@ -39,7 +47,14 @@ export async function activate(context: vscode.ExtensionContext) {
       }
 
       const fetchBranches = async () => await getBranches(gitPath, currentWorkspacePath);
-      const fetchCurrentBranch = async () => await getCurrentBranchName(gitPath, currentWorkspacePath);
+      const fetchCurrentBranch = async () => {
+        let branchName = await getCurrentBranchName(gitPath, currentWorkspacePath);
+        if (!branchName) {
+          const branchList = (await fetchBranches()).branchList;
+          branchName = getDefaultBranchName(branchList);
+        }
+        return branchName;
+      };
 
       const initialBaseBranchName = await fetchCurrentBranch();
       const fetchClusterNodes = async (baseBranchName = initialBaseBranchName) => {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -6,7 +6,7 @@ import { Credentials } from "./credentials";
 import { GithubTokenUndefinedError, WorkspacePathUndefinedError } from "./errors/ExtensionError";
 import { getGithubToken, setGithubToken } from "./setting-repository";
 import { mapClusterNodesFrom } from "./utils/csm.mapper";
-import { findGit, getBaseBranchName, getBranchNames, getGitConfig, getGitLog, getRepo } from "./utils/git.util";
+import { findGit, getBranches, getCurrentBranchName, getGitConfig, getGitLog, getRepo } from "./utils/git.util";
 import WebviewLoader from "./webview-loader";
 
 let myStatusBarItem: vscode.StatusBarItem;
@@ -38,18 +38,10 @@ export async function activate(context: vscode.ExtensionContext) {
         throw new GithubTokenUndefinedError("Cannot find your GitHub token. Retrying github authentication...");
       }
 
-      const fetchBranchList = async () => {
-        const storedBranchList = context.workspaceState.get<string[]>("branchList") ?? [];
-        context.workspaceState.update(
-          "branchList",
-          (await getBranchNames(gitPath, currentWorkspacePath)) ?? storedBranchList
-        );
-        return context.workspaceState.get<string[]>("branchList") ?? storedBranchList;
-      };
+      const fetchBranches = async () => await getBranches(gitPath, currentWorkspacePath);
+      const fetchCurrentBranch = async () => await getCurrentBranchName(gitPath, currentWorkspacePath);
 
-      const branchNames = await fetchBranchList();
-      const initialBaseBranchName = getBaseBranchName(branchNames);
-
+      const initialBaseBranchName = await fetchCurrentBranch();
       const fetchClusterNodes = async (baseBranchName = initialBaseBranchName) => {
         const gitLog = await getGitLog(gitPath, currentWorkspacePath);
         const gitConfig = await getGitConfig(gitPath, currentWorkspacePath, "origin");
@@ -67,7 +59,11 @@ export async function activate(context: vscode.ExtensionContext) {
         return clusterNodes;
       };
 
-      const webLoader = new WebviewLoader(extensionPath, context, fetchClusterNodes, fetchBranchList);
+      const webLoader = new WebviewLoader(extensionPath, context, {
+        fetchClusterNodes,
+        fetchBranches,
+        fetchCurrentBranch,
+      });
 
       subscriptions.push(webLoader);
       vscode.window.showInformationMessage("Hello Githru");

--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -248,11 +248,14 @@ export async function getBranches(
       .replace(/(.*) -> (?:.*)/g, "$1")
       .replace("remotes/", "");
     if (branch.startsWith("* ")) {
+      if (branch.includes("HEAD detached")) continue;
       branch = branch.replace("* ", "");
       head = branch;
     }
     branchList.push(branch);
   }
+
+  if (!head) head = getDefaultBranchName(branchList);
 
   return { branchList, head };
 }

--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -222,42 +222,54 @@ export const getRepo = (gitRemoteConfig: string) => {
   return { owner, repo };
 };
 
-export async function getBranchNames(path: string, repo: string): Promise<string[]> {
-  return new Promise((resolve, reject) => {
-    resolveSpawnOutput(
-      cp.spawn(path, ["branch", "-a"], {
-        cwd: repo,
-        env: Object.assign({}, process.env),
-      })
-    ).then((values) => {
-      const [status, stdout, stderr] = values;
-      if (status.code === 0) {
-        const branches = stdout
-          .toString()
-          .split("\n")
-          .map((name) =>
-            name
-              .replace("*", "") // delete * prefix
-              .replace("remotes/", "") // delete remotes/ prifix
-              .replace(/(.*) -> (?:.*)/g, "$1") // remote HEAD parsing
-              .trim()
-          )
-          .filter((name) => !!name);
-        resolve(branches);
-      } else {
-        reject(stderr);
-      }
-    });
-  });
+export async function getBranches(
+  path: string,
+  repo: string
+): Promise<{
+  branchList: string[];
+  head: string | null;
+}> {
+  let head = null;
+  const branchList = [];
+
+  const [status, stdout, stderr] = await resolveSpawnOutput(
+    cp.spawn(path, ["branch", "-a"], {
+      cwd: repo,
+      env: Object.assign({}, process.env),
+    })
+  );
+
+  if (status.code !== 0) throw stderr;
+
+  const branches = stdout.toString().split(/\r\n|\r|\n/g);
+  for (let branch of branches) {
+    branch = branch
+      .trim()
+      .replace(/(.*) -> (?:.*)/g, "$1")
+      .replace("remotes/", "");
+    if (branch.startsWith("* ")) {
+      branch = branch.replace("* ", "");
+      head = branch;
+    }
+    branchList.push(branch);
+  }
+
+  return { branchList, head };
 }
 
-export function getBaseBranchName(branchNames: string[]): string {
-  for (const name of branchNames) {
-    if (name === "main") {
-      return "main";
-    } else if (name === "master") {
-      return "master";
-    }
-  }
-  return branchNames[0];
+export function getDefaultBranchName(branchList: string[]): string {
+  const branchSet = new Set(branchList);
+  return branchSet.has("main") ? "main" : branchSet.has("master") ? "master" : branchList?.[0];
+}
+
+export async function getCurrentBranchName(path: string, repo: string): Promise<string> {
+  const [status, stdout, stderr] = await resolveSpawnOutput(
+    cp.spawn(path, ["branch", "--show-current"], {
+      cwd: repo,
+      env: Object.assign({}, process.env),
+    })
+  );
+
+  if (status.code !== 0) throw stderr;
+  return stdout.toString().trim();
 }


### PR DESCRIPTION
## Related issue
- #276

## Result
- 초기 base branch는 현재 local repository의 HEAD 위치 (git branch --show-current)
  - view 영역에서는 current branch를 따로 호출하지 않고 git branchList를 호출하면서 현재 head가 가리키고 있는 branch 전달 받음
- branch selector를 통해 base branch 변경

![githru](https://github.com/githru/githru-vscode-ext/assets/31684481/ca6da831-21be-4d0e-b2ea-bb6559b33f0a)

## Work list
- vscode git util 함수 변경
  - getCurrentBranch 함수 생성
    - `git branch --show-current`결과 값 return
  - getBranches 함수 변경
    - 단순 branchList만 return하던 구조에서 -> 현재 HEAD가 위치한 branch도 함께 반환
- BranchSelector onChange handler 구현
- 기타 리뷰 반영

## Discussion
- BranchSelector에서 현재 작업하고 있는 브랜치(HEAD)에 대한 특정 표시의 필요성 논의?
- vscode 타입 정리 -> vscode도 진행하고 있는지는 모르겠지만, 오프라인 회의나 리뷰 후 정리 되면 아래 타입 추가된 타입 내용 파일로 따로 빼겠습니다 :).
```ts
type GithruFetcher<D = unknown, P extends unknown[] = []> = (...params: P) => Promise<D>;
type GithruFetcherMap = {
  fetchClusterNodes: GithruFetcher<ClusterNode[], [string]>;
  fetchBranches: GithruFetcher<{ branchList: string[]; head: string | null }>;
  fetchCurrentBranch: GithruFetcher<string>;
};
```
> [!note]
> 추가적인 .git 디렉토리 관련 파일의 추가/변경에 대한 추적 필요성? https://vshaxe.github.io/vscode-extern/vscode/FileSystemWatcher.html