### PR TITLE
fix(view): 각 content title 수정

### DIFF
--- a/packages/view/src/App.scss
+++ b/packages/view/src/App.scss
@@ -35,5 +35,6 @@ body {
   display: grid;
   grid-template-columns: 4fr 1fr;
   height: calc(100vh - 200px);
-  margin-top: 20px;
+
+  padding: 20px;
 }

--- a/packages/view/src/App.tsx
+++ b/packages/view/src/App.tsx
@@ -3,14 +3,7 @@ import { container } from "tsyringe";
 import { useEffect, useRef } from "react";
 import BounceLoader from "react-spinners/BounceLoader";
 
-import {
-  BranchSelector,
-  Statistics,
-  TemporalFilter,
-  ThemeSelector,
-  VerticalClusterList,
-  FilteredAuthors,
-} from "components";
+import { BranchSelector, Statistics, TemporalFilter, ThemeSelector, VerticalClusterList } from "components";
 import "./App.scss";
 import type IDEPort from "ide/IDEPort";
 import { useGlobalData } from "hooks";
@@ -65,7 +58,6 @@ const App = () => {
       </div>
       <div className="top-container">
         <TemporalFilter />
-        <FilteredAuthors />
       </div>
       <div className="middle-container">
         {filteredData.length !== 0 ? (

--- a/packages/view/src/components/FilteredAuthors/FilteredAuthors.scss
+++ b/packages/view/src/components/FilteredAuthors/FilteredAuthors.scss
@@ -1,9 +1,7 @@
 .selected-container {
-  position: relative;
-  top: 30px;
   display: flex;
   flex-wrap: wrap;
   width: 100%;
-  padding: 4px 6px;
+  padding: 6px;
   box-sizing: border-box;
 }

--- a/packages/view/src/components/FilteredAuthors/FilteredAuthors.scss
+++ b/packages/view/src/components/FilteredAuthors/FilteredAuthors.scss
@@ -1,7 +1,12 @@
 .selected-container {
   display: flex;
-  flex-wrap: wrap;
+  align-items: center;
+  gap: 15px;
   width: 100%;
-  padding: 6px;
+}
+
+.selected-content {
+  display: flex;
+  flex-wrap: wrap;
   box-sizing: border-box;
 }

--- a/packages/view/src/components/FilteredAuthors/FilteredAuthors.tsx
+++ b/packages/view/src/components/FilteredAuthors/FilteredAuthors.tsx
@@ -12,18 +12,21 @@ const FilteredAuthors = () => {
 
   return (
     <div className="selected-container">
-      {authSrcMap &&
-        selectedClusters.map((selectedCluster) => {
-          return selectedCluster.summary.authorNames.map((authorArray: string[]) => {
-            return authorArray.map((authorName: string) => (
-              <Author
-                key={authorName}
-                name={authorName}
-                src={authSrcMap[authorName]}
-              />
-            ));
-          });
-        })}
+      {selectedClusters.length > 0 && <p>Authors:</p>}
+      <div className="selected-content">
+        {authSrcMap &&
+          selectedClusters.map((selectedCluster) => {
+            return selectedCluster.summary.authorNames.map((authorArray: string[]) => {
+              return authorArray.map((authorName: string) => (
+                <Author
+                  key={authorName}
+                  name={authorName}
+                  src={authSrcMap[authorName]}
+                />
+              ));
+            });
+          })}
+      </div>
     </div>
   );
 };

--- a/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
+++ b/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
@@ -137,7 +137,7 @@ const FileIcicleSummary = () => {
 
   return (
     <div className="file-icicle-summary">
-      <p>File Icicle Summary</p>
+      <p>File Summary</p>
       <svg ref={$summary} />
     </div>
   );

--- a/packages/view/src/components/Statistics/Statistics.scss
+++ b/packages/view/src/components/Statistics/Statistics.scss
@@ -3,7 +3,6 @@
   flex-direction: column;
   align-items: center;
   gap: 5vh;
-  padding: 20px;
   width: 350px;
   overflow-y: scroll;
 }

--- a/packages/view/src/components/VerticalClusterList/VerticalClusterList.scss
+++ b/packages/view/src/components/VerticalClusterList/VerticalClusterList.scss
@@ -1,6 +1,10 @@
 .vertical-cluster-list {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
+}
+
+.vertical-cluster-list__content {
+  display: flex;
   height: 100%;
   overflow-x: hidden;
   overflow-y: scroll;

--- a/packages/view/src/components/VerticalClusterList/VerticalClusterList.tsx
+++ b/packages/view/src/components/VerticalClusterList/VerticalClusterList.tsx
@@ -1,13 +1,18 @@
 import "./VerticalClusterList.scss";
 
+import { FilteredAuthors } from "components/FilteredAuthors";
+
 import { ClusterGraph } from "./ClusterGraph";
 import { Summary } from "./Summary";
 
 const VerticalClusterList = () => {
   return (
     <div className="vertical-cluster-list">
-      <ClusterGraph />
-      <Summary />
+      <FilteredAuthors />
+      <div className="vertical-cluster-list__content">
+        <ClusterGraph />
+        <Summary />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Related issue
close #582

## Result
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/eebd45e2-5018-4696-871b-f685ca6c1be5">


## Work list
- 멘토님이 말씀하셨던 대로, file icicle summary에서 file summary로 text 변경했습니다.
- 이전에는 App.tsx의 top-container에 FilteredAuthors가 속해있었는데 해당 컴포넌트는 middle-container의 VerticalClusterList와 관련이 있다고 생각되어 VerticalClusterList 내부에 두는 것으로 코드를 수정했습니다. 혹시 다른 의견이 있으시다면 남겨주세요..!!
- 첨부한 사진에서 표시한 부분인 ' Authors: ' text도 추가했습니다.
- middle container의 padding 값을 각 내부의 content에서 주는 것이 아닌, middle container 전체에 주도록 스타일 수정했습니다.

## Discussion
- authors 부분과 관련해 https://github.com/githru/githru-vscode-ext/pull/570 해당 pr과 충돌나는 부분이 있을 것 같아 머지하신 것을 확인하고 충돌 해결해서 추가로 push해두겠습니다!