### PR TITLE
fix(view): 커밋 메시지의 PR or Issue number 하이퍼링크 버그

### DIFF
--- a/packages/view/src/App.tsx
+++ b/packages/view/src/App.tsx
@@ -16,6 +16,7 @@ import type IDEPort from "ide/IDEPort";
 import { useGlobalData } from "hooks";
 import { RefreshButton } from "components/RefreshButton";
 import type { IDESentEvents } from "types/IDESentEvents";
+import type { RemoteGitHubInfo } from "types/RemoteGitHubInfo";
 
 const App = () => {
   const initRef = useRef<boolean>(false);
@@ -38,6 +39,18 @@ const App = () => {
       initRef.current = true;
     }
   }, [handleChangeAnalyzedData, handleChangeBranchList, ideAdapter, setLoading]);
+
+  const { setOwner, setRepo } = useGlobalData();
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent<RemoteGitHubInfo>) => {
+      const message = event.data;
+      setOwner(message.data.owner);
+      setRepo(message.data.repo);
+    };
+
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, []);
 
   if (loading) {
     return (

--- a/packages/view/src/components/VerticalClusterList/Summary/Content/Content.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Content/Content.tsx
@@ -1,33 +1,41 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { IoIosArrowDropdownCircle, IoIosArrowDropupCircle } from "react-icons/io";
+
+import { useGlobalData } from "hooks";
 
 import type { ContentProps } from "../Summary.type";
 
 const Content = ({ content, clusterId, selectedClusterId }: ContentProps) => {
-  const str: string = content.message;
-  const regex = /^(\(#[0-9]+\)|#[0-9]+)/g;
-  const tobeStr: string[] = str.split(" ");
+  const { owner, repo } = useGlobalData();
+  const [linkedStr, setLinkedStr] = useState<React.ReactNode[]>([]);
 
-  const linkedStr = tobeStr.reduce((acc: React.ReactNode[], tokenStr: string) => {
-    const matches = tokenStr.match(regex); // #num 으로 결과가 나옴 ()가 결과에 포함되지 않음
-    if (matches) {
-      const matchedStr = matches[0];
-      const matchedStrNum: string = matchedStr.substring(1);
-      const linkIssues = `https://github.com/githru/githru-vscode-ext/issues/${matchedStrNum}`;
-      acc.push(
-        <a
-          href={linkIssues}
-          key={`issues-${matchedStr}`}
-        >
-          {matchedStr}
-        </a>
-      );
-      acc.push(" ");
-    } else {
-      acc.push(tokenStr);
-      acc.push(" ");
-    }
-    return acc;
+  useEffect(() => {
+    const str: string = content.message;
+    const regex = /^(\(#[0-9]+\)|#[0-9]+)/g;
+    const tobeStr: string[] = str.split(" ");
+
+    const newLinkedStr = tobeStr.reduce((acc: React.ReactNode[], tokenStr: string) => {
+      const matches = tokenStr.match(regex); // #num 으로 결과가 나옴 ()가 결과에 포함되지 않음
+      if (matches) {
+        const matchedStr = matches[0];
+        const matchedStrNum: string = matchedStr.substring(1);
+        const linkIssues = `https://github.com/${owner}/${repo}/issues/${matchedStrNum}`;
+        acc.push(
+          <a
+            href={linkIssues}
+            key={`issues-${matchedStr}`}
+          >
+            {matchedStr}
+          </a>
+        );
+        acc.push(" ");
+      } else {
+        acc.push(tokenStr);
+        acc.push(" ");
+      }
+      return acc;
+    }, []);
+    setLinkedStr(newLinkedStr);
   }, []);
 
   return (

--- a/packages/view/src/context/GlobalDataProvider.tsx
+++ b/packages/view/src/context/GlobalDataProvider.tsx
@@ -14,6 +14,8 @@ export const GlobalDataProvider = ({ children }: PropsWithChildren) => {
 
   const [branchList, setBranchList] = useState<string[]>([]);
   const [selectedBranch, setSelectedBranch] = useState<string>(branchList?.[0]);
+  const [owner, setOwner] = useState<string>("");
+  const [repo, setRepo] = useState<string>("");
 
   const handleChangeBranchList = (branches: { branchList: string[]; head: string | null }) => {
     setSelectedBranch((prev) => (!prev && branches.head ? branches.head : prev));
@@ -44,8 +46,12 @@ export const GlobalDataProvider = ({ children }: PropsWithChildren) => {
       setSelectedBranch,
       handleChangeAnalyzedData,
       handleChangeBranchList,
+      owner,
+      setOwner,
+      repo,
+      setRepo,
     }),
-    [data, filteredRange, filteredData, selectedData, branchList, selectedBranch, loading]
+    [data, filteredRange, filteredData, selectedData, branchList, selectedBranch, loading, owner, repo]
   );
 
   return <GlobalDataContext.Provider value={value}>{children}</GlobalDataContext.Provider>;

--- a/packages/view/src/hooks/useGlobalData.ts
+++ b/packages/view/src/hooks/useGlobalData.ts
@@ -24,6 +24,10 @@ type GlobalDataState = {
   setBranchList: Dispatch<SetStateAction<string[]>>;
   selectedBranch: string;
   setSelectedBranch: Dispatch<SetStateAction<string>>;
+  owner: string;
+  setOwner: Dispatch<SetStateAction<string>>;
+  repo: string;
+  setRepo: Dispatch<SetStateAction<string>>;
 } & IDESentEvents;
 
 export const GlobalDataContext = createContext<GlobalDataState | undefined>(undefined);

--- a/packages/view/src/types/RemoteGitHubInfo.ts
+++ b/packages/view/src/types/RemoteGitHubInfo.ts
@@ -1,0 +1,6 @@
+export interface RemoteGitHubInfo {
+  data: {
+    owner: string;
+    repo: string;
+  };
+}

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -77,7 +77,9 @@ export async function activate(context: vscode.ExtensionContext) {
       const fetchClusterNodes = async (baseBranchName = initialBaseBranchName) => {
         const gitLog = await getGitLog(gitPath, currentWorkspacePath);
         const gitConfig = await getGitConfig(gitPath, currentWorkspacePath, "origin");
-        const { owner, repo } = getRepo(gitConfig);
+        let { owner, repo } = getRepo(gitConfig);
+        webLoader.setGlobalOwnerAndRepo(owner, repo);
+        repo = repo[0];
         const engine = new AnalysisEngine({
           isDebugMode: true,
           gitLog,

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -4,7 +4,7 @@ import * as vscode from "vscode";
 import { COMMAND_LAUNCH, COMMAND_LOGIN_WITH_GITHUB, COMMAND_RESET_GITHUB_AUTH } from "./commands";
 import { Credentials } from "./credentials";
 import { GithubTokenUndefinedError, WorkspacePathUndefinedError } from "./errors/ExtensionError";
-import { deleteGithubToken, getGithubToken, setGithubToken,  } from "./setting-repository";
+import { deleteGithubToken, getGithubToken, setGithubToken } from "./setting-repository";
 import { mapClusterNodesFrom } from "./utils/csm.mapper";
 import {
   findGit,
@@ -18,7 +18,7 @@ import {
 import WebviewLoader from "./webview-loader";
 
 let myStatusBarItem: vscode.StatusBarItem;
-const projectName = 'githru';
+const projectName = "githru";
 
 function normalizeFsPath(fsPath: string) {
   return fsPath.replace(/\\/g, "/");
@@ -58,12 +58,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
       const fetchBranches = async () => await getBranches(gitPath, currentWorkspacePath);
       const fetchCurrentBranch = async () => {
-
         let branchName;
         try {
-            branchName = await getCurrentBranchName(gitPath, currentWorkspacePath)
+          branchName = await getCurrentBranchName(gitPath, currentWorkspacePath);
         } catch (error) {
-            console.error(error);
+          console.error(error);
         }
 
         if (!branchName) {
@@ -77,9 +76,9 @@ export async function activate(context: vscode.ExtensionContext) {
       const fetchClusterNodes = async (baseBranchName = initialBaseBranchName) => {
         const gitLog = await getGitLog(gitPath, currentWorkspacePath);
         const gitConfig = await getGitConfig(gitPath, currentWorkspacePath, "origin");
-        let { owner, repo } = getRepo(gitConfig);
-        webLoader.setGlobalOwnerAndRepo(owner, repo);
-        repo = repo[0];
+        const { owner, repo: initialRepo } = getRepo(gitConfig);
+        webLoader.setGlobalOwnerAndRepo(owner, initialRepo);
+        const repo = initialRepo[0];
         const engine = new AnalysisEngine({
           isDebugMode: true,
           gitLog,

--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -208,7 +208,7 @@ export async function getGitConfig(
 
 export const getRepo = (gitRemoteConfig: string) => {
   const gitRemoteConfigPattern =
-    /(?:https?|git)(?::\/\/(?:\w+@)?|@)(?:github\.com)(?:\/|:)(?:(?<owner>[^\/]+?)\/(?<repo>[^\/\.]+))(?:\.git|\/)?(\S*)$/m;
+    /(?:https?|git)(?::\/\/(?:\w+@)?|@)(?:github\.com)(?:\/|:)(?:(?<owner>[^/]+?)\/(?<repo>[^/.]+))(?:\.git|\/)?(\S*)$/m;
   const gitRemote = gitRemoteConfig.match(gitRemoteConfigPattern)?.groups;
   if (!gitRemote) {
     throw new Error("git remote config should be: [https?://|git@]${domain}/${owner}/${repo}.git");

--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -208,7 +208,7 @@ export async function getGitConfig(
 
 export const getRepo = (gitRemoteConfig: string) => {
   const gitRemoteConfigPattern =
-    /(?:https?|git)(?::\/\/(?:\w+@)?|@)(?:github\.com)(?:\/|:)(?:(?<owner>.+?)\/(?<repo>.+?))(?:\.git|\/)?(\S*)$/m;
+    /(?:https?|git)(?::\/\/(?:\w+@)?|@)(?:github\.com)(?:\/|:)(?:(?<owner>[^\/]+?)\/(?<repo>[^\/\.]+))(?:\.git|\/)?(\S*)$/m;
   const gitRemote = gitRemoteConfig.match(gitRemoteConfigPattern)?.groups;
   if (!gitRemote) {
     throw new Error("git remote config should be: [https?://|git@]${domain}/${owner}/${repo}.git");

--- a/packages/vscode/src/webview-loader.ts
+++ b/packages/vscode/src/webview-loader.ts
@@ -111,6 +111,14 @@ export default class WebviewLoader implements vscode.Disposable {
         `;
     return returnString;
   }
+  public setGlobalOwnerAndRepo(owner: string, repo: string) {
+    if (this._panel) {
+      this._panel.webview.postMessage({
+        command: "setGlobalOwnerAndRepo",
+        data: { owner, repo },
+      });
+    }
+  }
 }
 
 type GithruFetcher<D = unknown, P extends unknown[] = []> = (...params: P) => Promise<D>;


### PR DESCRIPTION
## Related issue
#486 
### 원인
<img width="851" alt="image" src="https://github.com/user-attachments/assets/32e647cf-024f-47ce-96d1-0d7663ff9819">

- 하이퍼링크 github 주소가 `owner`는 `githru`, `repo`는 `githru-vscode-ext`로 하드코딩되어 있습니다.
- `githru-vscode-ext`가 아닌 레포지토리에서 issue number 링크를 열더라도 `githru-vscode-ext` 레포지토리로 이동합니다.

## Result
### 결과
<img width="918" alt="image" src="https://github.com/user-attachments/assets/c23c6980-b12c-4b06-be99-0437f5b84617">

- number의 `href` 주소가 remote github의 issue number 주소로 올바르게 반영됩니다.
   _number에 따라 issue 또는 PR이 결정되므로 `href` 주소가 `/issue/235` 이더라도 레포지토리에서 '235번'이 PR이라면 github.com에서 `/pull/235`로 자동 redirection 됩니다._

![httpstest](https://github.com/user-attachments/assets/bd046968-2c6a-4169-bd85-91db088af10f)
- HTTPS로 clone한 레포지토리에서 이슈 넘버를 클릭한 결과, 올바른 github의 issue로 이동합니다. 

![sshtest](https://github.com/user-attachments/assets/cf94e85d-160a-40d0-9e71-2fa64891ec31)
- SSH로 clone한 레포지토리에서 이슈 넘버를 클릭한 결과, 올바른 github의 issue로 이동합니다. 


## Work list
### 1. owner, repo를 parsing 하는 정규식 수정([Commit](https://github.com/githru/githru-vscode-ext/commit/ca9b8f3c5015b559606d03f5ebb03ae0bab2bef3))
- gitconfig가 `git@github.com:HandTris/FE-HandTris.git` 인 경우 `repo`를 'F', `owner`를 'HandTris'로 parsing하여 `repo` 정보를 사용할 수 없었음
    <img width="371" alt="레포_오너" src="https://github.com/user-attachments/assets/9808101f-9809-497d-a651-a5afd8f803d3">
- gitconfig가 `https://github.com/seungineer/react-toy-projcet.git`인 경우 `repo`를 'r', `owner`를 'seungineer'로 parsing하여 `repo` 정보를 사용할 수 없었음
    <img width="394" alt="temp" src="https://github.com/user-attachments/assets/d345ca4c-750f-43fb-96df-7df9c07eea9b">

- 정규식 수정 후 아래와 같이 올바르게 parsing 됩니다.

    <img width="415" alt="ㅇㅇㅇ" src="https://github.com/user-attachments/assets/ef618554-73bd-4be9-91b3-3a5058a1680b">
- `owner`는 'seungineer'이고, `repo`는 'react-toy-project'입니다.

### 2. owner와 repo 정보를 Global Data로 관리할 수 있도록 항목 추가([Commit](https://github.com/githru/githru-vscode-ext/commit/20fea1e344da3dcb0f3d9b51e4242e30315217f7))
- owner, repo 정보는 패널이 받는 `postMessage`에 의해서 결정되므로 `postMessage`를 listen 하는 곳과 owner, repo 정보를 사용하는 곳(`Content` 컴포넌트)이 다르기에 Global로 관리하였습니다.

### 3. owner와 repo를 global로 저장하기 위해 VSCode(Node.js)에서 패널로 메시지를 보내는 기능([Commit](https://github.com/githru/githru-vscode-ext/commit/e408706abf06a7921ab382e189e9f64591fae7b5))
- owner와 repo 정보를 담아서 postMessage 하도록 합니다.

### 4. 받은 메시지를 처리하며, owner와 repo를 결정하는 EventListener 구현([Commit](https://github.com/githru/githru-vscode-ext/commit/606f976d2bb1a39533dee217f250bb100fa08cb5))
- `App.tsx`에 EventListner를 추가하여 VSCode에서 보내는 메시지를 듣도록 하였습니다.
- 받은 메시지의 `owner`, `repo` 정보로 issue link 하이퍼링크에 사용될 `owner`, `repo` 상태를 업데이트합니다.

### 5. Content 컴포넌트가 렌더링될 때 Global Data의 owner와 repo 정보를 사용하여 Issue number의 하이퍼링크를 만들고, linkedStr을 만들도록 함([Commit](https://github.com/githru/githru-vscode-ext/commit/d2fd5598368e25c933fc73ce9f9a36cb63238b6e)) 
- `Content` 컴포넌트가 렌더링되면 `linkedStr`이 단 한 번 생성되어야 하므로 `useEffect` hook을 사용하였습니다.

### EventListner 도입 사유
- 'VSCode(Node.js)'에서 `owner`와 `repo`가 결정되면 'React'에서 이를 가져다 써야 하는 구조입니다. Node.js에서 직접 상태를 업데이트하거나 전달할 수 없습니다.
- `postMessage` 메써드와 EventListner를 사용하면 'React'에서 'VSCode 단'의 정보를 받을 수 있기에 도입하였습니다.
- VSCode API를 사용하여 Node.js에서 `owner`와 `repo` 정보를 상태 저장소에 저장한 후 'React'에서 저장된 상태를 요청하여 응답받는 방식이 가능합니다. 다만, VSCode API라 VSCode가 아닌 IDE에서는 작동하지 않기에 EventListener로 구현하였습니다.

## Discussion
혹 VSCode API를 사용하는 방식이 더 적합한 경우 피드백 주시면 수정해 보겠습니다!