### PR TITLE
[engine] getCommitRaws 테스트코드 보완

### DIFF
--- a/packages/analysis-engine/src/parser.spec.ts
+++ b/packages/analysis-engine/src/parser.spec.ts
@@ -36,12 +36,16 @@ describe("commit message type", () => {
 });
 
 describe("getCommitRaws", () => {
-  const testCommitLines = [
-    `${COMMIT_SEPARATOR}a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}commit message`,
-    `${COMMIT_SEPARATOR}a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD -> main, origin/main, origin/HEAD${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}commit message`,
-    `${COMMIT_SEPARATOR}a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD, tag: v1.0.0${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}commit message`,
-    `${COMMIT_SEPARATOR}a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD -> main, origin/main, origin/HEAD, tag: v2.0.0${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}commit message`,
-    `${COMMIT_SEPARATOR}a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD, tag: v2.0.0, tag: v1.4${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}commit message`,
+  const testAuthorAndCommitter = `${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900`
+
+  const testCommitMessage = `${GIT_LOG_SEPARATOR}commit message`;
+
+  const testCommitHashAndRefs = [
+    `a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD`,
+    `a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD -> main, origin/main, origin/HEAD`,
+    `a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD, tag: v1.0.0`,
+    `a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD -> main, origin/main, origin/HEAD, tag: v2.0.0`,
+    `a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD, tag: v2.0.0, tag: v1.4`,
   ];
 
   const expectedBranches = [
@@ -110,9 +114,9 @@ describe("getCommitRaws", () => {
     commitMessageType: "",
   };
 
-  testCommitLines.forEach((mockLog, index) => {
+  testCommitHashAndRefs.forEach((hashAndRefs, index) => {
     it(`should parse gitlog to commitRaw(branch, tag)`, () => {
-      const result = getCommitRaws(mockLog);
+      const result = getCommitRaws(`${COMMIT_SEPARATOR}${hashAndRefs}${testAuthorAndCommitter}${testCommitMessage}`);
       const expectedResult = {
         ...commonExpectatedResult,
         branches: expectedBranches[index],
@@ -125,7 +129,7 @@ describe("getCommitRaws", () => {
 
   testCommitFileChanges.forEach((mockLog, index) => {
     it(`should parse gitlog to commitRaw(file changed)`, () => {
-      const mock = `${COMMIT_SEPARATOR}${testCommitLines[0]}\n${mockLog}`;
+      const mock = `${COMMIT_SEPARATOR}${testCommitHashAndRefs[0]}${testAuthorAndCommitter}${testCommitMessage}\n${mockLog}`;
       const result = getCommitRaws(mock);
       const expectedResult = { ...commonExpectatedResult, differenceStatistic: expectedFileChanged[index] };
 

--- a/packages/analysis-engine/src/parser.spec.ts
+++ b/packages/analysis-engine/src/parser.spec.ts
@@ -127,9 +127,9 @@ describe("getCommitRaws", () => {
     });
   });
 
-  testCommitFileChanges.forEach((mockLog, index) => {
+  testCommitFileChanges.forEach((fileChange, index) => {
     it(`should parse gitlog to commitRaw(file changed)`, () => {
-      const mock = `${COMMIT_SEPARATOR}${testCommitHashAndRefs[0]}${testAuthorAndCommitter}${testCommitMessage}\n${mockLog}`;
+      const mock = `${COMMIT_SEPARATOR}${testCommitHashAndRefs[0]}${testAuthorAndCommitter}${testCommitMessage}\n${fileChange}`;
       const result = getCommitRaws(mock);
       const expectedResult = { ...commonExpectatedResult, differenceStatistic: expectedFileChanged[index] };
 

--- a/packages/analysis-engine/src/parser.spec.ts
+++ b/packages/analysis-engine/src/parser.spec.ts
@@ -36,7 +36,7 @@ describe("commit message type", () => {
 });
 
 describe("getCommitRaws", () => {
-  const testAuthorAndCommitter = `${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900`
+  const testAuthorAndCommitter = `${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900`;
 
   const testCommitMessage = `${GIT_LOG_SEPARATOR}commit message`;
 

--- a/packages/analysis-engine/src/parser.spec.ts
+++ b/packages/analysis-engine/src/parser.spec.ts
@@ -36,30 +36,13 @@ describe("commit message type", () => {
 });
 
 describe("getCommitRaws", () => {
-  const testAuthorCommitter = [
-    "John Park",
-    "mail@gmail.com",
-    "Sun Sep 4 20:17:59 2022 +0900",
-    "John Park 2",
-    "mail2@gmail.com",
-    "Sun Sep 5 20:17:59 2022 +0900",
+  const testCommitLines = [
+    `${COMMIT_SEPARATOR}a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}commit message`,
+    `${COMMIT_SEPARATOR}a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD -> main, origin/main, origin/HEAD${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}commit message`,
+    `${COMMIT_SEPARATOR}a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD, tag: v1.0.0${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}commit message`,
+    `${COMMIT_SEPARATOR}a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD -> main, origin/main, origin/HEAD, tag: v2.0.0${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}commit message`,
+    `${COMMIT_SEPARATOR}a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD, tag: v2.0.0, tag: v1.4${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}commit message`,
   ];
-
-  const testRefs = [
-    "HEAD",
-    "HEAD -> main, origin/main, origin/HEAD",
-    "HEAD, tag: v1.0.0",
-    "HEAD -> main, origin/main, origin/HEAD, tag: v2.0.0",
-    "HEAD, tag: v2.0.0, tag: v1.4",
-  ];
-
-  const testCommitHash = ["a", "b"];
-
-  const testCommitMessage = "commit message";
-
-  const testCommitLines = testRefs.map((ref) =>
-    [...testCommitHash, ref, ...testAuthorCommitter, testCommitMessage].join(GIT_LOG_SEPARATOR)
-  );
 
   const expectedBranches = [
     ["HEAD"],
@@ -114,11 +97,11 @@ describe("getCommitRaws", () => {
     parents: ["b"],
     branches: ["HEAD"],
     tags: [],
-    author: { name: testAuthorCommitter[0], email: testAuthorCommitter[1] },
-    authorDate: new Date(testAuthorCommitter[2]),
-    committer: { name: testAuthorCommitter[3], email: testAuthorCommitter[4] },
-    committerDate: new Date(testAuthorCommitter[5]),
-    message: testCommitMessage,
+    author: { name: "John Park", email: "mail@gmail.com" },
+    authorDate: new Date("Sun Sep 4 20:17:59 2022 +0900"),
+    committer: { name: "John Park 2", email: "mail2@gmail.com" },
+    committerDate: new Date("Sun Sep 5 20:17:59 2022 +0900"),
+    message: "commit message",
     differenceStatistic: {
       totalInsertionCount: 0,
       totalDeletionCount: 0,
@@ -129,7 +112,7 @@ describe("getCommitRaws", () => {
 
   testCommitLines.forEach((mockLog, index) => {
     it(`should parse gitlog to commitRaw(branch, tag)`, () => {
-      const result = getCommitRaws(COMMIT_SEPARATOR + mockLog);
+      const result = getCommitRaws(mockLog);
       const expectedResult = {
         ...commonExpectatedResult,
         branches: expectedBranches[index],


### PR DESCRIPTION
## Related issue

- Closes #690
- #680 
- #691

## Work list

- `join` 연산을 이용해서 생성하던 `testCommitLines` 의 값을 본연의 값을 사용하도록 수정했습니다.
- 다소 포괄적인 의미를 담고 있는`testCommitLines`, `mocklog` 라는 이름을 보다 담긴 데이터 파악이 용이하도록 변경했습니다. (`testCommitHashAndRefs`, `hashAndRefs` / `fileChange`)
- 테스트 코드 내에서 반복적으로 사용되는 `testAuthorAndCommitter`, `testCommitMessage`를 재사용이 가능하도록 상수화했습니다.

## Discussion

git log 출력의 온전한 구조를 테스트 코드 내에서 확인할 수 있어도 괜찮겠다는 생각에 출력 구조 그대로를 테스트 코드로 만드려고 했었는데, 
테스트 코드가 길어지고 가독성이 너무 떨어지게 되는 것 같아서 현재 PR의 방식대로 값들을 조합해서 구조를 만드는 쪽으로 했습니다. (위에 적은 것 처럼 재사용을 위해서도 있고요 ㅎㅎ)

변경된 구조를 잘 아는 제 입장에서는 객관적인 평가가 어려운 것 같아 어떤 쪽이 좀 더 git log 출력의 구조를 이해하기 쉬운지 의견 남겨주시면 큰 도움이 될 것 같습니다...!! 🙇‍♀️ (개인적으로는 지금의 값을 조합하는 방식이 좀 더 읽기 쉬워보입니다...ㅎㅎㅎ)
```
// 값을 조합하는 방식
`${COMMIT_SEPARATOR}${hashAndRefs}${testAuthorAndCommitter}${testCommitMessage}`

// 전체 구조
`${COMMIT_SEPARATOR}a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}commit message`
```
