### PR TITLE
reset 버튼 위치 수정

### DIFF
--- a/packages/view/src/App.scss
+++ b/packages/view/src/App.scss
@@ -14,7 +14,7 @@ body {
   height: 60px;
   justify-content: space-between;
   align-items: center;
-  padding: 0 20px;
+  padding: 0 12px 0 20px;
 }
 
 .top-container {

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.scss
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.scss
@@ -10,12 +10,14 @@
     flex-direction: column;
     align-items: flex-end;
     gap: 1rem;
+    position: relative;
 
     .reset-button {
       width: 3rem;
-      margin-right: 1rem;
       text-transform: none;
       background-color: var(--color-tertiary);
+      position: absolute;
+      top: 0;
     }
 
     span {

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
@@ -6,6 +6,7 @@ import BounceLoader from "react-spinners/BounceLoader";
 import { Button } from "@mui/material";
 
 import { useGlobalData } from "hooks";
+import { useLoadingStore } from "store";
 
 import { filterDataByDate, getMinMaxDate, lineChartTimeFormatter, sortBasedOnCommitNode } from "./TemporalFilter.util";
 import "./TemporalFilter.scss";
@@ -15,7 +16,6 @@ import { useWindowResize } from "./TemporalFilter.hook";
 import type { BrushXSelection } from "./LineChartBrush";
 import { createBrush, drawBrush, resetBrush } from "./LineChartBrush";
 import { BRUSH_MARGIN, TEMPORAL_FILTER_LINE_CHART_STYLES } from "./LineChart.const";
-import { useLoadingStore } from "store";
 
 const TemporalFilter = () => {
   const { data, filteredData, setFilteredData, filteredRange, setFilteredRange, setSelectedData } = useGlobalData();


### PR DESCRIPTION
## Related issue
#699 

## Result
![image](https://github.com/user-attachments/assets/a69748ec-af44-492b-93e7-4bd634dee516)

## Work list
- reset 버튼을 그래프 위로 띄워서 그래프의 날짜 부분이 잘리는 이슈를 해결하였습니다.
- padding 값을 조절하여 reset, refresh, theme 버튼을 양 끝 단에 맞췄습니다.