### PR TITLE
feat(view): drawSubGraph function without any relationship between commits &  e2e test to click on cluster

### DIFF
--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.hook.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.hook.tsx
@@ -27,7 +27,7 @@ const drawClusterGraph = (
     .attr("class", "cluster-graph__container")
     .attr("transform", (d, i) => getTranslateAfterSelect(d, i, detailElementHeight, true));
 
-  group.append("title").text((_, i) => `${i + 1}번째 container`);
+  group.append("title").text((_, i) => `${i + 1} container`);
 
   group
     .transition()

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.hook.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.hook.tsx
@@ -41,11 +41,9 @@ const drawClusterGraph = (
 
 export const useHandleClusterGraph = ({
   data,
-  clusterSizes,
   selectedIndex,
   setSelectedData,
 }: {
-  clusterSizes: number[];
   selectedIndex: number[];
   data: ClusterNode[];
   setSelectedData: Dispatch<React.SetStateAction<ClusterNode[]>>;
@@ -53,9 +51,9 @@ export const useHandleClusterGraph = ({
   const svgRef = useRef<SVGSVGElement>(null);
   const prevSelected = useRef<number[]>([-1]);
 
-  const clusterGraphElements = data.map((cluster, i) => ({
+  const clusterGraphElements = data.map((cluster) => ({
     cluster,
-    clusterSize: clusterSizes[i],
+    clusterSize: cluster.commitNodeList.length,
     selected: {
       prev: prevSelected.current,
       current: selectedIndex,

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.hook.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.hook.tsx
@@ -9,7 +9,7 @@ import { selectedDataUpdater } from "../VerticalClusterList.util";
 
 import { CLUSTER_HEIGHT, DETAIL_HEIGHT, GRAPH_WIDTH, NODE_GAP, SVG_MARGIN } from "./ClusterGraph.const";
 import type { ClusterGraphElement } from "./ClusterGraph.type";
-import { destroyClusterGraph, drawClusterBox, drawCommitAmountCluster, drawTotalLine } from "./Draws";
+import { destroyClusterGraph, drawClusterBox, drawCommitAmountCluster, drawSubGraph, drawTotalLine } from "./Draws";
 import { getTranslateAfterSelect } from "./ClusterGraph.util";
 
 const drawClusterGraph = (
@@ -34,9 +34,10 @@ const drawClusterGraph = (
     .duration(0)
     .attr("transform", (d, i) => getTranslateAfterSelect(d, i, detailElementHeight));
 
-  drawTotalLine(svgRef, data, detailElementHeight, SVG_MARGIN, CLUSTER_HEIGHT, NODE_GAP, GRAPH_WIDTH);
   drawClusterBox(group, GRAPH_WIDTH, CLUSTER_HEIGHT);
   drawCommitAmountCluster(group, GRAPH_WIDTH, CLUSTER_HEIGHT);
+  drawSubGraph(svgRef, data, detailElementHeight);
+  drawTotalLine(svgRef, data, detailElementHeight, SVG_MARGIN, CLUSTER_HEIGHT, NODE_GAP, GRAPH_WIDTH);
 };
 
 export const useHandleClusterGraph = ({
@@ -61,8 +62,10 @@ export const useHandleClusterGraph = ({
   }));
 
   const handleClickCluster = useCallback(
-    (_: PointerEvent, d: ClusterGraphElement) =>
-      setSelectedData(selectedDataUpdater(d.cluster, d.cluster.commitNodeList[0].clusterId)),
+    (_: PointerEvent, d: ClusterGraphElement) => {
+      const targetIndex = d.cluster.commitNodeList[0].clusterId;
+      setSelectedData(selectedDataUpdater(d.cluster, targetIndex));
+    },
     [setSelectedData]
   );
   useEffect(() => {

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
@@ -24,3 +24,7 @@
   stroke: var(--primary-color);
   stroke-width: 1;
 }
+
+.circle-group {
+  fill: var(--primary-color);
+}

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -14,7 +14,6 @@ const ClusterGraph = () => {
 
   const svgRef = useHandleClusterGraph({
     data,
-    clusterSizes,
     selectedIndex,
     setSelectedData,
   });

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.util.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.util.ts
@@ -11,11 +11,20 @@ export function getGraphHeight(clusterSizes: number[]) {
   return clusterSizes.length * CLUSTER_HEIGHT + clusterSizes.length * NODE_GAP + NODE_GAP;
 }
 
+export function getStartYEndY(d: ClusterGraphElement, a: number, detailElementHeight: number) {
+  const selected = d.selected.current;
+  const selectedLength = selected.filter((selectedIdx) => selectedIdx < a).length;
+  const selectedLongerHeight = selectedLength * detailElementHeight;
+  const startY = SVG_MARGIN.top + 20 + (a + 1) * (CLUSTER_HEIGHT + NODE_GAP) + selectedLongerHeight;
+  const endY = startY + detailElementHeight - 50;
+  return { startY, endY };
+}
+
 export function getTranslateAfterSelect(
   d: ClusterGraphElement,
   i: number,
   detailElementHeight: number,
-  isPrev = false
+  isPrev = false // TODO - 해당 인자를 개선해야할듯
 ) {
   const selected = isPrev ? d.selected.prev : d.selected.current;
   const selectedLength = selected.filter((selectedIdx) => selectedIdx < i).length;

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.util.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.util.ts
@@ -24,7 +24,7 @@ export function getTranslateAfterSelect(
   d: ClusterGraphElement,
   i: number,
   detailElementHeight: number,
-  isPrev = false // TODO - 해당 인자를 개선해야할듯
+  isPrev = false // TODO - this param can be removed
 ) {
   const selected = isPrev ? d.selected.prev : d.selected.current;
   const selectedLength = selected.filter((selectedIdx) => selectedIdx < i).length;

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/Draws/drawSubGraph.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/Draws/drawSubGraph.ts
@@ -1,0 +1,73 @@
+import * as d3 from "d3";
+import type { RefObject } from "react";
+
+import type { ClusterGraphElement } from "../ClusterGraph.type";
+import { getStartYEndY } from "../ClusterGraph.util";
+import { GRAPH_WIDTH } from "../ClusterGraph.const";
+
+// create tootip (HTML)
+const tooltip = d3
+  .select("body")
+  .append("div")
+  .attr("class", "tooltip")
+  .style("position", "absolute")
+  .style("z-index", "10")
+  .style("visibility", "hidden")
+  .text("Tooltip");
+
+const calculateCirclePositions = (numOfCircles: number, startY: number, endY: number, gap: number) => {
+  const positionStrategies = new Map<number, (start: number, end: number) => number[]>([
+    [1, (start, end) => [(start + end) / 2]],
+    [2, (start, end) => [(3 * start + end) / 4, (start + 3 * end) / 4]],
+  ]);
+
+  const strategy = positionStrategies.get(numOfCircles);
+
+  return strategy ? strategy(startY, endY) : Array.from({ length: numOfCircles }, (_, i) => startY + i * gap);
+};
+
+export const drawSubGraph = (
+  svgRef: RefObject<SVGSVGElement>,
+  data: ClusterGraphElement[],
+  detailElementHeight: number
+) => {
+  const allCirclePositions = data.reduce(
+    (acc, clusterData, index) => {
+      if (clusterData.selected.current.includes(index)) {
+        const { startY, endY } = getStartYEndY(clusterData, index, detailElementHeight);
+        const numOfCircles = clusterData.cluster.commitNodeList.length;
+        const gap = (endY - startY) / (numOfCircles - 1);
+        const circlePositions = calculateCirclePositions(numOfCircles, startY, endY, gap);
+
+        const enrichedPositions = circlePositions.map((y, circleIndex) => ({ y, clusterData, circleIndex }));
+        return acc.concat(enrichedPositions);
+      }
+      return acc;
+    },
+    [] as Array<{ y: number; clusterData: ClusterGraphElement; circleIndex: number }>
+  );
+
+  const circleRadius = 5;
+
+  d3.select(svgRef.current)
+    .selectAll(".circle-group")
+    .data(allCirclePositions)
+    .join("circle")
+    .attr("class", "circle-group")
+    .attr("cx", GRAPH_WIDTH / 2 + 2)
+    .attr("cy", (d) => d.y)
+    .attr("r", circleRadius)
+    .on("mouseover", (_, { clusterData, circleIndex }) => {
+      const { commitNodeList } = clusterData.cluster;
+      const targetIndex = commitNodeList.length - 1 - circleIndex;
+      const info = commitNodeList[targetIndex].commit.message;
+      tooltip.text(info);
+      return tooltip.style("visibility", "visible");
+    })
+    .on("mousemove", (event) => {
+      return tooltip.style("top", `${event.pageY - 10}px`).style("left", `${event.pageX + 10}px`);
+    })
+    .on("mouseout", () => {
+      return tooltip.style("visibility", "hidden");
+    });
+};

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/Draws/drawTotalLine.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/Draws/drawTotalLine.ts
@@ -33,5 +33,6 @@ export const drawTotalLine = (
     .attr("x2", svgMargin.left + graphWidth / 2)
     .attr("y2", (d) => d.end + d.selected.prev.length * detailElementHeight)
     .transition()
-    .attr("y2", (d) => d.end + d.selected.current.length * detailElementHeight);
+    .attr("y2", (d) => d.end + d.selected.current.length * detailElementHeight)
+    .attr("pointer-events", "none");
 };

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/Draws/index.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/Draws/index.ts
@@ -2,3 +2,4 @@ export * from "./drawClusterBox";
 export * from "./drawCommitAmountCluster";
 export * from "./drawTotalLine";
 export * from "./destroyClusterGraph";
+export * from "./drawSubGraph";

--- a/packages/view/src/ide/FakeIDEAdapter.ts
+++ b/packages/view/src/ide/FakeIDEAdapter.ts
@@ -14,7 +14,21 @@ export default class FakeIDEAdapter implements IDEPort {
     const onReceiveMessage = (e: IDEMessageEvent): void => {
       const responseMessage = e.data;
       const { command, payload } = responseMessage;
-      const payloadData = payload ? JSON.parse(payload) : undefined;
+      let payloadData;
+
+      // payload에서 string으로 올때 있고 object로 올때 있음 이건 잡아줘야하는 버그인데 당분간 못 잡지 않을까 ...
+      if (typeof payload === "string") {
+        try {
+          payloadData = JSON.parse(payload);
+        } catch (error) {
+          console.error("Error parsing JSON:", error);
+          payloadData = payload; // JSON 파싱 실패시 원래 문자열 사용
+        }
+      } else if (typeof payload === "object") {
+        payloadData = payload; // 이미 객체인 경우 그대로 사용
+      } else {
+        payloadData = undefined; // 그 외의 경우, undefined로 설정
+      }
 
       switch (command) {
         case "fetchAnalyzedData":

--- a/packages/view/src/ide/FakeIDEAdapter.ts
+++ b/packages/view/src/ide/FakeIDEAdapter.ts
@@ -14,21 +14,7 @@ export default class FakeIDEAdapter implements IDEPort {
     const onReceiveMessage = (e: IDEMessageEvent): void => {
       const responseMessage = e.data;
       const { command, payload } = responseMessage;
-      let payloadData;
-
-      // payload에서 string으로 올때 있고 object로 올때 있음 이건 잡아줘야하는 버그인데 당분간 못 잡지 않을까 ...
-      if (typeof payload === "string") {
-        try {
-          payloadData = JSON.parse(payload);
-        } catch (error) {
-          console.error("Error parsing JSON:", error);
-          payloadData = payload; // JSON 파싱 실패시 원래 문자열 사용
-        }
-      } else if (typeof payload === "object") {
-        payloadData = payload; // 이미 객체인 경우 그대로 사용
-      } else {
-        payloadData = undefined; // 그 외의 경우, undefined로 설정
-      }
+      const payloadData = command && payload ? JSON.parse(payload) : undefined;
 
       switch (command) {
         case "fetchAnalyzedData":

--- a/packages/view/tests/home.spec.ts
+++ b/packages/view/tests/home.spec.ts
@@ -1,11 +1,46 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("home", () => {
+  const CLICK_INDEX = 0;
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
   });
 
   test("has title", async ({ page }) => {
     await expect(page).toHaveTitle(/Githru/);
+  });
+
+  test("when click cluster", async ({ page }) => {
+    await page.waitForSelector(".cluster-graph");
+
+    await page.waitForSelector(".cluster-graph > .cluster-graph__container", { state: "attached" });
+
+    const childContainers = await page.$$(".cluster-graph > .cluster-graph__container");
+
+    if (childContainers.length > CLICK_INDEX) {
+      await childContainers[CLICK_INDEX].scrollIntoViewIfNeeded();
+      await childContainers[CLICK_INDEX].click();
+    } else {
+      throw new Error("No child containers found");
+    }
+
+    // waiting for changing
+    await page.waitForTimeout(1000);
+
+    const newChildContainers = await page.$$(".cluster-graph > .cluster-graph__container");
+
+    const targetIndexForCheck = CLICK_INDEX + 1;
+    const transformPositionForCheck = 10 + targetIndexForCheck * 50 + 220;
+    if (newChildContainers.length > targetIndexForCheck) {
+      const transformValue = await newChildContainers[targetIndexForCheck].getAttribute("transform");
+
+      if (transformValue !== null) {
+        expect(transformValue).toBe(`translate(2, ${transformPositionForCheck})`);
+      } else {
+        throw new Error("Transform attribute not found");
+      }
+    } else {
+      throw new Error("Not enough child containers found");
+    }
   });
 });

--- a/packages/view/tsconfig.json
+++ b/packages/view/tsconfig.json
@@ -39,7 +39,9 @@
     } /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": [
+      "@playwright/test"
+    ] /* Specify type package names to be included without being referenced in a source file. */,
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     "resolveJsonModule": true /* Enable importing .json files. */,


### PR DESCRIPTION
## Related issue

subGraph

## Result
- subGraph 화면
![image](https://github.com/githru/githru-vscode-ext/assets/66891085/df72fef4-073b-48b3-b0c3-8b391ee258e0)

- e2e test report(transform test, subGraph(x))
![image](https://github.com/githru/githru-vscode-ext/assets/66891085/750a545f-9423-47b7-a4f2-264894104662)

## Work list
- 이전 리팩토링 피드백 반영
- drawSubGraph function
- circle styling
- getStartYEndY util function
- e2e test to click on cluster(transform test, subGraph(x))

## Discussion
- subGraph에 각 commits 의 관계성을 갖는 선은 추가할 계획이긴 합니다.
- 기타 외 다른 개발 아이디어나 현재 UI상에서도 개선점이 있다면 의견 부탁드립니다!