### PR TITLE
feat(view): #623 클러스터 서브 그래프 툴팁 스타일링

### DIFF
--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
@@ -1,3 +1,5 @@
+@import "styles/_pallete";
+
 .cluster-graph__container {
   cursor: pointer;
   min-width: 84px;
@@ -28,4 +30,15 @@
 
 .circle-group {
   fill: var(--primary-color);
+}
+
+.sub-graph-tooltip {
+  position: absolute;
+  z-index: 10;
+  background: $white;
+  padding: 8px 16px;
+  font-size: 10px;
+  line-height: 1.5;
+  border-radius: 5px;
+  color: $gray-900;
 }

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/Draws/drawSubGraph.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/Draws/drawSubGraph.ts
@@ -9,9 +9,7 @@ import { GRAPH_WIDTH } from "../ClusterGraph.const";
 const tooltip = d3
   .select("body")
   .append("div")
-  .attr("class", "tooltip")
-  .style("position", "absolute")
-  .style("z-index", "10")
+  .attr("class", "sub-graph-tooltip")
   .style("visibility", "hidden")
   .text("Tooltip");
 


### PR DESCRIPTION
## Related issue

#623

## Result

![subGraphTooltip](https://github.com/user-attachments/assets/d1593ca9-fc19-41e1-97ee-84e0e509d731)

## Work list

- 서브 그래프 툴팁의 가독성을 개선하기 위해 배경 스타일을 부여했습니다.
- githru 내 다른 툴팁과 동일한 디자인을 적용하여 통일성을 유지했습니다.
- 다른 툴팁과 명확하게 구분 짓고자 클래스명을 변경했습니다.

## Discussion

UI 리뉴얼 과정에서 툴팁 디자인도 함께 변경해도 좋을 것 같습니다 😃