### PR TITLE
fix(view): dev 모드 실행 정상화

### DIFF
--- a/packages/view/src/App.tsx
+++ b/packages/view/src/App.tsx
@@ -37,8 +37,10 @@ const App = () => {
   useEffect(() => {
     const handleMessage = (event: MessageEvent<RemoteGitHubInfo>) => {
       const message = event.data;
-      setOwner(message.data.owner);
-      setRepo(message.data.repo);
+      if (message.data) {
+        setOwner(message.data.owner);
+        setRepo(message.data.repo);
+      }
     };
 
     window.addEventListener("message", handleMessage);

--- a/packages/vscode/src/webview-loader.ts
+++ b/packages/vscode/src/webview-loader.ts
@@ -147,6 +147,7 @@ export default class WebviewLoader implements vscode.Disposable {
     const gitLog = await getGitLog(this.gitPath, this.getCurrentWorkspacePath());
     const gitConfig = await getGitConfig(this.gitPath, this.getCurrentWorkspacePath(), "origin");
     const { owner, repo } = getRepo(gitConfig);
+    this.setGlobalOwnerAndRepo(owner, repo);
     const engine = new AnalysisEngine({
       isDebugMode: true,
       gitLog,


### PR DESCRIPTION
## Related issue
#603

## Result
- dev 모드 실행 이미지
![실행됨](https://github.com/user-attachments/assets/debca48d-5999-4890-837f-010e624fa748)

- 확장 개발 호스트 실행 이미지
![확장_실행됨](https://github.com/user-attachments/assets/a811a5f0-da1e-4b95-93a5-b650cd63054e)

## Work list
- dev 모드에서는 vscode에서 view 단으로 postMessage 하지 않기에 owner, repo 정보를 set하지 않도록 하였습니다.
- 확장 개발 호스트 모드에서는 vscode에서 view 단으로 `postMessage` 하는 부분이 누락되어 추가하였습니다.

## Discussion
- dev 모드 실행이 되지 않고 있기에 빠른 검토를 요청드립니다
- #588 Issue와 같이 `postMessage`를 사용하여 vscode에서 view로 정보를 전달하는 방식은 수정될 예정입니다.