### PR TITLE
fix(view): commit 중복 bug fix

### DIFF
--- a/packages/view/src/components/Detail/Detail.hook.tsx
+++ b/packages/view/src/components/Detail/Detail.hook.tsx
@@ -13,9 +13,9 @@ const useToggleHook = (init = false): UseToggleHook => {
 
 export const useCommitListHide = (commitNodeListInCluster: CommitNode[]) => {
   const list = getSummaryCommitList(commitNodeListInCluster).reverse();
-  const strech = commitNodeListInCluster.slice(5, commitNodeListInCluster.length).reverse();
+  const strech = commitNodeListInCluster.reverse();
   const [toggle, handleToggle] = useToggleHook();
-  const commitNodeList = toggle ? [...list, ...strech] : list;
+  const commitNodeList = toggle ? strech : list;
 
   return {
     toggle,


### PR DESCRIPTION
## Related issue
#507

## Result
전: 
![고치기 전](https://github.com/githru/githru-vscode-ext/assets/107672313/0c5fc6af-b31e-4f3d-a1a6-5d9fd80369fb)
후: 
![고친후](https://github.com/githru/githru-vscode-ext/assets/107672313/c843f845-8a47-4b8c-a3eb-f64102c7e137)


## Discussion
서브 그래프와 순서가 반대라, 헷갈릴 수 있을 것 같습니다.