### PR TITLE
feat(view): 레이아웃 수정

### DIFF
--- a/packages/view/src/App.scss
+++ b/packages/view/src/App.scss
@@ -32,8 +32,8 @@ body {
 }
 
 .middle-container {
-  display: flex;
-  justify-content: center;
+  display: grid;
+  grid-template-columns: 4fr 1fr;
   height: calc(100vh - 200px);
   margin-top: 20px;
 }

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
@@ -4,13 +4,12 @@
   width: fit-content;
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: flex-start;
 }
 
 .author-bar-chart__header {
   width: 100%;
   text-align: right;
-  padding-left: 40px;
 
   & .select-box {
     font-size: 10px;

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -168,6 +168,7 @@ const AuthorBarChart = () => {
 
   return (
     <div className="author-bar-chart__container">
+      <p>Author Bar Chart</p>
       <div className="author-bar-chart__header">
         <select
           className="select-box"

--- a/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.scss
+++ b/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.scss
@@ -1,6 +1,7 @@
 @import "styles/_pallete";
 
 .file-icicle-summary {
+  width: 90%;
   text {
     fill: var(--primary-color);
     filter: invert(100) grayscale(100) contrast(100);

--- a/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
+++ b/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
@@ -137,6 +137,7 @@ const FileIcicleSummary = () => {
 
   return (
     <div className="file-icicle-summary">
+      <p>File Icicle Summary</p>
       <svg ref={$summary} />
     </div>
   );

--- a/packages/view/src/components/Statistics/Statistics.scss
+++ b/packages/view/src/components/Statistics/Statistics.scss
@@ -1,9 +1,10 @@
 .statistics {
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 5vh;
-  padding: 0 20px 20px;
-  width: 300px;
+  padding: 20px;
+  width: 350px;
   overflow-y: scroll;
 }
 

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -9,7 +9,7 @@
   width: 100%;
 
   .cluster-summary__cluster {
-    padding: 5px 0;
+    padding: 5px;
     .toggle-contents-button {
       padding: 5px 15px;
       border: none;


### PR DESCRIPTION
## Related issue
#526 

## Result
- x scroll
<img width="1279" alt="화면 캡처 2024-07-30 163019" src="https://github.com/user-attachments/assets/7108911e-3051-4282-9267-c11c77a71fa9">

<br/>
<br/>


- 그래프 title
<img width="139" alt="image" src="https://github.com/user-attachments/assets/775678da-9c87-46fd-a213-4a9227524d59">
=>
<img width="310" alt="화면 캡처 2024-07-30 163100" src="https://github.com/user-attachments/assets/8751c808-787d-4e1d-97db-dc6e1465b63c">

## Work list
- 첫 번째 첨부해드린 사진을 보시면 이전에는 Statistics 부분의 아래쪽에  x축 scroll이 존재했었기에 개인적으로 ux가 불편하다는 생각을 했었습니다. 따라서 현재는 x축 scroll이 보이지 않도록 content 자체의 width를 변경시켜두었습니다.

- 두 번째 첨부해드린 사진은 각 그래프가 무엇을 의미하는 지 알기 어려운 사용자도 있을 수 있다는 생각이 들어서 이전에는 없었던 그래프의 title명을 추가해보았습니다..!

## Discussion
큰 변화는 없지만,,, 첫 pr인데 처음 보는 코드를 분석하면서 재미를 느꼈던 것 같습니다...! 앞으로도 더 많은 부분을 기여해보고 싶습니다😖🙂