### PR TITLE
fix(view): #540 Total Commit 그래프에 마우스 over, move 시 깜빡임

### DIFF
--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -84,7 +84,7 @@ const AuthorBarChart = () => {
     const handleMouseMove = (e: MouseEvent<SVGRectElement | SVGTextElement>, d: AuthorDataType) => {
       tooltip
         .style("left", `${e.pageX - 70}px`)
-        .style("top", `${e.pageY - 70}px`)
+        .style("top", `${e.pageY - 90}px`)
         .html(
           `<p class="name">${d.name}</p>
               <p>${metric}: 

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -78,11 +78,9 @@ const AuthorBarChart = () => {
       .text(`${metric} # / Total ${metric} # (%)`);
 
     // Event handler
-    const handleMouseOver = () => {
-      tooltip.style("display", "inline-block");
-    };
-    const handleMouseMove = (e: MouseEvent<SVGRectElement | SVGTextElement>, d: AuthorDataType) => {
+    const handleMouseOver = (e: MouseEvent<SVGRectElement | SVGTextElement>, d: AuthorDataType) => {
       tooltip
+        .style("display", "inline-block")
         .style("left", `${e.pageX - 70}px`)
         .style("top", `${e.pageY - 90}px`)
         .html(
@@ -95,6 +93,10 @@ const AuthorBarChart = () => {
                 (${((d[metric] / totalMetricValues) * 100).toFixed(1)}%) 
               </p>`
         );
+    };
+
+    const handleMouseMove = (e: MouseEvent<SVGRectElement | SVGTextElement>) => {
+      tooltip.style("left", `${e.pageX - 70}px`).style("top", `${e.pageY - 90}px`);
     };
     const handleMouseOut = () => {
       tooltip.style("display", "none");


### PR DESCRIPTION
## Related issue
#540 [view] Total Commit 그래프에 마우스 호버 시 깜빡임 현상 발생
### 원인
![githru_mouseover_bug](https://github.com/user-attachments/assets/7f67cb19-0484-4b8d-863f-6e117969749d)
- 마우스 move 시 `.style {display: none}`과 `.style {display: inline-block}`이 반복되는 것을 확인할 수 있습니다.

## Result
- Total Commit 그래프(Bar Chart)에 마우스 over 시 tooltip이 렌더링 되는 위치를 수정하였습니다.(`{e.pageY - 70}px` 을 `{e.pageY - 90}px` 으로)
- 마우스 Over 상태에서 마우스 Move 때마다 렌더링 되던 tooltip을 **마우스 Over 때 tooltip이 렌더링 되고, Move 때마다 tooltip의 위치를 조정**하도록 수정하였습니다. _(이미지2 참고)_

## Work list
### 결과(이미지1)
![author_bar_깜빡임해결](https://github.com/user-attachments/assets/eb27e9f8-36d7-438b-8560-751d5c9eacbd)
- tooltip의 위치가 항상 마우스보다 위에 있습니다.

### tooltip 렌더링 순서 변경 사유(이미지2)
![간헐적으로 씹히는 버그](https://github.com/user-attachments/assets/1791aa3c-74eb-44dd-a342-ea8908e95478)
- 마우스를 빠르게 움직일 경우, 움직이기 전 마우스 위치에서 tooltip이 렌더링 되고, tooltip이 렌더링 된 위치에 움직인 후의 마우스 커서가 존재할 경우 깜빡임이 발생합니다.
- 위 '깜빡임'의 원인은 렌더링 된 tooltip 위에 마우스가 위치할 경우 Bar Chart에서는 `handleMouseOut`되고, 이에 따라 tooltip이 사라지게 됩니다. Tooltip이 사라짐으로써 Bar Chart에 `handleMouseOver`가 호출됩니다. 이후 마우스가 움직이며 `handleMouseMove`가 호출됩니다. 위 과정이 반복되며 '깜빡'이는 것처럼 보이게 됩니다.

## Discussion
Bar Chart 외 `handleMouseOver`, `handleMouseMove` 이 호출되는 곳이 있는지 확인한 결과 Bar Chart 외 없어서 함수를 수정하였습니다. `handleMouseOver`, `handleMouseOut` 함수를 수정하지 않기 위해서는 Bar Chart 전용 마우스 Over, Move 함수를 만들어야 할 것 같습니다. _(예: `handleBarChartMouseOver`, `handleBarChartMouseMove`)_