### PR TITLE
[engine] getCommitRaws 함수 개선

### DIFF
--- a/packages/analysis-engine/src/constant.ts
+++ b/packages/analysis-engine/src/constant.ts
@@ -1,0 +1,2 @@
+export const COMMIT_SEPARATOR = "4itc2s8hH-oA64s08h19";
+export const GIT_LOG_SEPARATOR = "I9M-0XOzvHlYPegVPpzb";

--- a/packages/analysis-engine/src/index.ts
+++ b/packages/analysis-engine/src/index.ts
@@ -91,3 +91,4 @@ export class AnalysisEngine {
 }
 
 export default AnalysisEngine;
+export { COMMIT_SEPARATOR, GIT_LOG_SEPARATOR } from "./constant";

--- a/packages/analysis-engine/src/parser.spec.ts
+++ b/packages/analysis-engine/src/parser.spec.ts
@@ -1,7 +1,7 @@
 import { getCommitMessageType } from "./commit.util";
+import { COMMIT_SEPARATOR, GIT_LOG_SEPARATOR } from "./constant";
 import getCommitRaws from "./parser";
 import type { CommitRaw, DifferenceStatistic } from "./types";
-import { COMMIT_SEPARATOR, GIT_LOG_SEPARATOR } from "./constant";
 
 describe("commit message type", () => {
   it.each([

--- a/packages/analysis-engine/src/parser.spec.ts
+++ b/packages/analysis-engine/src/parser.spec.ts
@@ -1,6 +1,7 @@
 import { getCommitMessageType } from "./commit.util";
-import getCommitRaws from "./parser"; 
+import getCommitRaws from "./parser";
 import type { CommitRaw, DifferenceStatistic } from "./types";
+import { COMMIT_SEPARATOR, GIT_LOG_SEPARATOR } from "./constant";
 
 describe("commit message type", () => {
   it.each([
@@ -34,113 +35,114 @@ describe("commit message type", () => {
   });
 });
 
-describe('getCommitRaws', () => {
-  const testCommitLines = [
-    "commit a b (HEAD)",
-    "commit a b (HEAD -> main, origin/main, origin/HEAD)",
-    "commit a b (HEAD, tag: v1.0.0)",
-    "commit a b (HEAD -> main, origin/main, origin/HEAD, tag: v2.0.0)",
-    "commit a b (HEAD, tag: v2.0.0, tag: v1.4)"
+describe("getCommitRaws", () => {
+  const testAuthorCommitter = [
+    "John Park",
+    "mail@gmail.com",
+    "Sun Sep 4 20:17:59 2022 +0900",
+    "John Park 2",
+    "mail2@gmail.com",
+    "Sun Sep 5 20:17:59 2022 +0900",
   ];
+
+  const testRefs = [
+    "HEAD",
+    "HEAD -> main, origin/main, origin/HEAD",
+    "HEAD, tag: v1.0.0",
+    "HEAD -> main, origin/main, origin/HEAD, tag: v2.0.0",
+    "HEAD, tag: v2.0.0, tag: v1.4",
+  ];
+
+  const testCommitHash = ["a", "b"];
+
+  const testCommitMessage = "commit message";
+
+  const testCommitLines = testRefs.map((ref) =>
+    [...testCommitHash, ref, ...testAuthorCommitter, testCommitMessage].join(GIT_LOG_SEPARATOR)
+  );
 
   const expectedBranches = [
-    ['HEAD'],
-    ['HEAD', 'main', 'origin/main', 'origin/HEAD'],
-    ['HEAD'],
-    ['HEAD', 'main', 'origin/main', 'origin/HEAD'],
-    ['HEAD']
+    ["HEAD"],
+    ["HEAD", "main", "origin/main", "origin/HEAD"],
+    ["HEAD"],
+    ["HEAD", "main", "origin/main", "origin/HEAD"],
+    ["HEAD"],
   ];
 
-  const expectedTags = [
-    [],
-    [],
-    ['v1.0.0'],
-    ['v2.0.0'],
-    ['v2.0.0', 'v1.4']
-  ];
+  const expectedTags = [[], [], ["v1.0.0"], ["v2.0.0"], ["v2.0.0", "v1.4"]];
 
   const testCommitFileChanges = [
     "10\t0\ta.ts\n1\t0\tREADME.md",
     "3\t3\ta.ts",
     "4\t0\ta.ts",
-    "0\t6\ta.ts\n2\t0\tb.ts\n3\t3\tc.ts"
+    "0\t6\ta.ts\n2\t0\tb.ts\n3\t3\tc.ts",
   ];
 
-  const expectedFileChanged:DifferenceStatistic[] = [
+  const expectedFileChanged: DifferenceStatistic[] = [
     {
       totalInsertionCount: 11,
       totalDeletionCount: 0,
       fileDictionary: {
-        'a.ts': { insertionCount: 10, deletionCount: 0 },
-        'README.md': { insertionCount: 1, deletionCount: 0 },
-      }
+        "a.ts": { insertionCount: 10, deletionCount: 0 },
+        "README.md": { insertionCount: 1, deletionCount: 0 },
+      },
     },
     {
       totalInsertionCount: 3,
       totalDeletionCount: 3,
-      fileDictionary: { 'a.ts': { insertionCount: 3, deletionCount: 3 } }
+      fileDictionary: { "a.ts": { insertionCount: 3, deletionCount: 3 } },
     },
     {
       totalInsertionCount: 4,
       totalDeletionCount: 0,
-      fileDictionary: { 'a.ts': { insertionCount: 4, deletionCount: 0 } }
+      fileDictionary: { "a.ts": { insertionCount: 4, deletionCount: 0 } },
     },
     {
       totalInsertionCount: 5,
       totalDeletionCount: 9,
       fileDictionary: {
-        'a.ts': { insertionCount: 0, deletionCount: 6 },
-        'b.ts': { insertionCount: 2, deletionCount: 0 },
-        'c.ts': { insertionCount: 3, deletionCount: 3 },
-      }
-    }
+        "a.ts": { insertionCount: 0, deletionCount: 6 },
+        "b.ts": { insertionCount: 2, deletionCount: 0 },
+        "c.ts": { insertionCount: 3, deletionCount: 3 },
+      },
+    },
   ];
 
-  const commonExpectatedResult: CommitRaw={
+  const commonExpectatedResult: CommitRaw = {
     sequence: 0,
-    id: 'a',
-    parents: ['b'],
-    branches: ['HEAD'],
+    id: "a",
+    parents: ["b"],
+    branches: ["HEAD"],
     tags: [],
-    author: { name: 'John Park', email: 'mail@gmail.com' },
-    authorDate: new Date('Sun Sep 4 20:17:59 2022 +0900'),
-    committer: { name: 'John Park', email: 'mail@gmail.com' },
-    committerDate: new Date('Sun Sep 4 20:17:59 2022 +0900'),
-    message: 'commit message',
+    author: { name: testAuthorCommitter[0], email: testAuthorCommitter[1] },
+    authorDate: new Date(testAuthorCommitter[2]),
+    committer: { name: testAuthorCommitter[3], email: testAuthorCommitter[4] },
+    committerDate: new Date(testAuthorCommitter[5]),
+    message: testCommitMessage,
     differenceStatistic: {
       totalInsertionCount: 0,
       totalDeletionCount: 0,
       fileDictionary: {},
     },
-    commitMessageType: ""
+    commitMessageType: "",
   };
 
   testCommitLines.forEach((mockLog, index) => {
     it(`should parse gitlog to commitRaw(branch, tag)`, () => {
-      const mock = `${mockLog}
-Author: John Park <mail@gmail.com>
-AuthorDate: Sun Sep 4 20:17:59 2022 +0900
-Commit: John Park <mail@gmail.com>
-CommitDate: Sun Sep 4 20:17:59 2022 +0900
-\n\tcommit message
-`;
-      const result = getCommitRaws(mock);
-      const expectedResult = { ...commonExpectatedResult, branches: expectedBranches[index], tags: expectedTags[index] };
-      
+      const result = getCommitRaws(COMMIT_SEPARATOR + mockLog);
+      const expectedResult = {
+        ...commonExpectatedResult,
+        branches: expectedBranches[index],
+        tags: expectedTags[index],
+      };
+
       expect(result).toEqual([expectedResult]);
     });
   });
 
   testCommitFileChanges.forEach((mockLog, index) => {
     it(`should parse gitlog to commitRaw(file changed)`, () => {
-      const mock = `commit a b (HEAD)
-Author: John Park <mail@gmail.com>
-AuthorDate: Sun Sep 4 20:17:59 2022 +0900
-Commit: John Park <mail@gmail.com>
-CommitDate: Sun Sep 4 20:17:59 2022 +0900
-\n\tcommit message
-\n${mockLog}
-`;
+      const mock = `${COMMIT_SEPARATOR}${testCommitLines[0]}\n${mockLog}`;
       const result = getCommitRaws(mock);
       const expectedResult = { ...commonExpectatedResult, differenceStatistic: expectedFileChanged[index] };
 

--- a/packages/analysis-engine/src/parser.ts
+++ b/packages/analysis-engine/src/parser.ts
@@ -1,6 +1,6 @@
 import { getCommitMessageType } from "./commit.util";
-import type { CommitRaw } from "./types";
 import { COMMIT_SEPARATOR, GIT_LOG_SEPARATOR } from "./constant";
+import type { CommitRaw } from "./types";
 
 export default function getCommitRaws(log: string) {
   if (!log) return [];

--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -1,6 +1,7 @@
 import * as cp from "child_process";
 import * as fs from "fs";
 import * as path from "path";
+import { COMMIT_SEPARATOR, GIT_LOG_SEPARATOR } from "@githru-vscode-ext/analysis-engine";
 
 export interface GitExecutable {
   readonly path: string;
@@ -154,6 +155,20 @@ export async function getGitExecutableFromPaths(paths: string[]): Promise<GitExe
 
 export async function getGitLog(gitPath: string, currentWorkspacePath: string): Promise<string> {
   return new Promise((resolve, reject) => {
+    const gitLogFormat =
+      COMMIT_SEPARATOR +
+      [
+        "%H", // commit hash (id)
+        "%P", // parent hashes
+        "%D", // ref names (branches, tags)
+        "%an", // author name
+        "%ae", // author email
+        "%ad", // author date
+        "%cn",
+        "%ce",
+        "%cd", // committer name, committer email and committer date
+        "%s", // subject (commit message)
+      ].join(GIT_LOG_SEPARATOR);
     const args = [
       "--no-pager",
       "log",
@@ -161,7 +176,7 @@ export async function getGitLog(gitPath: string, currentWorkspacePath: string): 
       "--parents",
       "--numstat",
       "--date-order",
-      "--pretty=fuller",
+      `--pretty=format:${gitLogFormat}`,
       "--decorate",
       "-c",
     ];

--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -1,7 +1,7 @@
+import { COMMIT_SEPARATOR, GIT_LOG_SEPARATOR } from "@githru-vscode-ext/analysis-engine";
 import * as cp from "child_process";
 import * as fs from "fs";
 import * as path from "path";
-import { COMMIT_SEPARATOR, GIT_LOG_SEPARATOR } from "@githru-vscode-ext/analysis-engine";
 
 export interface GitExecutable {
   readonly path: string;


### PR DESCRIPTION
## Related issue

closes #675 

## Work list

중요한 변경하게 된 이유 설명을 빼먹어벼려서,,, 😅 이슈에도 추가해두긴 했습니다만 PR에도 남깁니다!

> 기존에 git log 포맷으로 사용하던 `fuller` 포맷은 사람이 이해하기에는 편한 포맷이지만 컴퓨터가 읽기에는 (간결한 코드로 파싱하기에는) 좀 복잡한 포맷이라고 생각했습니다.
`fuller` 포맷을 파싱하는 `getCommitRaws` 함수 코드를 봤을 때 해결하고 싶었던 부분이 조금 있었는데,
> 1. 로그를 new line 단위로 끊어서 `startWith`으로 각 라인의 첫 문장을 확인하여 파싱하는 방식이
   정확히 해당 코드가 어떤 내용을 파싱하고 있는지 (`fuller` 형식에 대한 이해가 부족하다면) 한눈에 이해하기 어려움
   예) `if (str.startsWith("CommitDate")` 분기에서 `CommitDate` 외에도 `commit message`와 `fileChange`를 처리함
> 2. fuller 포맷의 `“commit”`, `username <user email>`, ref 목록을 감싸는 괄호 등의 형식을 제거하는 코드가 오히려 `fuller` 형식을 모를 때에는 의도를 파악하기 어려움
> 3. line 별로 읽으면서 각 line을 카테고리별로 분리하는 for loop 한번
   각 카테고리의 원소들을 다시 json 타입으로 변환하는 for loop 한번, 총 2번의 for loop를 돌게 되는데, 
   이렇게 중복으로 동일한 데이터를 반복하는 것이 성능에 영향을 줄 것이라 생각

이러한 부분들을 해결해보고 싶어서 git log의 출력 형식을 변경하고, getCommitRaws의 파싱 과정을 변경해보려고 했습니다!

---

- `getGitLog` 함수로 불러오는 git log의 포맷을 파싱이 간단한 형태로 변경했습니다.
```
// as-is
commit fbb514f6136ae6c4cc0d289f95504fa11a483604 491c846957acfa4a8383e9d110b6f7c0213e4e5d (HEAD -> main, origin/main, origin/HEAD)
Author:     yoouyeon <jyeon.yoon59@gmail.com>
AuthorDate: Fri Aug 30 12:58:10 2024 +0900
Commit:     yoouyeon <jyeon.yoon59@gmail.com>
CommitDate: Fri Aug 30 12:58:10 2024 +0900

    fix(engine): lint error

1       1       packages/analysis-engine/src/parser.spec.ts
1       1       packages/analysis-engine/src/parser.ts
```

```
// to-be
4itc2s8hH-oA64s08h19fbb514f6136ae6c4cc0d289f95504fa11a483604I9M-0XOzvHlYPegVPpzb491c846957acfa4a8383e9d110b6f7c0213e4e5dI9M-0XOzvHlYPegVPpzbHEAD -> main, origin/main, origin/HEADI9M-0XOzvHlYPegVPpzbyoouyeonI9M-0XOzvHlYPegVPpzbjyeon.yoon59@gmail.comI9M-0XOzvHlYPegVPpzbFri Aug 30 12:58:10 2024 +0900I9M-0XOzvHlYPegVPpzbyoouyeonI9M-0XOzvHlYPegVPpzbjyeon.yoon59@gmail.comI9M-0XOzvHlYPegVPpzbFri Aug 30 12:58:10 2024 +0900I9M-0XOzvHlYPegVPpzbfix(engine): lint error
1       1       packages/analysis-engine/src/parser.spec.ts
1       1       packages/analysis-engine/src/parser.ts
```

- 변경한 git log 포맷에 맞게 `getCommitRaws` 의 파싱 방식을 수정했습니다.
- 변경한 git log 포맷에 맞게 `getCommitRaws` 테스트 케이스의 형식을 수정했습니다.
  (prettier에 문제가 있었는지,, 변경사항이 많아졌네요.. 🥲)

---




## Discussion

vscode 패키지의 `getGitLog`와 engine 패키지의 `getCommitRaws`에서 모두 쓰이는 SEPARATOR 상수를 우선 engine쪽 constant.ts에 선언해두었는데, 괜찮은 방법인지 잘 모르겠습니다,,,
더 좋은 방법이 있다면 코멘트 부탁드립니다! 🙇‍♀️