### PR TITLE
[view] Theme Selector 구현 및 테마에 따른 컴포넌트 컬러 변경

### DIFF
--- a/packages/view/src/App.scss
+++ b/packages/view/src/App.scss
@@ -1,5 +1,3 @@
-@import "styles/_custom";
-
 // FIXME
 :root {
   --primary-color: #ff8272;
@@ -14,19 +12,9 @@ body {
   position: relative;
   display: flex;
   height: 60px;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
-}
-
-.header-buttons {
-  position: absolute;
-  right: 0;
-  display: flex;
-  align-items: center;
-
-  > *:not(:last-child) {
-    margin-right: 4px;
-  }
+  padding: 0 20px;
 }
 
 .top-container {

--- a/packages/view/src/App.tsx
+++ b/packages/view/src/App.tsx
@@ -66,11 +66,9 @@ const App = () => {
   return (
     <>
       <div className="header-container">
+        <ThemeSelector />
         <BranchSelector />
-        <div className="header-buttons">
-          <ThemeSelector />
-          <RefreshButton />
-        </div>
+        <RefreshButton />
       </div>
       <div className="top-container">
         <TemporalFilter />

--- a/packages/view/src/components/Detail/Detail.scss
+++ b/packages/view/src/components/Detail/Detail.scss
@@ -21,6 +21,7 @@
       position: relative;
       margin-right: 10px;
       display: inline-flex;
+      align-items: center;
       gap: 4px;
 
       &:last-child {
@@ -30,11 +31,11 @@
   }
 
   .additions {
-    color: green;
+    color: var(--color-success);
   }
 
   .deletions {
-    color: red;
+    color: var(--color-failed);
   }
 }
 
@@ -112,11 +113,22 @@
       width: 6em;
       position: relative;
 
+      a {
+        text-decoration: none;
+        color: var(--color-lightgray);
+        &:visited {
+          color: var(--color-lightgray);
+        }
+        &:hover {
+          color: var(--color-primary);
+          .commit-id__tooltip {
+            display: inline-block;
+          }
+        }
+      }
+
       a:hover {
         cursor: pointer;
-        .commit-id__tooltip {
-          display: inline-block;
-        }
       }
     }
   }
@@ -127,7 +139,7 @@
   margin: 0 auto;
   border: none;
   background: none;
-  color: var(--primary-color);
+  color: var(--color-tertiary);
   cursor: pointer;
 
   &:hover {

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
@@ -61,14 +61,12 @@
     .bar {
       &:hover {
         rect {
-          fill: transparent;
-          stroke: var(--primary-color);
-          stroke-width: 2;
+          fill: var(--color-tertiary);
         }
       }
 
       rect {
-        fill: var(--primary-color);
+        fill: var(--color-secondary);
       }
 
       .name {
@@ -94,7 +92,7 @@
   color: $gray-900;
 
   .selected {
-    color: var(--primary-color);
+    color: var(--color-primary);
     font-weight: $font-weight-semibold;
   }
   .name {

--- a/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.scss
+++ b/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.scss
@@ -3,7 +3,7 @@
 .file-icicle-summary {
   width: 16rem;
   text {
-    fill: var(--primary-color);
+    fill: var(--color-primary);
     filter: invert(100) grayscale(100) contrast(100);
   }
 }

--- a/packages/view/src/components/TemporalFilter/LineChart.scss
+++ b/packages/view/src/components/TemporalFilter/LineChart.scss
@@ -11,5 +11,5 @@
 
 .cloc-line-chart {
   overflow: visible;
-  fill: var(--primary-color);
+  fill: var(--color-primary);
 }

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.scss
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.scss
@@ -15,7 +15,7 @@
       width: 3rem;
       margin-right: 1rem;
       text-transform: none;
-      background-color: var(--primary-color);
+      background-color: var(--color-tertiary);
     }
 
     span {
@@ -27,6 +27,9 @@
   .line-charts-svg {
     height: 100%;
     width: 100%;
+    > g > text {
+      fill: var(--color-tertiary);
+    }
   }
 
   .line-chart-wrap {
@@ -40,7 +43,7 @@
 
   .line-chart {
     overflow: visible;
-    fill: var(--primary-color);
+    fill: var(--color-primary);
   }
 }
 

--- a/packages/view/src/components/ThemeSelector/ThemeSelector.scss
+++ b/packages/view/src/components/ThemeSelector/ThemeSelector.scss
@@ -1,13 +1,77 @@
-@import "styles/_pallete";
+@import "styles/app";
 
 .theme-selector {
-  input[type="color"] {
-    outline: none;
-    -webkit-appearance: none;
-    padding: 0;
-    border: none;
-    background-color: transparent;
-    width: 54px;
-    height: 30px;
+  position: relative;
+  svg {
+    cursor: pointer;
+  }
+}
+
+.selector__container {
+  position: absolute;
+  top: 30px;
+  left: 0;
+  padding: 24px;
+  background-color: var(--color-darkgray);
+  border-radius: 5px 40px 40px 40px;
+  z-index: 10;
+
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  > div {
+    display: flex;
+    justify-content: space-between;
+    gap: 4px;
+    &:nth-child(1) {
+      font-size: $font-size-title;
+      font-weight: $font-weight-semibold;
+    }
+    &:nth-child(2) {
+      display: flex;
+    }
+  }
+}
+
+.theme-icon {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-items: center;
+  gap: 24px;
+  padding: 10px;
+  box-sizing: border-box;
+
+  &:hover,
+  &--selected {
+    @extend .theme-icon;
+    background-color: #363636;
+    border-radius: 10px;
+    cursor: pointer;
+  }
+
+  p {
+    font-size: $font-size-body;
+    font-weight: $font-weight-regular;
+  }
+}
+
+.icon__container {
+  position: relative;
+  margin: auto;
+
+  display: flex;
+  justify-items: center;
+  align-items: center;
+
+  > div {
+    width: 42px;
+    height: 42px;
+    border-radius: 100%;
+    margin-left: -12px;
+    &:nth-child(1) {
+      margin-left: 0;
+    }
   }
 }

--- a/packages/view/src/components/ThemeSelector/ThemeSelector.tsx
+++ b/packages/view/src/components/ThemeSelector/ThemeSelector.tsx
@@ -1,7 +1,3 @@
-// 1. 코드리뷰 (변수명, 로직 등) - 특히 theme colors를 가져오는 방식
-// 2. localStorage에 저장 못 하는 이슈.
-// 3. 컬러 배치를 어떻게 해야 할지 ? (primary, secondary의 영역)
-
 import { useEffect, useState } from "react";
 import "./ThemeSelector.scss";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";

--- a/packages/view/src/components/ThemeSelector/ThemeSelector.tsx
+++ b/packages/view/src/components/ThemeSelector/ThemeSelector.tsx
@@ -1,39 +1,144 @@
+// 1. 코드리뷰 (변수명, 로직 등) - 특히 theme colors를 가져오는 방식
+// 2. localStorage에 저장 못 하는 이슈.
+// 3. 컬러 배치를 어떻게 해야 할지 ? (primary, secondary의 영역)
+
+import { useEffect, useState } from "react";
 import "./ThemeSelector.scss";
-import { useCallback, useEffect, useState } from "react";
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import CloseIcon from "@mui/icons-material/Close";
 
-import { debounce } from "utils";
-import { setPrimaryColor } from "services";
+const themes = [
+  {
+    title: "Githru",
+    value: "githru",
+    colors: {
+      primary: "#f14f8c",
+      secondary: "#8421c9",
+      tertiary: "#ffcb7d",
+    },
+  },
+  {
+    title: "Hacker Blue",
+    value: "hacker-blue",
+    colors: {
+      primary: "#456cf7",
+      secondary: "#0c216f",
+      tertiary: "#6c60f0",
+    },
+  },
+  {
+    title: "Aqua",
+    value: "aqua",
+    colors: {
+      primary: "#25d4bf",
+      secondary: "#0687a3",
+      tertiary: "#35ffff",
+    },
+  },
+  {
+    title: "Cotton Candy",
+    value: "cotton-candy",
+    colors: {
+      primary: "#ffcccb",
+      secondary: "#feffd1",
+      tertiary: "#8979ca",
+    },
+  },
 
-import { PRIMARY_COLOR_VARIABLE_NAME } from "../../constants/constants";
+  {
+    title: "Mono",
+    value: "mono",
+    colors: {
+      primary: "#5f6f86",
+      secondary: "#3a4776",
+      tertiary: "#9499c3",
+    },
+  },
+];
 
-const ThemeSelector = () => {
-  const [color, setColor] = useState<string>(window.primaryColor);
+type ThemeIconsProps = {
+  title: string;
+  value: string;
+  colors: {
+    primary: string;
+    secondary: string;
+    tertiary: string;
+  };
+  onClick: () => void;
+};
+
+const ThemeIcons = ({ title, value, colors, onClick }: ThemeIconsProps) => {
+  const [isSelected, setIsSelected] = useState<string>("");
 
   useEffect(() => {
-    document.documentElement.style.setProperty(PRIMARY_COLOR_VARIABLE_NAME, window.primaryColor);
+    const selectedTheme = document.documentElement.getAttribute("custom-type");
+    if (selectedTheme) setIsSelected(selectedTheme);
   }, []);
 
-  const storeColorHandler = debounce((colorCode: string) => {
-    setPrimaryColor(colorCode);
-  }, 3000);
-
-  const handlePrimaryColor = useCallback(
-    (colorCode: string) => storeColorHandler(colorCode),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
+  return (
+    <div
+      className={`theme-icon${isSelected === value ? "--selected" : ""}`}
+      onClick={onClick}
+      role="presentation"
+    >
+      <div className="icon__container">
+        <div
+          className="icon"
+          style={{ backgroundColor: colors.primary }}
+        />
+        <div
+          className="icon"
+          style={{ backgroundColor: colors.secondary }}
+        />
+        <div
+          className="icon"
+          style={{ backgroundColor: colors.tertiary }}
+        />
+      </div>
+      <p>{title}</p>
+    </div>
   );
+};
+
+const ThemeSelector = () => {
+  const [open, setOpen] = useState<boolean>(false);
+
+  const handleTheme = (value: string) => {
+    document.documentElement.setAttribute("custom-type", value);
+  };
+
+  useEffect(() => {
+    document.documentElement.setAttribute("custom-type", "githru");
+  }, []);
 
   return (
     <div className="theme-selector">
-      <input
-        type="color"
-        value={color}
-        onChange={(e) => {
-          setColor(e.target.value);
-          handlePrimaryColor(e.target.value as string);
-          document.documentElement.style.setProperty(PRIMARY_COLOR_VARIABLE_NAME, e.target.value);
-        }}
-      />
+      <AutoAwesomeIcon onClick={() => setOpen(true)} />
+      {open && (
+        <div className="selector__container">
+          <div>
+            <p>Theme</p>
+            <CloseIcon
+              fontSize="small"
+              onClick={() => setOpen(false)}
+            />
+          </div>
+          <div>
+            {themes.map((theme) => (
+              <ThemeIcons
+                key={theme.value}
+                title={theme.title}
+                value={theme.value}
+                colors={theme.colors}
+                onClick={() => {
+                  handleTheme(theme.value);
+                  setOpen(false);
+                }}
+              />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
+++ b/packages/view/src/components/VerticalClusterList/ClusterGraph/ClusterGraph.scss
@@ -13,23 +13,23 @@
   .cluster-graph-container__box {
     rx: 5;
     stroke-width: 1;
-    stroke: var(--primary-color);
+    stroke: var(--color-primary);
     fill: transparent;
   }
 
   .cluster-graph-container__commit-amount-cluster {
     rx: 5;
-    fill: var(--primary-color);
+    fill: var(--color-primary);
   }
 }
 
 .cluster-graph__connector-line {
-  stroke: var(--primary-color);
+  stroke: var(--color-primary);
   stroke-width: 1;
 }
 
 .circle-group {
-  fill: var(--primary-color);
+  fill: var(--color-primary);
 }
 
 .sub-graph-tooltip {

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -20,7 +20,7 @@
       border: none;
       background-color: transparent;
       cursor: pointer;
-      color: $white;
+      color: var(--color-text-white);
       width: 100%;
 
       &:hover {
@@ -56,7 +56,7 @@
       background-color: transparent;
       border: none;
       font-size: 24px;
-      color: var(--primary-color);
+      color: var(--color-primary);
       visibility: hidden;
       cursor: pointer;
 
@@ -91,6 +91,17 @@
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;
+
+          a {
+            text-decoration: none;
+            color: var(--color-lightgray);
+            &:visited {
+              color: var(--color-lightgray);
+            }
+            &:hover {
+              color: var(--color-primary);
+            }
+          }
         }
       }
 
@@ -113,7 +124,7 @@
 }
 
 .sort-button {
-  color: var(--primary-color);
+  color: var(--color-primary);
   cursor: pointer;
   position: absolute;
   right: 26%;

--- a/packages/view/src/constants/constants.tsx
+++ b/packages/view/src/constants/constants.tsx
@@ -1,4 +1,4 @@
 export const GITHUB_URL = "https://github.com";
 export const GRAVATA_URL = "https://www.gravatar.com/avatar";
-export const PRIMARY_COLOR_VARIABLE_NAME = "--primary-color";
+export const PRIMARY_COLOR_VARIABLE_NAME = "--color-primary";
 export const NODE_TYPES = ["COMMIT", "CLUSTER"] as const;

--- a/packages/view/src/styles/_customTheme.scss
+++ b/packages/view/src/styles/_customTheme.scss
@@ -1,6 +1,17 @@
 :root {
   --color-black: #000000;
   --color-white: #ffffff;
+  --color-lightgray: #bdbdbd;
+  --color-darkgray: #3e3e3e;
+  --color-text-white: #f8f8f8;
+}
+
+html[custom-type="hacker-blue"] {
+  --color-primary: #456cf7;
+  --color-secondary: #465070;
+  --color-tertiary: #6c60f0;
+  --color-success: #1fc7a9;
+  --color-failed: #ee2479;
 }
 
 html[custom-type="aqua"] {
@@ -11,15 +22,7 @@ html[custom-type="aqua"] {
   --color-failed: #ee2479;
 }
 
-html[custom-type="hacker-blue"] {
-  --color-primary: #456cf7;
-  --color-secondary: #0c216f;
-  --color-tertiary: #6c60f0;
-  --color-success: #1fc7a9;
-  --color-failed: #ee2479;
-}
-
-html[custom-type="cotton"] {
+html[custom-type="cotton-candy"] {
   --color-primary: #ffcccb;
   --color-secondary: #feffd1;
   --color-tertiary: #8979ca;

--- a/packages/view/src/styles/app.scss
+++ b/packages/view/src/styles/app.scss
@@ -1,4 +1,4 @@
-@import "custom";
+@import "customTheme";
 @import "colors";
 @import "font";
 @import "pallete";


### PR DESCRIPTION
## Related issue
#686 #647 

## Result
https://github.com/user-attachments/assets/4026ce71-abee-4470-a8b1-4b393fe24b93

## Work list
사용자가 테마를 선택할 수 있는 Theme Selector를 구현했습니다.
왼쪽 상단의 버튼을 클릭하면 Theme Selector가 표시되고, 이를 이용해 테마를 선택할 수 있습니다.

## Discussion
- 사용자가 다시 githru에 접속을 했을 때, 기존에 설정한 theme을 저장할 방법으로 vscode의 context를 이용해보려고 합니다. (현재 PR엔 적용되어있지 않습니다.)
- 컬러에 대한 피드백 부탁드립니다 ! 색상이 막상 적용되니 별로다 ... 🥲 하는 부분도 수렴 후 반영하도록 하겠습니다. 
- 코드리뷰 부탁드립니다 🥹 특히 변수명, 구현 로직에 대한 의견 주시면 감사드리겠습니다 !! 
