### PR TITLE
feat(view): dev 모드 로딩 애니메이션 시간 축소

### DIFF
--- a/packages/view/src/ide/FakeIDEAdapter.ts
+++ b/packages/view/src/ide/FakeIDEAdapter.ts
@@ -43,7 +43,7 @@ export default class FakeIDEAdapter implements IDEPort {
     };
     setTimeout(() => {
       this.sendMessageToMe(message);
-    }, 3000);
+    }, 1500);
   }
 
   public sendFetchBranchListMessage() {

--- a/packages/view/src/ide/FakeIDEAdapter.ts
+++ b/packages/view/src/ide/FakeIDEAdapter.ts
@@ -42,6 +42,7 @@ export default class FakeIDEAdapter implements IDEPort {
       payload,
     };
     setTimeout(() => {
+      // loading time을 시뮬레이션 하기 위함
       this.sendMessageToMe(message);
     }, 1500);
   }


### PR DESCRIPTION
## Related issue

#615 

## Result

### 수정 후 로딩 애니메이션(시간 지연 **1,500ms**)
![tobe(15)](https://github.com/user-attachments/assets/38fc23df-e621-4d75-aa1e-99d23b58a565)
- 진한 색의 원이 커졌다가 작아졌다가 다시 커지는 중간에 종료되어 어떤 애니메이션이 실행되는지 확인이 가능합니다.

## Work list
- dev 모드의 경우 로딩 시간이 필요 없지만 애니메이션 확인을 위해 의도적으로 `setTimeout`이 적용되어 있습니다.
- `setTimeout`의 시간 지연을 기존 `3000ms` 에서 `1500ms` 로 수정하였습니다.

### 기존 로딩 애니메이션(시간 지연 3,000ms)
![asis](https://github.com/user-attachments/assets/0247f788-d0fd-499a-b318-fb15b31e25dc)
 
## Discussion
settimeout으로 loading이 발생하는 상황을 시뮬레이션 한다는 내용이 적혀 있으면 좋을 것 같아 주석을 추가하였습니다. 잘 안 건들이는 부분이라  주석이 불필요하면 제거하도록 하겠습니다. 😁