### PR TITLE
[view] Author Bar Chart select box mui로 변경

### DIFF
--- a/packages/view/src/components/BranchSelector/BranchSelector.tsx
+++ b/packages/view/src/components/BranchSelector/BranchSelector.tsx
@@ -35,6 +35,7 @@ const BranchSelector = () => {
               sx: {
                 backgroundColor: "#212121",
                 color: "white",
+                marginTop: "1px",
                 "& .MuiMenuItem-root": {
                   backgroundColor: "#212121 !important ",
                   "&:hover": {

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.const.ts
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.const.ts
@@ -1,5 +1,5 @@
 export const DIMENSIONS = {
-  width: 200,
+  width: 250,
   height: 200,
   margins: 60,
 };

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.scss
@@ -16,20 +16,20 @@
   width: 100%;
   text-align: right;
 
-  & .select-box {
-    font-size: $font-size-caption;
-    background: transparent;
-    border: 1px solid $white;
-    border-radius: 5px;
-    width: fit-content;
-    padding: 0 10px;
+  .select-box {
+    background-color: #212121;
+    border: 1px solid var(--color-white);
+    color: var(--color-white);
     height: 25px;
-    color: $white;
-    outline: none;
-    text-align: center;
+    width: 100px;
+    font-size: $font-size-caption;
 
-    option {
-      background: $gray-900;
+    & .MuiSvgIcon-root {
+      color: var(--color-white);
+    }
+
+    &.Mui-focused .MuiOutlinedInput-notchedOutline {
+      border: none;
     }
   }
 }

--- a/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
+++ b/packages/view/src/components/Statistics/AuthorBarChart/AuthorBarChart.tsx
@@ -1,6 +1,8 @@
-import type { ChangeEvent, MouseEvent } from "react";
+import type { MouseEvent } from "react";
 import { useRef, useEffect, useState } from "react";
 import * as d3 from "d3";
+import type { SelectChangeEvent } from "@mui/material";
+import { FormControl, MenuItem, Select } from "@mui/material";
 
 import type { ClusterNode, AuthorInfo } from "types";
 import { useGlobalData } from "hooks";
@@ -207,27 +209,53 @@ const AuthorBarChart = () => {
     setSelectedAuthor,
   ]);
 
-  const handleChangeMetric = (e: ChangeEvent<HTMLSelectElement>): void => {
-    setMetric(e.target.value as MetricType);
+  const handleChangeMetric = (event: SelectChangeEvent): void => {
+    setMetric(event.target.value as MetricType);
   };
 
   return (
     <div className="author-bar-chart__container">
       <p>Author Bar Chart</p>
       <div className="author-bar-chart__header">
-        <select
-          className="select-box"
-          onChange={handleChangeMetric}
+        <FormControl
+          sx={{ m: 1, minWidth: 120 }}
+          size="small"
         >
-          {METRIC_TYPE.map((option) => (
-            <option
-              key={option}
-              value={option}
-            >
-              {option === METRIC_TYPE[0] ? `${option} #` : option}
-            </option>
-          ))}
-        </select>
+          <Select
+            value={metric}
+            className="select-box"
+            onChange={handleChangeMetric}
+            inputProps={{ "aria-label": "Without label" }}
+            MenuProps={{
+              PaperProps: {
+                sx: {
+                  marginTop: "1px",
+                  backgroundColor: "#212121",
+                  color: "white",
+                  "& .MuiMenuItem-root": {
+                    fontSize: "12px",
+                    backgroundColor: "#212121 !important ",
+                    "&:hover": {
+                      backgroundColor: "#333333 !important",
+                    },
+                  },
+                  "& .MuiMenuItem-root.Mui-selected": {
+                    backgroundColor: "#333333 !important",
+                  },
+                },
+              },
+            }}
+          >
+            {METRIC_TYPE.map((option) => (
+              <MenuItem
+                key={option}
+                value={option}
+              >
+                {option === METRIC_TYPE[0] ? `${option} #` : option}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
       </div>
       <svg
         className="author-bar-chart"


### PR DESCRIPTION
## Related issue
close #696

## Result
- Author Bar Chart의 select box를 mui Select로 변경했습니다.
<img width="294" alt="image" src="https://github.com/user-attachments/assets/a266cf32-993e-48d2-92ec-04a9a41e5b57">

<br/>
<br/>

- 상단 branch select에서 dropdown이 select 박스 일부를 가려, dropdown에 `marginTop:1px` 값을 주었습니다.
- 수정 전
<img width="220" alt="image" src="https://github.com/user-attachments/assets/1ce56142-06b8-43c8-abd3-85f6dcc89dad">

- 수정 후
<img width="275" alt="image" src="https://github.com/user-attachments/assets/8467df83-babf-4e1a-8247-18f0ba1fb422">



## Work list

## Discussion
https://github.com/githru/githru-vscode-ext/pull/710 이 머지된 후에 color 관련해서 이번 pr도 수정하기 위해 draft pr로 올려두겠습니다.