### PR TITLE
[engine] 브랜치 초기 조회시  데이터 캐싱

### DIFF
--- a/packages/vscode/src/webview-loader.ts
+++ b/packages/vscode/src/webview-loader.ts
@@ -17,6 +17,12 @@ export default class WebviewLoader implements vscode.Disposable {
     const { fetchClusterNodes, fetchBranches, fetchCurrentBranch } = fetcher;
     const viewColumn = vscode.ViewColumn.One;
 
+     //캐시 초기화
+     console.log("Initialize cache data");
+     context.workspaceState.keys().forEach(key => {
+       context.workspaceState.update(key, undefined);
+     });
+
     this._panel = vscode.window.createWebviewPanel("WebviewLoader", "githru-view", viewColumn, {
       enableScripts: true,
       retainContextWhenHidden: true,
@@ -31,12 +37,21 @@ export default class WebviewLoader implements vscode.Disposable {
 
       if (command === "fetchAnalyzedData" || command === "refresh") {
         const baseBranchName = (payload && JSON.parse(payload)) ?? (await fetchCurrentBranch());
-        // Disable Cache temporarily
-        // const storedAnalyzedData = context.workspaceState.get<ClusterNode[]>(`${ANALYZE_DATA_KEY}_${baseBranchName}`);
-        // if (!storedAnalyzedData) {
+        const storedAnalyzedData = context.workspaceState.get<ClusterNode[]>(`${ANALYZE_DATA_KEY}_${baseBranchName}`);
+        let analyzedData = storedAnalyzedData;
+        if (!storedAnalyzedData) {
+          console.log("No cache Data");
+          console.log("baseBranchName : ",baseBranchName);
+          analyzedData = await fetchClusterNodes(baseBranchName);
+          context.workspaceState.update(`${ANALYZE_DATA_KEY}_${baseBranchName}`, analyzedData);
+        }else console.log("Cache data exists");
 
-        const analyzedData = await fetchClusterNodes(baseBranchName);
-        context.workspaceState.update(`${ANALYZE_DATA_KEY}_${baseBranchName}`, analyzedData);
+        // 현재 캐싱된 Branch
+        console.log("Current Stored data");
+        context.workspaceState.keys().forEach(key=>{
+            console.log(key);
+        })
+
 
         const resMessage = {
             command,


### PR DESCRIPTION
## Related issue

Githru의 성능 개선을 위해 캐싱을 사용했습니다.
아직 논의해야 할 부분이 많지만 우선 개발을 해보는 것이 중요하다고 생각하여 한 번 조회한 브랜치의 데이터를 캐싱하여 다시 조회하는 경우 캐싱된 데이터를 보여주는 식으로 구현하였습니다.

## Result
![ezgif-7-96631f0ab4](https://github.com/user-attachments/assets/c274b4ac-1cd1-4aad-88ec-d7aa76c770bb)

처음 origin/HEAD 브랜치의 데이터를 조회할 때보다 이후 데이터를 조회하는 경우 속도가 더 빠른 것을 확인 할 수 있습니다.

## Work list
- webview-loader 생성시 이전에 캐시된 내용 삭제
- 최초 브랜치 조회시 테이터 캐싱

## Discussion
Todo
- CSM 생성 방식 이해
- 특정 기간 혹은 개수에 대한 요청이 올 때 어떻게 CSM을 생성할지 고민해보기
