### PR TITLE
[view] 커밋 링크 추가

### DIFF
--- a/packages/view/src/components/Detail/Detail.scss
+++ b/packages/view/src/components/Detail/Detail.scss
@@ -113,7 +113,7 @@
       width: 6em;
       position: relative;
 
-      span:hover {
+      a:hover {
         cursor: pointer;
         .commit-id__tooltip {
           display: inline-block;

--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -13,6 +13,7 @@ import { FIRST_SHOW_NUM } from "./Detail.const";
 import type { DetailProps, DetailSummaryProps, DetailSummaryItem } from "./Detail.type";
 
 import "./Detail.scss";
+import { useGlobalData } from "hooks";
 
 const DetailSummary = ({ commitNodeListInCluster }: DetailSummaryProps) => {
   const { authorLength, fileLength, commitLength, insertions, deletions } = getCommitListDetail({
@@ -49,11 +50,11 @@ const Detail = ({ selectedData, clusterId, authSrcMap }: DetailProps) => {
   const commitNodeListInCluster =
     selectedData?.filter((selected) => selected.commitNodeList[0].clusterId === clusterId)[0].commitNodeList ?? [];
   const { commitNodeList, toggle, handleToggle } = useCommitListHide(commitNodeListInCluster);
+  const { repo, owner } = useGlobalData();
   const isShow = commitNodeListInCluster.length > FIRST_SHOW_NUM;
   const handleCommitIdCopy = (id: string) => async () => {
     navigator.clipboard.writeText(id);
   };
-
   if (!selectedData) return null;
 
   return (
@@ -84,15 +85,15 @@ const Detail = ({ selectedData, clusterId, authSrcMap }: DetailProps) => {
                 </span>
               </div>
               <div className="commit-id">
-                <span
+                <a
+                  href={`https://github.com/${owner}/${repo}/commit/${id}`}
                   onClick={handleCommitIdCopy(id)}
-                  role="button"
                   tabIndex={0}
                   onKeyDown={handleCommitIdCopy(id)}
                 >
                   {id.slice(0, 6)}
                   <span className="commit-id__tooltip">{id}</span>
-                </span>
+                </a>
               </div>
             </li>
           );


### PR DESCRIPTION
## Related issue
#534
## Result
https://github.com/user-attachments/assets/a451234b-b4f9-4291-8088-d9d511cacbb5

## Work list

- [x] 커밋 해시 코드를 클릭하면 해당 커밋 내역 링크 페이지로 이동합니다.

## Discussion
1. 현재 keydown시 커밋 해시 코드가 복사되고 있는데요. 모든 키보드 입력을 처리하기보다는 Enter 키를 눌렀을 때만 커밋 해시 코드가 복사되도록 하는게 더 자연스러울것같은데 어떻게 생각하시나요?👀 추가로 불필요한 handleCommitIdCopy함수 실행도 줄일수있을것같아요! :)
2. 오픈소스에 기여하는 작업이 익숙하지 않아 문제가 있다면 알려주세요! 감사합니다😌