### PR TITLE
[view] 일부 컴포넌트 mui로 변경

### DIFF
--- a/packages/view/src/components/BranchSelector/BranchSelector.scss
+++ b/packages/view/src/components/BranchSelector/BranchSelector.scss
@@ -1,28 +1,12 @@
 .branch-selector {
   display: flex;
+  flex-direction: row;
+  gap: 1rem;
   align-items: center;
-  font-weight: 600;
-  font-size: 0.825rem;
-  max-width: 315px;
-  width: 100%;
-  user-select: none;
-  margin-right: 12px;
-  position: relative;
+  font-weight: bold;
+  font-size: 1rem;
 
   .select-box {
-    text-align: center;
-    margin-left: 8px;
-    width: 100%;
-    padding: 4px;
-    border: solid 1px rgba(255, 255, 255, 0.22);
-    border-radius: 3px;
-    color: white;
-    background: rgba(255, 255, 255, 0.09);
-    font-weight: 300;
-    font-size: 0.825rem;
-
-    option {
-      background: #212121;
-    }
+    background-color: white;
   }
 }

--- a/packages/view/src/components/BranchSelector/BranchSelector.tsx
+++ b/packages/view/src/components/BranchSelector/BranchSelector.tsx
@@ -1,36 +1,52 @@
-import { type ChangeEventHandler } from "react";
-import "./BranchSelector.scss";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import FormControl from "@mui/material/FormControl";
+import type { SelectChangeEvent } from "@mui/material/Select";
+import Select from "@mui/material/Select";
 
 import { useGlobalData } from "hooks";
 import { sendFetchAnalyzedDataCommand } from "services";
+import "./BranchSelector.scss";
 
 const BranchSelector = () => {
   const { branchList, selectedBranch, setSelectedBranch, setLoading } = useGlobalData();
 
-  const handleChangeSelect: ChangeEventHandler<HTMLSelectElement> = (e) => {
-    setSelectedBranch(e.target.value);
+  const handleChangeSelect = (event: SelectChangeEvent) => {
+    setSelectedBranch(event.target.value);
     setLoading(true);
-    sendFetchAnalyzedDataCommand(e.target.value);
+    sendFetchAnalyzedDataCommand(event.target.value);
   };
 
   return (
-    <section className="branch-selector">
-      <span>Branches:</span>
-      <select
-        className="select-box"
-        onChange={handleChangeSelect}
-        value={selectedBranch}
+    <div className="branch-selector">
+      <p>Branches: </p>
+      <FormControl
+        sx={{ m: 1, minWidth: 120 }}
+        size="small"
       >
-        {branchList?.map((option) => (
-          <option
-            key={option}
-            value={option}
-          >
-            {option}
-          </option>
-        ))}
-      </select>
-    </section>
+        <InputLabel id="branch-select-small-label">Branches</InputLabel>
+        <Select
+          labelId="branch-select-small-label"
+          id="branch-select-small"
+          value={selectedBranch}
+          label="Branches"
+          onChange={handleChangeSelect}
+          className="select-box"
+        >
+          <MenuItem value="">
+            <em>None</em>
+          </MenuItem>
+          {branchList?.map((option) => (
+            <MenuItem
+              key={option}
+              value={option}
+            >
+              {option}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </div>
   );
 };
 

--- a/packages/view/src/components/RefreshButton/RefreshButton.scss
+++ b/packages/view/src/components/RefreshButton/RefreshButton.scss
@@ -1,9 +1,6 @@
 .refresh-button {
   width: 30px;
   height: 30px;
-  border: 0px solid transparent;
-  background-color: transparent;
-  cursor: pointer;
 }
 
 .refresh-button-icon {

--- a/packages/view/src/components/RefreshButton/RefreshButton.tsx
+++ b/packages/view/src/components/RefreshButton/RefreshButton.tsx
@@ -1,6 +1,7 @@
 import "reflect-metadata";
 import cn from "classnames";
 import ReplayCircleFilledRoundedIcon from "@mui/icons-material/ReplayCircleFilledRounded";
+import { IconButton } from "@mui/material";
 
 import { throttle } from "utils";
 import { useGlobalData } from "hooks";
@@ -16,16 +17,16 @@ const RefreshButton = () => {
   }, 3000);
 
   return (
-    <button
-      type="button"
+    <IconButton
       className={cn("refresh-button")}
       onClick={refreshHandler}
+      disabled={loading}
+      sx={{ color: "white" }}
     >
       <ReplayCircleFilledRoundedIcon
         className={cn("refresh-button-icon", { "refresh-button-icon--loading": loading })}
-        style={{ color: "white" }}
       />
-    </button>
+    </IconButton>
   );
 };
 

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.scss
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.scss
@@ -5,11 +5,17 @@
   .line-charts {
     display: flex;
     flex-direction: column;
+    align-items: flex-end;
+    padding: 1rem;
     height: 140px;
-    width: 100%;
     align-content: space-around;
-    
-    margin-top: 30px;
+
+    .reset-button {
+      width: 3rem;
+      margin-right: 1rem;
+      text-transform: none;
+      background-color: var(--primary-color);
+    }
   }
 
   .line-charts-svg {

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties } from "react";
 import { useEffect, useMemo, useRef } from "react";
 import * as d3 from "d3";
 import BounceLoader from "react-spinners/BounceLoader";
+import { Button } from "@mui/material";
 
 import { useGlobalData } from "hooks";
 
@@ -152,12 +153,15 @@ const TemporalFilter = () => {
         ref={wrapperRef}
       >
         {filteredRange && (
-          <button
+          <Button
             type="button"
+            variant="contained"
             onClick={resetBrushHandler}
+            size="small"
+            className="reset-button"
           >
-            reset
-          </button>
+            Reset
+          </Button>
         )}
         <svg
           className="line-charts-svg"


### PR DESCRIPTION
## Related issue
close #644 

## Result
- 상단 line-chart brushing 후 Reset 버튼
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/993bb1a3-caa0-4c55-8340-c90602d2b9fd">

<br/>
<br/>

- 상단 branch selector
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/2cb231fe-f9f7-4ae5-aa8e-6d0a766c1927">
<img width="1276" alt="image" src="https://github.com/user-attachments/assets/0635e22b-0f72-4cff-9fc4-388d6896e4b3">

<br/>
<br/>

- 상단 Refresh Button (컴포넌트를 mui로 변경 - 스타일에는 변화 없습니다.)
<img width="85" alt="image" src="https://github.com/user-attachments/assets/1a121077-1b1c-416b-be5c-b87601b66129">



## Work list
- [x] 상단 line-chart brushing 후 Reset 버튼 변경(close #631)
- [x] 상단 branch selector mui로 변경
- [x]  이 외에 버튼이 존재한다면 mui 버튼으로 변경

## Discussion
- Button color같은 경우 디자인 시스템 팀에서 새롭게 theme을 구현할 예정이라 우선 color picker의 색상으로 지정해 둔 상태입니다. 추후 color palette 수정이 이루어진 뒤 추가 수정이 필요합니다.
- branch selector 또한 배경 색이 white인 상태입니다.
---
전체 파일 내에서 button을 검색했을 때 일반적인 Button은 mui로 수정했으나, 첨부한 사진과 같은 부분은 button으로 감싸져있지만 mui의 Button으로 수정하지는 않았습니다. 이러한 부분도 mui로의 변경이 필요하다고 생각하시면 말씀해주세요!


<img width="464" alt="image" src="https://github.com/user-attachments/assets/ea8b8bc1-e55a-41ea-8c0b-36c4e5a9684a">
