### PR TITLE
[view] 레이아웃이 잘리는 문제 해결

### DIFF
--- a/packages/view/src/App.scss
+++ b/packages/view/src/App.scss
@@ -19,8 +19,7 @@ body {
 }
 
 .middle-container {
-  display: grid;
-  grid-template-columns: 4fr 2fr;
+  display: flex;
   height: calc(100vh - 200px);
   padding: 20px;
 }

--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -104,7 +104,7 @@ const Detail = ({ selectedData, clusterId, authSrcMap }: DetailProps) => {
                     title={id}
                     PopperProps={{ sx: { ".MuiTooltip-tooltip": { bgcolor: "#3c4048" } } }}
                   >
-                    <p>{`${id.slice(0, 6)}...`}</p>
+                    <p>{`${id.slice(0, 6)}`}</p>
                   </Tooltip>
                 </a>
               </div>

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.const.ts
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.const.ts
@@ -1,2 +1,0 @@
-export const GITHUB_URL = "https://github.com";
-export const GRAVATA_URL = "https://www.gravatar.com/avatar";

--- a/packages/view/src/components/VerticalClusterList/VerticalClusterList.scss
+++ b/packages/view/src/components/VerticalClusterList/VerticalClusterList.scss
@@ -2,6 +2,7 @@
 
 .vertical-cluster-list {
   display: flex;
+  flex: 1;
   flex-direction: column;
 
   &__header {


### PR DESCRIPTION
## Related issue
close #697 #719

## Result
### AS IS
![image](https://github.com/user-attachments/assets/53d6352f-fd87-49f8-8cfb-17a66fac2603)
![image](https://github.com/user-attachments/assets/8776a7e2-c5c7-4d67-ae8e-eef3249122f7)

### TO BE
![image](https://github.com/user-attachments/assets/19e9917d-3c9a-4b11-b4fd-fb81ac542486)
![image](https://github.com/user-attachments/assets/8a2766d4-6083-46fe-a58c-56251ac90618)


## Work list
- 복잡한 레이아웃이 아니기 때문에 `grid`에서 `flex`로 수정하였으며, 오른쪽 차트에 `flex:1` 을 주어 잘리지 않도록 하였습니다.
- 이전 이슈 #720 에서 다뤘던 말 줄임 표시를 원복하였습니다.
- 해당 이슈와는 크게 관련 없지만..! 사용하지 않는 + 다른 파일과 중복된 constant 파일이 있어 제거하였습니다.