### PR TITLE
[engine/AI] 현재 author가 작성한 커밋이 있다면 최신 10개 커밋 요약하기

### DIFF
--- a/packages/analysis-engine/src/index.ts
+++ b/packages/analysis-engine/src/index.ts
@@ -7,7 +7,7 @@ import { buildCSMDict } from "./csm";
 import getCommitRaws from "./parser";
 import { PluginOctokit } from "./pluginOctokit";
 import { buildStemDict } from "./stem";
-import { getSummary } from "./summary";
+import { getCurrentUserCommitSummary, getLatestCommitSummary } from "./summary";
 
 type AnalysisEngineArgs = {
   isDebugMode?: boolean;
@@ -75,9 +75,11 @@ export class AnalysisEngine {
     if (this.isDebugMode) console.log("stemDict: ", stemDict);
     const csmDict = buildCSMDict(commitDict, stemDict, this.baseBranchName, pullRequests);
     if (this.isDebugMode) console.log("csmDict: ", csmDict);
-    const nodes = stemDict.get(this.baseBranchName)?.nodes?.map(({commit}) => commit);
-    const geminiCommitSummary = await getSummary(nodes ? nodes?.slice(-10) : []);
-    if (this.isDebugMode) console.log("GeminiCommitSummary: ", geminiCommitSummary);
+    const latestCommitSummary = await getLatestCommitSummary(stemDict, this.baseBranchName);
+    if (this.isDebugMode) console.log("latestCommitSummary: ", latestCommitSummary);
+
+    const currentUserCommitSummary = await getCurrentUserCommitSummary(stemDict, this.baseBranchName, this.octokit);
+    if (this.isDebugMode) console.log("currentUserCommitSummary: ", currentUserCommitSummary);
 
     return {
       isPRSuccess,


### PR DESCRIPTION
## Related issue

close #717 

## Result

vitest 레포지토리로 테스트

```
latestCommitSummary:  
- chore(deps): update dependencies
- feat(browser): support `--inspect-brk`
- fix(browser): exclude missed packages from optimization
- fix(ui): remove "filters" flickering
- fix: ignore importer when resolving Vitest
```

- git 로그인 유저로 커밋이 없는 경우

```
currentUserCommitSummary:  Please provide the commit messages you would like me to summarize. I need the actual commit messages to follow the instructions and generate the output in the desired format.
```

개인 레포지토리 테스트

```
latestCommitSummary:  
- fix: protocol 기본을 https로 변경
- fix: build error
- fix: 잘못된 파일 삭제
- 4주차 템플릿 업로드
- 5주차 템플릿 업로드
- fix: 6주차 템플릿 업로드
- 7주차 템플릿 업로드
- 8주차 템플릿 업로드
- 8주차 서평 & 소감 
```

```
currentUserCommitSummary:  
- feat: nav 설정 추가
- fix: protocol 기본을 https로 변경
- fix: 잘못된 파일 삭제
- fix: build error
- 4주차 템플릿 업로드
- 5주차 템플릿 업로드
- fix: 6주차 템플릿 업로드
- 7주차 템플릿 업로드
- 8주차 템플릿 업로드
```

## Work list

기존 커밋 요약 기능을 함수로 분리하고 머지 커밋을 아예 필터링하도록 개선했습니다. 현재 author가 작성한 커밋이 있다면 최신 10개 커밋 요약하는 함수를 추가했습니다. 

- `getLatestCommitSummary`: 최신 10개 커밋 필터해 요약하기
- `getCurrentUserCommitSummary`: 현재 유저가 작성한 최신 커밋 10개 요약하기

## Discussion

- [epic/ai-summary](https://github.com/githru/githru-vscode-ext/tree/epic/ai-summary)으로 머지합니다!
- 후속 이슈에서 버튼과 상호작용해서 동작하도록 수정할 예정입니다.