### PR TITLE
[engine/AI] AI 요약 기능 고도화

### DIFF
--- a/packages/analysis-engine/.gitignore
+++ b/packages/analysis-engine/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 coverage
+.env

--- a/packages/analysis-engine/src/index.ts
+++ b/packages/analysis-engine/src/index.ts
@@ -75,7 +75,8 @@ export class AnalysisEngine {
     if (this.isDebugMode) console.log("stemDict: ", stemDict);
     const csmDict = buildCSMDict(commitDict, stemDict, this.baseBranchName, pullRequests);
     if (this.isDebugMode) console.log("csmDict: ", csmDict);
-    const geminiCommitSummary = await getSummary(commitRaws?.slice(-10) ?? []);
+    const nodes = stemDict.get(this.baseBranchName)?.nodes?.map(({commit}) => commit);
+    const geminiCommitSummary = await getSummary(nodes ? nodes?.slice(-10) : []);
     if (this.isDebugMode) console.log("GeminiCommitSummary: ", geminiCommitSummary);
 
     return {

--- a/packages/analysis-engine/src/summary.ts
+++ b/packages/analysis-engine/src/summary.ts
@@ -4,9 +4,8 @@ const apiKey = process.env.GEMENI_API_KEY || '';
 const apiUrl = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=";
 
 export async function getSummary(csmNodes: CommitRaw[]) {
-  const commitMessages = csmNodes.map((csmNode) => csmNode.message).join(', ');
+  const commitMessages = csmNodes.map((csmNode) => csmNode.message.split('\n')[0]).join(', ');
 
-  console.log(commitMessages, 'apiKey');
   try {
     const response = await fetch(apiUrl + apiKey, {
       method: "POST",


### PR DESCRIPTION
## Related issue

close #579 

## Result

- 기존 커밋 요약 기능을 main 브랜치가 아닌 모든 브랜치의 STEM에서 동작하도록 합니다.
- 특정 노드의 상위 10개 커밋까지만 가져와서 요약합니다.
- 브랜치를 변경하면 summary 결과가 다르게 출력됩니다. 

## Work list

formik 라이브러리에서 브랜치를 변경한 후 나온 출력물입니다.

![Screenshot 2024-08-31 at 5 06 59 PM](https://github.com/user-attachments/assets/47b2ed2d-5c95-480c-bcba-d1823a1772c7)
![Screenshot 2024-08-31 at 5 07 32 PM](https://github.com/user-attachments/assets/657657c4-7f34-4a44-be44-e3ab1414a378)
![Screenshot 2024-08-31 at 5 07 14 PM](https://github.com/user-attachments/assets/c1f860f8-c61c-42b6-a65e-79997f023a61)

## Discussion

커밋을 가져오는 기준, view에서 보여주는 방법에 대해서는 별도 이슈에서 논의할 예정입니다!
