### PR TITLE
feat(view): Primary color에 따라 File Summary 글자 색상 동적 변경

### DIFF
--- a/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.scss
+++ b/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.scss
@@ -2,6 +2,7 @@
 
 .file-icicle-summary {
   text {
-    fill: $white;
+    fill: var(--primary-color);
+    filter: invert(100) grayscale(100) contrast(100);
   }
 }


### PR DESCRIPTION
## Related issue

#528 

## Result

File Summary 차트의 배경 색상이 되는 `primary color`가 변경될 때마다 글자 색상이 동적으로 변경됩니다.

## Work list

- CSS의 `filter` 속성을 사용하여 배경 색상이 어두울 때는 `white` 컬러, 배경 색상이 밝을 때는 `black` 컬러로 보입니다.
- 이슈에 첨부해주신 [링크](https://miunau.com/posts/dynamic-text-contrast-in-css)를 참고했습니다. 감사합니다. 🤗

![githru#528](https://github.com/user-attachments/assets/95a1134d-3094-4c52-ac5f-c6a7380332d7)

## Discussion

색상 값을 계산하거나 SVG 필터를 씌우는 것보다 간단한 방법이라고 생각해서 이렇게 구현했는데요,
혹시 더 좋은 방법이 있다면 편하게 제안해주세요! 🙌🙌🙌