### PR TITLE
[view] vertical cluster list 내 cluster graph, cluster summary 단일화

### DIFF
--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
@@ -23,7 +23,7 @@
   }
 }
 
-.cluster-graph__total-line {
+.cluster-graph__connector-line {
   stroke: var(--primary-color);
   stroke-width: 1;
 }

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.tsx
@@ -1,14 +1,16 @@
-import { useGlobalData } from "hooks";
+import React from "react";
 
-import { getGraphHeight, getClusterSizes, getSelectedIndex } from "./ClusterGraph.util";
+import { useGlobalData } from "hooks";
+import type { ClusterGraphProps } from "types/ClusterGraphProps";
+
+import { getGraphHeight, getSelectedIndex } from "./ClusterGraph.util";
 import { DETAIL_HEIGHT, SVG_WIDTH } from "./ClusterGraph.const";
 import { useHandleClusterGraph } from "./ClusterGraph.hook";
 
 import "./ClusterGraph.scss";
 
-const ClusterGraph = () => {
-  const { filteredData: data, selectedData, setSelectedData } = useGlobalData();
-  const clusterSizes = getClusterSizes(data);
+const ClusterGraph: React.FC<ClusterGraphProps> = ({ data, clusterSizes }) => {
+  const { selectedData, setSelectedData } = useGlobalData();
   const selectedIndex = getSelectedIndex(data, selectedData);
   const graphHeight = getGraphHeight(clusterSizes) + selectedIndex.length * DETAIL_HEIGHT;
 

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/Draws/drawTotalLine.ts
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/Draws/drawTotalLine.ts
@@ -14,8 +14,8 @@ export const drawTotalLine = (
 ) => {
   const lineData = [
     {
-      start: svgMargin.top,
-      end: (clusterHeight + nodeGap) * data.length,
+      start: 0,
+      end: clusterHeight + nodeGap * 2,
       selected: {
         prev: data[0].selected.prev,
         current: data[0].selected.current,
@@ -24,10 +24,10 @@ export const drawTotalLine = (
   ];
 
   d3.select(svgRef.current)
-    .selectAll(".cluster-graph__total-line")
+    .selectAll(".cluster-graph__connector-line")
     .data(lineData)
     .join("line")
-    .attr("class", "cluster-graph__total-line")
+    .attr("class", "cluster-graph__connector-line")
     .attr("x1", svgMargin.left + graphWidth / 2)
     .attr("y1", (d) => d.start)
     .attr("x2", svgMargin.left + graphWidth / 2)

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -9,7 +9,8 @@
   width: 100%;
 
   .cluster-summary__cluster {
-    padding: 5px;
+    display: flex;
+    align-items: center;
     .toggle-contents-button {
       padding: 5px 15px;
       border: none;
@@ -22,6 +23,11 @@
         border-radius: 40px;
         background-color: lighten($gray-800, 5);
       }
+    }
+    .cluster-summary__info-wrapper {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
     }
 
     .toggle-contents-container {
@@ -85,6 +91,9 @@
       }
     }
   }
+}
+.cluster-graph {
+  display: block;
 }
 
 .detail__container {

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.tsx
@@ -7,6 +7,8 @@ import { useGlobalData } from "hooks";
 import "./Summary.scss";
 import { Author } from "../../@common/Author";
 import { selectedDataUpdater } from "../VerticalClusterList.util";
+import { ClusterGraph } from "../ClusterGraph";
+import { getClusterSizes } from "../ClusterGraph/ClusterGraph.util";
 
 import { usePreLoadAuthorImg } from "./Summary.hook";
 import { getInitData, getClusterIds, getClusterById } from "./Summary.util";
@@ -19,6 +21,7 @@ const Summary = () => {
   const detailRef = useRef<HTMLDivElement>(null);
   const authSrcMap = usePreLoadAuthorImg();
   const selectedClusterId = getClusterIds(selectedData);
+  const clusterSizes = getClusterSizes(data);
   const onClickClusterSummary = (clusterId: number) => () => {
     const selected = getClusterById(data, clusterId);
     setSelectedData((prevState: ClusterNode[]) => selectedDataUpdater(selected, clusterId)(prevState));
@@ -33,50 +36,58 @@ const Summary = () => {
 
   return (
     <div className="cluster-summary__container">
-      {clusters.map((cluster: Cluster) => {
+      {clusters.map((cluster: Cluster, index: number) => {
         return (
           <div
             role="presentation"
             className="cluster-summary__cluster"
             key={cluster.clusterId}
           >
-            <button
-              type="button"
-              className="toggle-contents-button"
-              onClick={onClickClusterSummary(cluster.clusterId)}
-            >
-              <div className="toggle-contents-container">
-                <div className="name-box">
-                  {authSrcMap &&
-                    cluster.summary.authorNames.map((authorArray: string[]) => {
-                      return authorArray.map((authorName: string) => (
-                        <Author
-                          key={authorName}
-                          name={authorName}
-                          src={authSrcMap[authorName]}
-                        />
-                      ));
-                    })}
-                </div>
-                <Content
-                  content={cluster.summary.content}
-                  clusterId={cluster.clusterId}
-                  selectedClusterId={selectedClusterId}
-                />
-              </div>
-            </button>
-            {selectedClusterId.includes(cluster.clusterId) && (
-              <div
-                className="detail__container"
-                ref={detailRef}
+            <div className="cluster-summary__graph-wrapper">
+              <ClusterGraph
+                data={[data[index]]}
+                clusterSizes={[clusterSizes[index]]}
+              />
+            </div>
+            <div className="cluster-summary__info-wrapper">
+              <button
+                type="button"
+                className="toggle-contents-button"
+                onClick={onClickClusterSummary(cluster.clusterId)}
               >
-                <Detail
-                  selectedData={selectedData}
-                  clusterId={cluster.clusterId}
-                  authSrcMap={authSrcMap}
-                />
-              </div>
-            )}
+                <div className="toggle-contents-container">
+                  <div className="name-box">
+                    {authSrcMap &&
+                      cluster.summary.authorNames.map((authorArray: string[]) => {
+                        return authorArray.map((authorName: string) => (
+                          <Author
+                            key={authorName}
+                            name={authorName}
+                            src={authSrcMap[authorName]}
+                          />
+                        ));
+                      })}
+                  </div>
+                  <Content
+                    content={cluster.summary.content}
+                    clusterId={cluster.clusterId}
+                    selectedClusterId={selectedClusterId}
+                  />
+                </div>
+              </button>
+              {selectedClusterId.includes(cluster.clusterId) && (
+                <div
+                  className="detail__container"
+                  ref={detailRef}
+                >
+                  <Detail
+                    selectedData={selectedData}
+                    clusterId={cluster.clusterId}
+                    authSrcMap={authSrcMap}
+                  />
+                </div>
+              )}
+            </div>
           </div>
         );
       })}

--- a/packages/view/src/components/VerticalClusterList/VerticalClusterList.scss
+++ b/packages/view/src/components/VerticalClusterList/VerticalClusterList.scss
@@ -9,5 +9,4 @@
   overflow-x: hidden;
   overflow-y: scroll;
   flex-grow: 1;
-  width: 70%;
 }

--- a/packages/view/src/components/VerticalClusterList/VerticalClusterList.tsx
+++ b/packages/view/src/components/VerticalClusterList/VerticalClusterList.tsx
@@ -2,7 +2,6 @@ import "./VerticalClusterList.scss";
 
 import { FilteredAuthors } from "components/FilteredAuthors";
 
-import { ClusterGraph } from "./ClusterGraph";
 import { Summary } from "./Summary";
 
 const VerticalClusterList = () => {
@@ -10,7 +9,6 @@ const VerticalClusterList = () => {
     <div className="vertical-cluster-list">
       <FilteredAuthors />
       <div className="vertical-cluster-list__content">
-        <ClusterGraph />
         <Summary />
       </div>
     </div>

--- a/packages/view/src/types/ClusterGraphProps.ts
+++ b/packages/view/src/types/ClusterGraphProps.ts
@@ -1,0 +1,6 @@
+import type { ClusterNode } from "./Nodes";
+
+export interface ClusterGraphProps {
+  data: ClusterNode[];
+  clusterSizes: number[];
+}


### PR DESCRIPTION
## Related issue

Close #640

## Result

<img width="1037" alt="image" src="https://github.com/user-attachments/assets/80975ec0-be4b-4c78-bcd1-94139fda07d4">

- vertical cluster list 내에 한 개의 열이 존재합니다.
- vertical cluster graph는 한 개의 cluster에 맞는 graph(1개의 <rect>를 갖는 svg)를 의미합니다.
- vertical cluster content list가 한 행씩 렌더링 될 때, vertical cluster graph를 각각의 행 내에서 렌더링합니다.

## Work list

- Vertical cluter list 내 이중 Column으로 구성되던 것을 단일 Column으로 수정하였습니다.
        - 80b3f0f0572807d84adb3570f048cfdda1abdc5f
        - dccad2d440b02701231d6fb3abb772feb55608f1
- 전체 cluster graph를 잇는 선이 한 번에 그려지던 것을 각 cluster graph를 렌더링할 때, 그리도록 수정하였습니다.
        - 3db25167fb932b2eb9237292912d82aca2676732

### AS-IS

<img width="880" alt="image" src="https://github.com/user-attachments/assets/cf657293-e145-4b8f-b06c-05defc8f00a0">

- vertical cluster list 내에 두 개의 열이 존재합니다.
- vertical cluster graph는 전체 content의 cluster graph를 그리는 세로로 긴 graph(n개의 <rect>를 갖는 svg)를 의미합니다.
- vertical cluster graph가 세로로 길게 왼편에 위치하고, vertical cluster content list가 오른편에 content 별로 렌더링 됩니다.

## Discussion

구조가 바뀜으로써 class 명도 바뀌어야 할 것 같습니다. 이는 새로운 이슈를 만들도록 하겠습니다.

PR 올린 상태의 class 명은 아래와 같습니다.

<img width="1169" alt="image" src="https://github.com/user-attachments/assets/5f27cfca-e58f-406f-9860-fea05ba54508">

- `cluster-summary__container` 내 `cluster-summary__cluster`가 행별로 렌더링 됩니다.
- `cluster-summary__cluster` 내 `cluster-summary_graph-wrapper`, `cluster-summary_info-wrapper`가 존재합니다.
- `cluster-summary_info-wrapper` 내에 `toggle-contents-button` 요소만 존재하고, 이를 클릭 시 `detail__container`가 `toggle-contents-button` 아래에 추가됩니다.
