### PR TITLE
Fix: allow github token in gitRemote

### DIFF
--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -208,7 +208,7 @@ export async function getGitConfig(
 
 export const getRepo = (gitRemoteConfig: string) => {
   const gitRemoteConfigPattern =
-    /(?:https?|git)(?::\/\/(?:\w+@)?|@)(?:github\.com)(?:\/|:)(?:(?<owner>.+?)\/(?<repo>.+?))(?:\.git|\/)?$/m;
+    /(?:https?|git)(?::\/\/(?:\w+@)?|@)(?:github\.com)(?:\/|:)(?:(?<owner>.+?)\/(?<repo>.+?))(?:\.git|\/)?(\S*)$/m;
   const gitRemote = gitRemoteConfig.match(gitRemoteConfigPattern)?.groups;
   if (!gitRemote) {
     throw new Error("git remote config should be: [https?://|git@]${domain}/${owner}/${repo}.git");


### PR DESCRIPTION
#366  에 대한 해결입니다. 
gitRemote 정규식이 토큰이 포함되어있을 때도 허용되는 정규식 패턴으로 수정되었습니다. 