### PR TITLE
[fix]#520 git 연동이 안된 프로젝트에서 무한로딩 증상 개선

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -42,6 +42,7 @@ export async function activate(context: vscode.ExtensionContext) {
         myStatusBarItem.text = `$(check) ${projectName}`;
         return;
       }
+
       const gitPath = (await findGit()).path;
 
       const currentWorkspaceUri = vscode.workspace.workspaceFolders?.[0].uri;
@@ -57,6 +58,7 @@ export async function activate(context: vscode.ExtensionContext) {
       }
 
       const fetchBranches = async () => await getBranches(gitPath, currentWorkspacePath);
+
       const fetchCurrentBranch = async () => {
         let branchName;
         try {
@@ -76,6 +78,7 @@ export async function activate(context: vscode.ExtensionContext) {
       const fetchClusterNodes = async (baseBranchName = initialBaseBranchName) => {
         const gitLog = await getGitLog(gitPath, currentWorkspacePath);
         const gitConfig = await getGitConfig(gitPath, currentWorkspacePath, "origin");
+
         const { owner, repo: initialRepo } = getRepo(gitConfig);
         webLoader.setGlobalOwnerAndRepo(owner, initialRepo);
         const repo = initialRepo[0];
@@ -89,8 +92,7 @@ export async function activate(context: vscode.ExtensionContext) {
         });
 
         const { isPRSuccess, csmDict } = await engine.analyzeGit();
-        if (isPRSuccess) console.log("crawling PR failed");
-
+        if (isPRSuccess) console.log("crawling PR Success");
         return mapClusterNodesFrom(csmDict);
       };
 
@@ -99,6 +101,7 @@ export async function activate(context: vscode.ExtensionContext) {
         fetchBranches,
         fetchCurrentBranch,
       });
+
       currentPanel = webLoader.getPanel();
 
       currentPanel?.onDidDispose(
@@ -121,6 +124,7 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.window.showErrorMessage(error.message);
       } else {
         vscode.window.showErrorMessage((error as Error).message);
+        myStatusBarItem.text = `$(diff-review-close) ${projectName}`;
       }
     }
   });

--- a/packages/vscode/src/webview-loader.ts
+++ b/packages/vscode/src/webview-loader.ts
@@ -15,8 +15,13 @@ export default class WebviewLoader implements vscode.Disposable {
     fetcher: GithruFetcherMap
   ) {
     const { fetchClusterNodes, fetchBranches, fetchCurrentBranch } = fetcher;
-
     const viewColumn = vscode.ViewColumn.One;
+
+    //캐시 초기화
+    console.log("Initialize cache data");
+    context.workspaceState.keys().forEach((key) => {
+      context.workspaceState.update(key, undefined);
+    });
 
     this._panel = vscode.window.createWebviewPanel("WebviewLoader", "githru-view", viewColumn, {
       enableScripts: true,
@@ -33,13 +38,24 @@ export default class WebviewLoader implements vscode.Disposable {
 
         if (command === "fetchAnalyzedData" || command === "refresh") {
           const baseBranchName = (payload && JSON.parse(payload)) ?? (await fetchCurrentBranch());
-          // Disable Cache temporarily
-          // const storedAnalyzedData = context.workspaceState.get<ClusterNode[]>(`${ANALYZE_DATA_KEY}_${baseBranchName}`);
-
-          // if (!storedAnalyzedData) {
           try {
-            analyzedData = await fetchClusterNodes(baseBranchName);
-            context.workspaceState.update(`${ANALYZE_DATA_KEY}_${baseBranchName}`, analyzedData);
+            const baseBranchName = (payload && JSON.parse(payload)) ?? (await fetchCurrentBranch());
+            const storedAnalyzedData = context.workspaceState.get<ClusterNode[]>(
+              `${ANALYZE_DATA_KEY}_${baseBranchName}`
+            );
+            let analyzedData = storedAnalyzedData;
+            if (!storedAnalyzedData) {
+              console.log("No cache Data");
+              console.log("baseBranchName : ", baseBranchName);
+              analyzedData = await fetchClusterNodes(baseBranchName);
+              context.workspaceState.update(`${ANALYZE_DATA_KEY}_${baseBranchName}`, analyzedData);
+            } else console.log("Cache data exists");
+
+            // 현재 캐싱된 Branch
+            console.log("Current Stored data");
+            context.workspaceState.keys().forEach((key) => {
+              console.log(key);
+            });
 
             const resMessage = {
               command,


### PR DESCRIPTION
## Related issue
#520 

## Result
git 연동이 안된 프로젝트에서 무한로딩 증상 개선을 위해 오른쪽 하단 toast메시지를 표기해주었습니다.  
![362687269-e2af7f98-3693-45a8-afbb-b5c0367f852e](https://github.com/user-attachments/assets/f3f46ebe-12c2-4ded-9213-919e8f9d5b2c)




## Work list
사용자에게 깃이 연동되지 않은 프로젝트를 보여줄 때 무한로딩화면을 제거하고 하단 오른쪽에 오류 메시지를 보여줄 수 있도록 변경하였습니다.

## Discussion
현재 패널이 잠깐 열렸다 닫히며 깜빡임이 있는데, 추후 웹뷰 판넬 자체가 열리지 않도록 개선이 필요합니다.
관련해서 코드 피드백을 주시면 적극 반영해보도록 하겠습니다! 
