### PR TITLE
[view] temporal filter 차트가 잘리는 경우에도 보이도록 수정

### DIFF
--- a/packages/view/src/components/TemporalFilter/TemporalFilter.scss
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.scss
@@ -21,6 +21,7 @@
   .line-charts-svg {
     height: 100%;
     width: 100%;
+    overflow: visible;
   }
 
   .line-chart-wrap {


### PR DESCRIPTION
## Related issue
#649 

## Result

<img width="1194" alt="image" src="https://github.com/user-attachments/assets/b4030488-0ace-40aa-8863-32f80891c110">

- 차트의 하단까지 잘 보이는 것을 확인할 수 있습니다.

## Work list

- 차트 영역 바깥으로 넘어가는 그래프도 보이도록 `overflow: visible;`속성 값을 추가했습니다.

## Discussion

<img width="959" alt="image" src="https://github.com/user-attachments/assets/7799d8a9-4093-4c52-89c3-5cff0a435c32">

- 임시방편으로 `overflow: visible` 속성을 추가하여 보이도록 하였습니다.
- `line-charts` 내에서 차트가 잘리지 않고 표시되도록 추후 수정이 필요할 것 같습니다.