### PR TITLE
[engine] 성능 최적화를 위한 view와의 메시징 방안

### DIFF
--- a/packages/analysis-engine/src/index.ts
+++ b/packages/analysis-engine/src/index.ts
@@ -87,5 +87,4 @@ export class AnalysisEngine {
   };
 }
 
-export * from "./utils";
 export default AnalysisEngine;

--- a/packages/analysis-engine/src/index.ts
+++ b/packages/analysis-engine/src/index.ts
@@ -53,19 +53,22 @@ export class AnalysisEngine {
 
     const commitRaws = getCommitRaws(this.gitLog);
     if (this.isDebugMode) console.log("commitRaws: ", commitRaws);
-    
+
     const commitDict = buildCommitDict(commitRaws);
     if (this.isDebugMode) console.log("commitDict: ", commitDict);
 
-    const pullRequests = await this.octokit.getPullRequests().catch((err) => {
-      console.error(err);
-      isPRSuccess = false;
-      return [];
-    }).then((pullRequests) => {
-      console.log("success, pr = ", pullRequests);
-      return pullRequests;
-    });
-    if (this.isDebugMode) console.log("pullRequests: ", pullRequests, );
+    const pullRequests = await this.octokit
+      .getPullRequests()
+      .catch((err) => {
+        console.error(err);
+        isPRSuccess = false;
+        return [];
+      })
+      .then((pullRequests) => {
+        console.log("success, pr = ", pullRequests);
+        return pullRequests;
+      });
+    if (this.isDebugMode) console.log("pullRequests: ", pullRequests);
 
     const stemDict = buildStemDict(commitDict, this.baseBranchName);
     if (this.isDebugMode) console.log("stemDict: ", stemDict);
@@ -74,7 +77,7 @@ export class AnalysisEngine {
 
     return {
       isPRSuccess,
-      csmDict
+      csmDict,
     };
   };
 
@@ -84,4 +87,5 @@ export class AnalysisEngine {
   };
 }
 
+export * from "./utils";
 export default AnalysisEngine;

--- a/packages/view/src/App.tsx
+++ b/packages/view/src/App.tsx
@@ -47,7 +47,7 @@ const App = () => {
   useEffect(() => {
     const handleMessage = (event: MessageEvent<RemoteGitHubInfo & GitLogPayload>) => {
       const message = event.data;
-      console.log("engine -> view 메시지 : ", { message });
+      console.log("[engine -> view] message : ", { message });
       if (message.data) {
         setOwner(message.data.owner);
         setRepo(message.data.repo);
@@ -56,7 +56,7 @@ const App = () => {
       // TODO : 커맨드명이 패키지 공통으로 쓰이고 있기 때문에, enum 등으로 전역 관리하는 것도 좋을 것 같습니다.
       if (message.command === "fetchMoreGitLog") {
         const newGitLogCount = JSON.parse(message.payload as unknown as string).newGitLogCount as string;
-        setCurrentGitLogCount((p) => p + +newGitLogCount);
+        setCurrentGitLogCount((p) => p + Number(newGitLogCount));
       }
     };
 
@@ -92,7 +92,7 @@ const App = () => {
               ideAdapter.sendFetchMoreGitLogMessage(100);
             }}
           >
-            로그 더 불러오기 (현재 {currentGitLogCount}개)
+            Fetch More Git Logs (current : {currentGitLogCount} logs)
           </button>
 
           <RefreshButton />

--- a/packages/view/src/App.tsx
+++ b/packages/view/src/App.tsx
@@ -11,11 +11,19 @@ import { useGlobalData } from "hooks";
 import { RefreshButton } from "components/RefreshButton";
 import type { IDESentEvents } from "types/IDESentEvents";
 import type { RemoteGitHubInfo } from "types/RemoteGitHubInfo";
+import type { GitLogPayload } from "types/GitLogPayload";
 
 const App = () => {
   const initRef = useRef<boolean>(false);
 
-  const { filteredData, handleChangeAnalyzedData, handleChangeBranchList, loading, setLoading } = useGlobalData();
+  const {
+    filteredData,
+    handleChangeAnalyzedData,
+    handleChangeBranchList,
+    handleChangeGitLogSkipCount,
+    loading,
+    setLoading,
+  } = useGlobalData();
 
   const ideAdapter = container.resolve<IDEPort>("IDEAdapter");
 
@@ -24,6 +32,7 @@ const App = () => {
       const callbacks: IDESentEvents = {
         handleChangeAnalyzedData,
         handleChangeBranchList,
+        handleChangeGitLogSkipCount,
       };
 
       setLoading(true);
@@ -32,15 +41,22 @@ const App = () => {
       ideAdapter.sendFetchBranchListMessage();
       initRef.current = true;
     }
-  }, [handleChangeAnalyzedData, handleChangeBranchList, ideAdapter, setLoading]);
+  }, [handleChangeAnalyzedData, handleChangeBranchList, handleChangeGitLogSkipCount, ideAdapter, setLoading]);
 
-  const { setOwner, setRepo } = useGlobalData();
+  const { setOwner, setRepo, currentGitLogCount, setCurrentGitLogCount } = useGlobalData();
   useEffect(() => {
-    const handleMessage = (event: MessageEvent<RemoteGitHubInfo>) => {
+    const handleMessage = (event: MessageEvent<RemoteGitHubInfo & GitLogPayload>) => {
       const message = event.data;
+      console.log("engine -> view 메시지 : ", { message });
       if (message.data) {
         setOwner(message.data.owner);
         setRepo(message.data.repo);
+      }
+
+      // TODO : 커맨드명이 패키지 공통으로 쓰이고 있기 때문에, enum 등으로 전역 관리하는 것도 좋을 것 같습니다.
+      if (message.command === "fetchMoreGitLog") {
+        const newGitLogCount = JSON.parse(message.payload as unknown as string).newGitLogCount as string;
+        setCurrentGitLogCount((p) => p + +newGitLogCount);
       }
     };
 
@@ -62,13 +78,23 @@ const App = () => {
       />
     );
   }
-
   return (
     <>
       <div className="header-container">
         <BranchSelector />
         <div className="header-buttons">
           <ThemeSelector />
+
+          <button
+            type="button"
+            onClick={() => {
+              // TODO : 얼만큼씩 받아올지 정해지면, 따로 상수로 빼는 것 고려하고, globalState.currentGitLogCount와 통일하기 (일단 임시로 100)
+              ideAdapter.sendFetchMoreGitLogMessage(100);
+            }}
+          >
+            로그 더 불러오기 (현재 {currentGitLogCount}개)
+          </button>
+
           <RefreshButton />
         </div>
       </div>

--- a/packages/view/src/context/GlobalDataProvider.tsx
+++ b/packages/view/src/context/GlobalDataProvider.tsx
@@ -1,5 +1,5 @@
 import type { PropsWithChildren } from "react";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { GlobalDataContext, type DateFilterRange } from "hooks";
 import type { ClusterNode } from "types";
@@ -29,6 +29,13 @@ export const GlobalDataProvider = ({ children }: PropsWithChildren) => {
     setLoading(false);
   };
 
+  /** Git Log 분할 로직 */
+  // TODO : vscode 설정에서 처음 받아올 로그의 count를 설정한 후 주입하게 해도 됩니다.
+  const [currentGitLogCount, setCurrentGitLogCount] = useState<number>(100);
+  const handleChangeGitLogSkipCount = useCallback((newSkipCount: number) => {
+    setCurrentGitLogCount((p) => p + newSkipCount);
+  }, []);
+
   const value = useMemo(
     () => ({
       data,
@@ -50,8 +57,23 @@ export const GlobalDataProvider = ({ children }: PropsWithChildren) => {
       setOwner,
       repo,
       setRepo,
+      currentGitLogCount,
+      setCurrentGitLogCount,
+      handleChangeGitLogSkipCount,
     }),
-    [data, filteredRange, filteredData, selectedData, branchList, selectedBranch, loading, owner, repo]
+    [
+      data,
+      filteredRange,
+      filteredData,
+      selectedData,
+      loading,
+      branchList,
+      selectedBranch,
+      owner,
+      repo,
+      currentGitLogCount,
+      handleChangeGitLogSkipCount,
+    ]
   );
 
   return <GlobalDataContext.Provider value={value}>{children}</GlobalDataContext.Provider>;

--- a/packages/view/src/hooks/useGlobalData.ts
+++ b/packages/view/src/hooks/useGlobalData.ts
@@ -28,6 +28,8 @@ type GlobalDataState = {
   setOwner: Dispatch<SetStateAction<string>>;
   repo: string;
   setRepo: Dispatch<SetStateAction<string>>;
+  currentGitLogCount: number;
+  setCurrentGitLogCount: Dispatch<SetStateAction<number>>;
 } & IDESentEvents;
 
 export const GlobalDataContext = createContext<GlobalDataState | undefined>(undefined);

--- a/packages/view/src/ide/FakeIDEAdapter.ts
+++ b/packages/view/src/ide/FakeIDEAdapter.ts
@@ -20,12 +20,30 @@ export default class FakeIDEAdapter implements IDEPort {
           return events.handleChangeAnalyzedData(payload ? JSON.parse(payload) : undefined);
         case "fetchBranchList":
           return events.handleChangeBranchList(payload ? JSON.parse(payload) : undefined);
+        case "fetchMoreGitLog": {
+          const gitLogOffset = JSON.parse(payload || "")?.offset;
+
+          if (gitLogOffset) {
+            events.handleChangeGitLogSkipCount(+gitLogOffset);
+          } else {
+            console.log("Invalid Offset", gitLogOffset);
+          }
+          break;
+        }
         default:
           console.log("Unknown Message");
       }
     };
 
     window.addEventListener("message", onReceiveMessage);
+  }
+
+  public sendFetchMoreGitLogMessage(offset = 0, limit = 100) {
+    const message: IDEMessage = {
+      command: "fetchMoreGitLog",
+      payload: JSON.stringify({ offset, limit }),
+    };
+    this.sendMessageToMe(message);
   }
 
   public sendRefreshDataMessage(payload?: string) {
@@ -66,6 +84,11 @@ export default class FakeIDEAdapter implements IDEPort {
     const { command } = message;
 
     switch (command) {
+      case "fetchMoreGitLog":
+        return {
+          command,
+          payload: { offset: 100, limit: 100 },
+        };
       case "fetchAnalyzedData":
         return {
           command,

--- a/packages/view/src/ide/IDEPort.ts
+++ b/packages/view/src/ide/IDEPort.ts
@@ -7,6 +7,7 @@ export type IDEMessage = {
 
 export default interface IDEPort {
   addIDESentEventListener: (apiCallbacks: IDESentEvents) => void;
+  sendFetchMoreGitLogMessage: (skipLogCount?: number) => void;
   sendRefreshDataMessage: (payload?: string) => void;
   sendFetchAnalyzedDataMessage: (payload?: string) => void;
   sendFetchBranchListMessage: () => void;

--- a/packages/view/src/ide/VSCodeIDEAdapter.ts
+++ b/packages/view/src/ide/VSCodeIDEAdapter.ts
@@ -19,11 +19,29 @@ export default class VSCodeIDEAdapter implements IDEPort {
           return events.handleChangeAnalyzedData(payloadData);
         case "fetchBranchList":
           return events.handleChangeBranchList(payloadData);
+        case "fetchMoreGitLog": {
+          const gitLogOffset = JSON.parse(payload || "")?.offset;
+
+          if (gitLogOffset) {
+            events.handleChangeGitLogSkipCount(+gitLogOffset);
+          } else {
+            console.log("Invalid Offset", gitLogOffset);
+          }
+          break;
+        }
         default:
           console.log("Unknown Message");
       }
     };
     window.addEventListener("message", onReceiveMessage);
+  }
+
+  public sendFetchMoreGitLogMessage(offset = 0, limit = 100) {
+    const message: IDEMessage = {
+      command: "fetchMoreGitLog",
+      payload: JSON.stringify({ offset, limit }),
+    };
+    this.sendMessageToIDE(message);
   }
 
   public sendRefreshDataMessage(baseBranch?: string) {

--- a/packages/view/src/types/GitLogPayload.ts
+++ b/packages/view/src/types/GitLogPayload.ts
@@ -1,0 +1,6 @@
+export type GitLogPayload = {
+  command: string;
+  payload: {
+    newGitLogCount: string;
+  };
+};

--- a/packages/view/src/types/IDEMessage.ts
+++ b/packages/view/src/types/IDEMessage.ts
@@ -12,4 +12,5 @@ export type IDEMessageCommandNames =
   | "fetchAnalyzedData"
   | "fetchBranchList"
   | "fetchCurrentBranch"
+  | "fetchMoreGitLog"
   | "updatePrimaryColor";

--- a/packages/view/src/types/IDESentEvents.ts
+++ b/packages/view/src/types/IDESentEvents.ts
@@ -4,4 +4,5 @@ import type { ClusterNode } from "types";
 export type IDESentEvents = {
   handleChangeAnalyzedData: (analyzedData: ClusterNode[]) => void;
   handleChangeBranchList: (branches: { branchList: string[]; head: string | null }) => void;
+  handleChangeGitLogSkipCount: (newCount: number) => void;
 };

--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -152,7 +152,13 @@ export async function getGitExecutableFromPaths(paths: string[]): Promise<GitExe
   throw new Error("None of the provided paths are a Git executable");
 }
 
-export async function getGitLog(gitPath: string, currentWorkspacePath: string): Promise<string> {
+export async function getGitLog(
+  gitPath: string,
+  currentWorkspacePath: string
+  // TODO
+  // gitLogCountOffset: number,
+  // gitLogCountLimit: number
+): Promise<string> {
   return new Promise((resolve, reject) => {
     const args = [
       "--no-pager",
@@ -165,6 +171,11 @@ export async function getGitLog(gitPath: string, currentWorkspacePath: string): 
       "--decorate",
       "-c",
     ];
+
+    // TODO
+    // console.log("getGitLog", { gitLogCountOffset, gitLogCountLimit });
+    // if (gitLogCountOffset) args.push(`--skip=${gitLogCountOffset}`);
+    // if (gitLogCountLimit) args.push(`-n ${gitLogCountLimit}`);
 
     resolveSpawnOutput(
       cp.spawn(gitPath, args, {

--- a/packages/vscode/src/webview-loader.ts
+++ b/packages/vscode/src/webview-loader.ts
@@ -76,7 +76,7 @@ export default class WebviewLoader implements vscode.Disposable {
 
         const newGitLogCount = +(limit ?? 0);
         this.gitLogCount = this.gitLogCount + newGitLogCount;
-        console.log("view -> engine 메시지 : ", { offset, limit, newGitLogCount });
+        console.log("[view -> engine] message : ", { offset, limit, newGitLogCount });
 
         // TODO : CSM 가공 (이어붙이기)
         const analyzedData = await fetchClusterNodes(


### PR DESCRIPTION
## Related issue
#618
view와 engine 간의 git log 추가 요청을 위한 메시징 로직을 추가하였습니다.
현재 릴리즈되어 있는([v0.6.1](https://github.com/githru/githru-vscode-ext/releases/tag/v0.6.1)) 메인 로직에 영향을 최소화하기 위해 우선 `upstream:main`에서 `feature/618` 브랜치를 따로 추가하여 작업중입니다.
engine 및 view 성능 최적화 모듈의 다른 기능들과 어느정도 병합된 후 main에 머지하는 것이 좋을 것 같아서 이렇게 진행하였고, 성능 최적화를 담당하시는 다른 분들도 우선 여기에 머지해 두는 것이 좋을 것 같은데, 이와 관련하여 의견 주셔도 좋습니다!!

## Result
https://github.com/user-attachments/assets/9b87a4ca-bbef-4c9e-9dd3-92dd3d11d172

## Work list
> 초안 코드 작성의 범위
> - view
>   - 스크롤 대신 단순 버튼 클릭으로 트리거
>   - GlobalDataProvider에서 지금까지 받아온 git log(커밋노드)의 개수를 useState에 저장
>   - IDE Port & Message 요청
> - engine
>   - Message payload 파싱해서 getGitLog 재호출
>   - Message 답장

https://github.com/githru/githru-vscode-ext/issues/618#issuecomment-2273493982

## Discussion
- TODO
  - `<TemporalFilter />`(상단 CLOC, Commit 그래프)는 전체를 보여주도록 `commitDate` & `differenceStatistics`만 따로 전체 처리 가능한지 검토 예정
  - git log 분할 처리를 위한 파라미터 추가
  - CSM 노드 재생성 연구 (@BeA-Pro 님께서 담당해주고 계시며, 함께 연구해도 좋을 것 같습니다! 🙌)
- 해당 이슈를 해결하면서 생각난 제안 사항
  - 초기 실행 시 몇 개의 로그를 불러올지 추후 정하면 좋겠습니다.
    - 평균 N개의 CSM 노드를 만들었을 때 초기 로딩되는 시간을 역추산하여, 특정 개수의 로그만 처음에 받도록 상수를 하드코딩하거나,
    - 설정 탭이나 view의 Select 등에서 유저가 고를 수 있도록 하거나
    - etc.
  - 다음과 같이 패키지(vscode&engine&view) 공통으로 쓰이는 상수 또는 함수를 전역 관리하는 것도 좋을 것 같습니다. (`packages/utils`처럼 새로 만들어도 되며, 현재는 임시로 `packages/analysis-engine/utils`에 만들어두었습니다)
    - 메시지 커맨드명(ex. fetchAnalyzedData, refresh, updatePrimaryColor, fetchMoreGitLog, ...)
    - 이번 이슈에서 새로 만든 `getPayloadParam` 함수
- cc. @novice1993 @BeA-Pro @yoouyeon @seungineer @Sang-minKIM