### PR TITLE
[vscode] git 연결된 레포지토리가 확장 개발 호스트에서 실행되지 않는 버그 임시 수정

### DIFF
--- a/packages/vscode/src/webview-loader.ts
+++ b/packages/vscode/src/webview-loader.ts
@@ -87,10 +87,11 @@ export default class WebviewLoader implements vscode.Disposable {
         console.error("An error occurred while processing the webview message:", e);
       }
     });
-    if (!analyzedData) {
-      this.dispose();
-      throw new Error("Project not connected to Git.");
-    }
+    //FIXME - For repositories where git exists, analyzedData is initially assigned as undefined.
+    // if (!analyzedData) {
+    //   this.dispose();
+    //   throw new Error("Project not connected to Git.");
+    // }
     this._panel.webview.html = this.getWebviewContent(this._panel.webview);
   }
 


### PR DESCRIPTION
## Related issue
- '확장개발호스트'에서 githru가 열리지 않는 버그
- 레포지토리 내에 git이 연결되어 있음에도 panel이 `dispose`됩니다.

## Result
- '확장개발호스트'에서 githru가 열리도록 주석 처리하였습니다.
- #520 에서 다룬 issue가 재발합니다.

## Work list
- 레포지토리의 git 연결 여부를 확인하던 부분을 주석 처리하였습니다.
- `analyzedData` 값의 할당 유무로 git 연결 여부를 확인하였으나 **git 연결된 경우에도 `analyzedData`에는 undefined가 할당됩니다.**

## Discussion
- `analyzedData`에 항상 `undefined` 값이 할당되는 원인을 모르겠습니다. 🥲