### PR TITLE
fix(view): #553  Author(other bar) 클릭시 해당 사용자들 관련 커밋내역이 나오지는 않는 문제 수정

### DIFF
--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -91,10 +91,11 @@ const AuthorBarChart = () => {
 
     // Event handler
     const handleMouseOver = (e: MouseEvent<SVGRectElement | SVGTextElement>, d: AuthorDataType) => {
+      console.log("이름입니다", d.name);
       tooltip
         .style("display", "inline-block")
         .style("left", `${e.pageX - 70}px`)
-        .style("top", `${e.pageY - 90}px`)
+        .style("top", `${e.pageY - 120}px`)
         .html(
           `<p class="name">${d.name}</p>
               <p>${metric}: 
@@ -108,7 +109,7 @@ const AuthorBarChart = () => {
     };
 
     const handleMouseMove = (e: MouseEvent<SVGRectElement | SVGTextElement>) => {
-      tooltip.style("left", `${e.pageX - 70}px`).style("top", `${e.pageY - 90}px`);
+      tooltip.style("left", `${e.pageX - 70}px`).style("top", `${e.pageY - 120}px`);
     };
     const handleMouseOut = () => {
       tooltip.style("display", "none");

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -127,18 +127,25 @@ const AuthorBarChart = () => {
         setFilteredData(newFilteredData ?? filteredData);
         setPrevData([...prevData]);
         setSelectedAuthor("");
-      } else if (d.name === "others") {
+        setSelectedData([]);
+        tooltip.style("display", "none");
+        return;
+      }
+
+      if (d.name === "others") {
         // "others" 바를 클릭할 때
         setPrevData([...prevData, filteredData]);
         setFilteredData(getNewFilteredData(d.names || []));
         setSelectedAuthor(d.name);
-      } else {
-        // 특정 사용자를 클릭할 때
-        setPrevData([...prevData, filteredData]);
-        setFilteredData(getNewFilteredData([d.name]));
-        setSelectedAuthor(d.name);
+        setSelectedData([]);
+        tooltip.style("display", "none");
+        return;
       }
 
+      // 특정 사용자를 클릭할 때
+      setPrevData([...prevData, filteredData]);
+      setFilteredData(getNewFilteredData([d.name]));
+      setSelectedAuthor(d.name);
       setSelectedData([]);
       tooltip.style("display", "none");
     };

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -91,7 +91,6 @@ const AuthorBarChart = () => {
 
     // Event handler
     const handleMouseOver = (e: MouseEvent<SVGRectElement | SVGTextElement>, d: AuthorDataType) => {
-      console.log("이름입니다", d.name);
       tooltip
         .style("display", "inline-block")
         .style("left", `${e.pageX - 70}px`)

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -122,7 +122,7 @@ const AuthorBarChart = () => {
       };
 
       if (isAuthorSelected) {
-        // 현재 선택된 저자를 다시 클릭하면 이전 데이터로 복원
+        // 현재 선택된 사용자를 다시 클릭하면 이전 데이터로 복원
         const newFilteredData = prevData.length > 0 ? prevData.pop() : filteredData;
         setFilteredData(newFilteredData ?? filteredData);
         setPrevData([...prevData]);
@@ -198,7 +198,6 @@ const AuthorBarChart = () => {
     totalData,
     selectedAuthor,
     setSelectedAuthor,
-    // selectedAuthorNames,
   ]);
 
   const handleChangeMetric = (e: ChangeEvent<HTMLSelectElement>): void => {

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.type.ts
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.type.ts
@@ -5,6 +5,7 @@ export type AuthorDataType = {
   commit: number;
   insertion: number;
   deletion: number;
+  names?: string[];
 };
 
 export type MetricType = (typeof METRIC_TYPE)[number];

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.util.ts
@@ -51,12 +51,16 @@ export const convertNumberFormat = (d: number | { valueOf(): number }): string =
   return d3.format("~s")(d);
 };
 
-export const sortDataByAuthor = (data: ClusterNode[], author: string): ClusterNode[] => {
+export const sortDataByAuthor = (data: ClusterNode[], names: string[]): ClusterNode[] => {
   return data.reduce((acc: ClusterNode[], cluster: ClusterNode) => {
     const checkedCluster = cluster.commitNodeList.filter((commitNode: CommitNode) =>
-      commitNode.commit.author.names.includes(author)
+      names.some((name) => commitNode.commit.author.names.includes(name))
     );
-    if (!checkedCluster.length) return acc;
-    return [...acc, { nodeTypeName: "CLUSTER" as const, commitNodeList: checkedCluster }];
+
+    if (checkedCluster.length > 0) {
+      acc.push({ nodeTypeName: "CLUSTER", commitNodeList: checkedCluster });
+    }
+
+    return acc;
   }, []);
 };

--- a/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.scss
+++ b/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.scss
@@ -2,6 +2,7 @@
 
 .file-icicle-summary {
   text {
-    fill: $white;
+    fill: var(--primary-color);
+    filter: invert(100) grayscale(100) contrast(100);
   }
 }


### PR DESCRIPTION
## Related issue

#553

## Result

10명의 사용자가 초과되는 경우 slice로 나눠 나머지는 Others로 분류시켰습니다. 또 그 Others bar를 클릭하게 되면 topAuthors 를 제외한 나머지(Others)의 커밋 내역들 역시 summary에 보여지도록 수정하였습니다. **다만 (#540)해당 이슈는 며칠전 수정이 되었음에도 others바에는 적용이 안되었기에 불가피하게 이전 수정 부분에서 수치를 좀 더 주었습니다.**

## Work list

![image](https://github.com/user-attachments/assets/2fa0f593-dbdb-4b97-b654-2feca00f0de3)
<img width="1466" alt="image" src="https://github.com/user-attachments/assets/ee342f9e-ab08-4f4b-8772-3a142cba39b3">


## Discussion
~~아쉬운 점은 others 바를 끝까지 타고 들어갔을때 그 이전의 author들을 보여주지 못한다는 점이 조금 아쉽습니다...ㅠ 이 부분은 따로 버튼을 넣어 뒤로가기를 만들어야만 할거 같아 해당부분 이슈 올리겠습니다...!!~~ **(해당 이슈는 이미 올라와있는 것 같아 따로 올리지 않겠습니다 #529)** 그 외에도 보다 효율적인 방법이 있다면 피드백 주시면 감사하겠습니다...!😁