### PR TITLE
feat(vscode): #321 githru 열리기 전까지 progress 표시

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -33,6 +33,7 @@ export async function activate(context: vscode.ExtensionContext) {
   console.log('Congratulations, your extension "githru" is now active!');
 
   const disposable = vscode.commands.registerCommand(COMMAND_LAUNCH, async () => {
+    myStatusBarItem.text = "$(sync~spin) githru";
     try {
       console.debug("current Panel = ", currentPanel, currentPanel?.onDidDispose);
       if (currentPanel) {
@@ -100,12 +101,14 @@ export async function activate(context: vscode.ExtensionContext) {
       currentPanel?.onDidDispose(
         () => {
           currentPanel = undefined;
+          myStatusBarItem.text = "githru";
         },
         null,
         context.subscriptions
       );
 
       subscriptions.push(webLoader);
+      myStatusBarItem.text = "$(check) githru";
       vscode.window.showInformationMessage("Hello Githru");
     } catch (error) {
       if (error instanceof GithubTokenUndefinedError) {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -38,6 +38,7 @@ export async function activate(context: vscode.ExtensionContext) {
       console.debug("current Panel = ", currentPanel, currentPanel?.onDidDispose);
       if (currentPanel) {
         currentPanel.reveal();
+        myStatusBarItem.text = "$(check) githru";
         return;
       }
       const gitPath = (await findGit()).path;

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -18,6 +18,7 @@ import {
 import WebviewLoader from "./webview-loader";
 
 let myStatusBarItem: vscode.StatusBarItem;
+const projectName = 'githru';
 
 function normalizeFsPath(fsPath: string) {
   return fsPath.replace(/\\/g, "/");
@@ -33,12 +34,12 @@ export async function activate(context: vscode.ExtensionContext) {
   console.log('Congratulations, your extension "githru" is now active!');
 
   const disposable = vscode.commands.registerCommand(COMMAND_LAUNCH, async () => {
-    myStatusBarItem.text = "$(sync~spin) githru";
+    myStatusBarItem.text = `$(sync~spin) ${projectName}`;
     try {
       console.debug("current Panel = ", currentPanel, currentPanel?.onDidDispose);
       if (currentPanel) {
         currentPanel.reveal();
-        myStatusBarItem.text = "$(check) githru";
+        myStatusBarItem.text = `$(check) ${projectName}`;
         return;
       }
       const gitPath = (await findGit()).path;
@@ -102,14 +103,14 @@ export async function activate(context: vscode.ExtensionContext) {
       currentPanel?.onDidDispose(
         () => {
           currentPanel = undefined;
-          myStatusBarItem.text = "githru";
+          myStatusBarItem.text = projectName;
         },
         null,
         context.subscriptions
       );
 
       subscriptions.push(webLoader);
-      myStatusBarItem.text = "$(check) githru";
+      myStatusBarItem.text = `$(check) ${projectName}`;
       vscode.window.showInformationMessage("Hello Githru");
     } catch (error) {
       if (error instanceof GithubTokenUndefinedError) {
@@ -141,7 +142,7 @@ export async function activate(context: vscode.ExtensionContext) {
   subscriptions.concat([disposable, loginWithGithub, resetGithubAuth]);
 
   myStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -10);
-  myStatusBarItem.text = "githru";
+  myStatusBarItem.text = projectName;
   myStatusBarItem.command = COMMAND_LAUNCH;
   subscriptions.push(myStatusBarItem);
 


### PR DESCRIPTION
## Related issue
#321 [vscode] githru 열리기 전까지 progress 표시

## Result
- githru 버튼을 누른 후 패널이 뜨기 전까지 githru 버튼 옆에 스피너가 표시됩니다.
- 패널이 뜨게 되면 githru 버튼 옆에 체크 표시가 됩니다.
- 패널을 닫으면 버튼이 처음 상태로 돌아옵니다. 

## Work list
#### 패널이 열리기 전 / 닫은 후
![image](https://github.com/user-attachments/assets/45235ed0-f7df-4281-925b-b08800f09c66)

#### 패널이 뜨는 중
![image](https://github.com/user-attachments/assets/26899522-fa12-4f82-80d2-15e8e9b1f51c)

#### 패널이 뜬 후
![image](https://github.com/user-attachments/assets/2c51501f-4670-4132-a364-3f77b6f7bae5)

## Discussion
로딩 시 스피너 외에 패널이 뜬 후 패널이 없을 때와 구분을 위해 체크 progress를 추가 하였습니다.

## Reference 
[visualstuido 공식문서]
https://code.visualstudio.com/api/references/icons-in-labels
https://code.visualstudio.com/api/ux-guidelines/status-bar
https://code.visualstudio.com/api/references/vscode-api#StatusBarItem


