### PR TITLE
폰트 속성 변수로 대체

### DIFF
--- a/packages/view/src/components/BranchSelector/BranchSelector.scss
+++ b/packages/view/src/components/BranchSelector/BranchSelector.scss
@@ -1,10 +1,11 @@
+@import "styles/app";
+
 .branch-selector {
   display: flex;
   flex-direction: row;
   gap: 1rem;
   align-items: center;
-  font-weight: bold;
-  font-size: 1rem;
+  font-weight: $font-weight-semibold;
 
   .select-box {
     background-color: white;

--- a/packages/view/src/components/Detail/Detail.scss
+++ b/packages/view/src/components/Detail/Detail.scss
@@ -1,11 +1,11 @@
-@import "styles/_pallete";
+@import "styles/app";
 
 .detail__summary__container {
   display: flex;
   justify-content: space-between;
   margin: 15px 0 20px;
   align-items: center;
-  font-size: 12px;
+  font-size: $font-size-caption;
 
   .divider {
     margin-right: 1rem;
@@ -50,7 +50,7 @@
   flex-direction: column;
   row-gap: 7px;
   padding: 0 20px;
-  font-size: 12px;
+  font-size: $font-size-body;
 
   .commit-item {
     width: 100%;
@@ -142,7 +142,7 @@
   background: $white;
   padding: 8px 16px;
   text-align: center;
-  font-size: 10px;
+  font-size: $font-size-caption;
   line-height: 1.5;
   border-radius: 5px;
   color: $gray-900;

--- a/packages/view/src/components/FilteredAuthors/FilteredAuthors.scss
+++ b/packages/view/src/components/FilteredAuthors/FilteredAuthors.scss
@@ -1,8 +1,15 @@
+@import "styles/app";
+
 .selected-container {
   display: flex;
   align-items: center;
   gap: 15px;
   width: 100%;
+
+  p {
+    font-size: $font-size-title;
+    font-weight: $font-weight-semibold;
+  }
 }
 
 .selected-content {

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
@@ -1,10 +1,15 @@
-@import "styles/_pallete";
+@import "styles/app";
 
 .author-bar-chart__container {
   width: fit-content;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+
+  p {
+    font-size: $font-size-title;
+    font-weight: $font-weight-semibold;
+  }
 }
 
 .author-bar-chart__header {
@@ -12,7 +17,7 @@
   text-align: right;
 
   & .select-box {
-    font-size: 10px;
+    font-size: $font-size-caption;
     background: transparent;
     border: 1px solid $white;
     border-radius: 5px;
@@ -35,7 +40,7 @@
 
   .axis {
     color: $white;
-    font-weight: bold;
+    font-weight: $font-weight-semibold;
 
     &.x-axis {
       .tick {
@@ -69,9 +74,9 @@
       .name {
         fill: $white;
         stroke: none;
-        font-size: 10px;
+        font-size: $font-size-caption;
         text-anchor: start;
-        font-weight: normal;
+        font-weight: $font-weight-semibold;
       }
     }
   }
@@ -83,16 +88,16 @@
   background: $white;
   padding: 8px 16px;
   text-align: center;
-  font-size: 10px;
+  font-size: $font-size-caption;
   line-height: 1.5;
   border-radius: 5px;
   color: $gray-900;
 
   .selected {
     color: var(--primary-color);
-    font-weight: bold;
+    font-weight: $font-weight-semibold;
   }
   .name {
-    font-weight: bold;
+    font-weight: $font-weight-semibold;
   }
 }

--- a/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.scss
+++ b/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.scss
@@ -1,4 +1,4 @@
-@import "styles/_pallete";
+@import "styles/app";
 
 .file-icicle-summary {
   width: 16rem;
@@ -6,4 +6,10 @@
     fill: var(--primary-color);
     filter: invert(100) grayscale(100) contrast(100);
   }
+}
+
+.file-icicle-title {
+  font-size: $font-size-title;
+  font-weight: $font-weight-semibold;
+  margin-bottom: 1rem;
 }

--- a/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
+++ b/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
@@ -137,7 +137,7 @@ const FileIcicleSummary = () => {
 
   return (
     <div className="file-icicle-summary">
-      <p>File Summary</p>
+      <p className="file-icicle-title">File Summary</p>
       <svg ref={$summary} />
     </div>
   );

--- a/packages/view/src/components/TemporalFilter/LineChart.scss
+++ b/packages/view/src/components/TemporalFilter/LineChart.scss
@@ -1,4 +1,4 @@
-@import "styles/_pallete";
+@import "styles/app";
 
 .cloc-line-chart-wrap {
   height: 50%;

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.scss
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.scss
@@ -1,3 +1,5 @@
+@import "styles/app";
+
 .temporal-filter {
   display: flex;
   flex-direction: column;
@@ -40,8 +42,8 @@
 }
 
 .filter {
-  font-weight: 600;
-  font-size: 0.825rem;
+  font-weight: $font-weight-semibold;
+  font-size: $font-size-caption;
 
   .date-from,
   .date-to {
@@ -51,13 +53,13 @@
     border-radius: 3px;
     color: white;
     background: rgba(255, 255, 255, 0.09);
-    font-weight: 300;
-    font-size: 0.825rem;
+    font-weight: $font-weight-light;
+    font-size: $font-size-caption;
   }
 }
 
 .temporal-filter__label {
-  font-size: 10px;
-  font-weight: 500;
+  font-size: $font-size-title;
+  font-weight: $font-weight-semibold;
   fill: white;
 }

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
@@ -1,4 +1,4 @@
-@import "styles/_pallete";
+@import "styles/app";
 
 .cluster-graph__container {
   cursor: pointer;
@@ -37,7 +37,7 @@
   z-index: 10;
   background: $white;
   padding: 8px 16px;
-  font-size: 10px;
+  font-size: $font-size-caption;
   line-height: 1.5;
   border-radius: 5px;
   color: $gray-900;

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -1,4 +1,4 @@
-@import "styles/_pallete";
+@import "styles/app";
 
 .cluster-summary__container {
   display: flex;
@@ -67,7 +67,7 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
-      font-size: 12px;
+      font-size: $font-size-body;
       gap: 10px;
 
       .commit-message__wrapper {
@@ -87,7 +87,7 @@
 
       .more-commit-count {
         text-align: right;
-        font-size: 10px;
+        font-size: $font-size-caption;
       }
     }
   }

--- a/packages/view/src/styles/_font.scss
+++ b/packages/view/src/styles/_font.scss
@@ -1,40 +1,13 @@
-$font-size--base: font-size(16px);
-$font-size--secondary: font-size(14px);
+$font-size-title: 1rem;
+$font-size-body: 0.875rem;
+$font-size-caption: 0.75rem;
 
-$font-weight--thin: 100;
-$font-weight--extralight: 200;
-$font-weight--light: 300;
-$font-weight--regular: 400;
-$font-weight--medium: 500;
-$font-weight--semibold: 600;
-$font-weight--bold: 700;
-$font-weight--extrabold: 800;
-$font-weight--black: 900;
+$font-weight-light: 300;
+$font-weight-regular: 400;
+$font-weight-semibold: 600;
+$font-weight-extrabold: 800;
 
-$line-height--base: 1.62;
-$line-height--title: 1.15;
-$line-height--quote: 1.3;
-$line-height--button: 1;
-
-@function calculateRem($size) {
-  $remSize: $size / 16px;
-  @return $remSize * 1rem;
-}
-
-@mixin font-size($size) {
-  font-size: $size;
-  font-size: calculateRem($size);
-}
-
-@mixin font-face($font-name, $file-name, $weight: normal, $style: normal) {
-  @font-face {
-    font-family: quote($font-name);
-    src: url($file-name + ".eot");
-    src: url($file-name + ".eot?#iefix") format("embedded-opentype"),
-      url($file-name + ".woff") format("woff"),
-      url($file-name + ".ttf") format("truetype"),
-      url($file-name + ".svg##{$font-name}") format("svg");
-    font-weight: $weight;
-    font-style: $style;
-  }
-}
+$line-height-base: 1.62;
+$line-height-title: 1.15;
+$line-height-quote: 1.3;
+$line-height-button: 1;

--- a/packages/view/src/styles/_reset.scss
+++ b/packages/view/src/styles/_reset.scss
@@ -1,46 +1,10 @@
 /*! minireset.css v0.0.6 | MIT License | github.com/jgthms/minireset.css */
-html,
-body,
-p,
-ol,
-ul,
-li,
-dl,
-dt,
-dd,
-blockquote,
-figure,
-fieldset,
-legend,
-textarea,
-pre,
-iframe,
-hr,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+* {
   margin: 0;
   padding: 0;
 }
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-size: inherit;
-  font-weight: normal;
-}
 ul {
   list-style: none;
-}
-button,
-input,
-select {
-  margin: 0;
 }
 html {
   box-sizing: border-box;
@@ -68,8 +32,6 @@ th {
 }
 
 body {
-  font-size: 10px;
-
   &::-webkit-scrollbar,
   &::-webkit-scrollbar:horizontal {
     display: block;


### PR DESCRIPTION
## Related issue
#654

## Result
### AS IS
![image](https://github.com/user-attachments/assets/e80d251b-7315-4c86-bcfa-dfef6c4027a3)

### TO BE
![image](https://github.com/user-attachments/assets/390a78ec-17fa-494c-bfb6-4a4cf6e17b37)

## Work list
- 기존에 scss에서 변수로 사이즈를 다 지정해두고 사용하지 않았기 때문에, 그래프 영역을 제외한 나머지 `font-weight` `font-size`를 사용하는 부분을 모두 변수로 교체하였습니다.
- 필요없는 함수를 제거하고, 얇게, 보통, 굵게, 아주 굵게를 제외한 `font-weight` 가짓수를 줄였습니다.
- 앞으로 컬러 시스템 등을 사용하게 되면 어차피 `@import "styles/,,,"` 로 각 scss 폴더를 불러와야 하기 때문에, 번거로움을 줄이고자 전체를 합친 `app` 자체를 불러오도록 하였습니다.
- `reset.scss` 에서 브라우저 상에서 주로 사용하는 거의 모든 태그를 하나씩 불러와서 마진, 패딩 값을 조절해주고 있어서, 전체 `*` 태그로 수정하였습니다. 이미 나열된 목록이 너무 많아 차라리 특정하게 마진, 패딩 값을 다시 늘려주는 요소만 지정해주는 게 좋을 것 같다고 판단하였습니다. 

## Discussion
사이즈는 1920 * 1080 (기본 브라우저 사이즈) 기준으로 캡쳐하였습니다.
브라우저 상으론 조금 더 늘려도 될 것 같긴 한데, `extension`은 조금 더 크게 보일 것 같아 살짝만 조정했습니다.
그럼에도 좀 작게 보이면 캡션 사이즈는 그대로 두고, 본문과 제목만 2px 늘려도 될 것 같습니다.