### PR TITLE
[engine] getCommitRaws 테스트케이스 추가

### DIFF
--- a/packages/analysis-engine/src/parser.spec.ts
+++ b/packages/analysis-engine/src/parser.spec.ts
@@ -39,20 +39,6 @@ describe("getCommitRaws", () => {
   const fakeAuthorAndCommitter = `${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900`;
   const fakeCommitMessage = `${GIT_LOG_SEPARATOR}commit message${GIT_LOG_SEPARATOR}`;
   const fakeCommitMessageAndBody = `${GIT_LOG_SEPARATOR}commit message title\n\ncommit message body${GIT_LOG_SEPARATOR}`;
-  const fakeCommitMessages = [
-    `${GIT_LOG_SEPARATOR}commit message title${GIT_LOG_SEPARATOR}`,
-    `${GIT_LOG_SEPARATOR}commit message title\ncommit message${GIT_LOG_SEPARATOR}`,
-    `${GIT_LOG_SEPARATOR}commit message title\n\ncommit message body${GIT_LOG_SEPARATOR}`,
-    `${GIT_LOG_SEPARATOR}commit message title\n\n\ncommit message body${GIT_LOG_SEPARATOR}`,
-    `${GIT_LOG_SEPARATOR}${GIT_LOG_SEPARATOR}`,
-  ];
-  const expectedCommitMessages = [
-    "commit message title",
-    "commit message title\ncommit message",
-    "commit message title\n\ncommit message body",
-    "commit message title\n\n\ncommit message body",
-    "",
-  ];
   const expectedCommitMessageBody = "commit message title\n\ncommit message body";
 
   const fakeCommitHash = `a${GIT_LOG_SEPARATOR}b`;
@@ -233,14 +219,30 @@ describe("getCommitRaws", () => {
     expect(result).toEqual(expectedResult);
   });
 
-  fakeCommitMessages.forEach((fakeMessage, index) => {
-    it(`should parse gitlog to commitRaw(commit message)`, () => {
-      const mockLog = `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${fakeMessage}`;
-      const result = getCommitRaws(mockLog);
-      const expectedResult = { ...commonExpectatedResult, message: expectedCommitMessages[index] };
-
-      expect(result).toEqual([expectedResult]);
-    });
+  it.each([
+    [
+      `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${`${GIT_LOG_SEPARATOR}commit message title${GIT_LOG_SEPARATOR}`}`,
+      { ...commonExpectatedResult, message: "commit message title" },
+    ],
+    [
+      `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${`${GIT_LOG_SEPARATOR}commit message title\ncommit message${GIT_LOG_SEPARATOR}`}`,
+      { ...commonExpectatedResult, message: "commit message title\ncommit message" },
+    ],
+    [
+      `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${`${GIT_LOG_SEPARATOR}commit message title\n\ncommit message body${GIT_LOG_SEPARATOR}`}`,
+      { ...commonExpectatedResult, message: "commit message title\n\ncommit message body" },
+    ],
+    [
+      `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${`${GIT_LOG_SEPARATOR}commit message title\n\n\ncommit message body${GIT_LOG_SEPARATOR}`}`,
+      { ...commonExpectatedResult, message: "commit message title\n\n\ncommit message body" },
+    ],
+    [
+      `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${`${GIT_LOG_SEPARATOR}${GIT_LOG_SEPARATOR}`}`,
+      { ...commonExpectatedResult, message: "" },
+    ],
+  ])("should parse gitlog to commitRaw(commit message)", (mockLog, expectedResult) => {
+    const result = getCommitRaws(mockLog);
+    expect(result).toEqual([expectedResult]);
   });
 
   it(`should parse gitlog to commitRaw(commit message body and file change)`, () => {

--- a/packages/analysis-engine/src/parser.spec.ts
+++ b/packages/analysis-engine/src/parser.spec.ts
@@ -57,12 +57,6 @@ describe("getCommitRaws", () => {
   const expectedCommitMessageBody = "commit message title\n\ncommit message body";
 
   const fakeCommitHash = `a${GIT_LOG_SEPARATOR}b`;
-  const fakeCommitHashs = [`a${GIT_LOG_SEPARATOR}`, `c${GIT_LOG_SEPARATOR}b`, `d${GIT_LOG_SEPARATOR}e f`];
-  const expectedCommitHashs = [
-    { id: "a", parents: [""] },
-    { id: "c", parents: ["b"] },
-    { id: "d", parents: ["e", "f"] },
-  ];
 
   const fakeCommitRef = `${GIT_LOG_SEPARATOR}HEAD`;
   const fakeCommitRefs = [
@@ -148,18 +142,34 @@ describe("getCommitRaws", () => {
     commitMessageType: "",
   };
 
-  fakeCommitHashs.forEach((fakeHash, index) => {
-    it(`should parse gitlog to commitRaw(hash)`, () => {
-      const mockLog = `${COMMIT_SEPARATOR}${fakeHash}${fakeCommitRef}${fakeAuthorAndCommitter}${fakeCommitMessage}`;
-      const result = getCommitRaws(mockLog);
-      const expectedResult = {
+  it.each([
+    [
+      `${COMMIT_SEPARATOR}${`a${GIT_LOG_SEPARATOR}`}${fakeCommitRef}${fakeAuthorAndCommitter}${fakeCommitMessage}`,
+      {
         ...commonExpectatedResult,
-        id: expectedCommitHashs[index].id,
-        parents: expectedCommitHashs[index].parents,
-      };
-
-      expect(result).toEqual([expectedResult]);
-    });
+        id: "a",
+        parents: [""],
+      },
+    ],
+    [
+      `${COMMIT_SEPARATOR}${`c${GIT_LOG_SEPARATOR}b`}${fakeCommitRef}${fakeAuthorAndCommitter}${fakeCommitMessage}`,
+      {
+        ...commonExpectatedResult,
+        id: "c",
+        parents: ["b"],
+      },
+    ],
+    [
+      `${COMMIT_SEPARATOR}${`d${GIT_LOG_SEPARATOR}e f`}${fakeCommitRef}${fakeAuthorAndCommitter}${fakeCommitMessage}`,
+      {
+        ...commonExpectatedResult,
+        id: "d",
+        parents: ["e", "f"],
+      },
+    ],
+  ])("should parse gitlog to commitRaw(hash)", (mockLog, expectedResult) => {
+    const result = getCommitRaws(mockLog);
+    expect(result).toEqual([expectedResult]);
   });
 
   fakeCommitRefs.forEach((fakeRefs, index) => {

--- a/packages/analysis-engine/src/parser.spec.ts
+++ b/packages/analysis-engine/src/parser.spec.ts
@@ -36,11 +36,11 @@ describe("commit message type", () => {
 });
 
 describe("getCommitRaws", () => {
-  const testAuthorAndCommitter = `${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900`;
+  const mockAuthorAndCommitter = `${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900`;
 
-  const testCommitMessage = `${GIT_LOG_SEPARATOR}commit message`;
+  const mockCommitMessage = `${GIT_LOG_SEPARATOR}commit message`;
 
-  const testCommitHashAndRefs = [
+  const mockCommitHashAndRefs = [
     `a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD`,
     `a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD -> main, origin/main, origin/HEAD`,
     `a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD, tag: v1.0.0`,
@@ -58,7 +58,7 @@ describe("getCommitRaws", () => {
 
   const expectedTags = [[], [], ["v1.0.0"], ["v2.0.0"], ["v2.0.0", "v1.4"]];
 
-  const testCommitFileChanges = [
+  const mockCommitFileChanges = [
     "10\t0\ta.ts\n1\t0\tREADME.md",
     "3\t3\ta.ts",
     "4\t0\ta.ts",
@@ -114,9 +114,9 @@ describe("getCommitRaws", () => {
     commitMessageType: "",
   };
 
-  testCommitHashAndRefs.forEach((hashAndRefs, index) => {
+  mockCommitHashAndRefs.forEach((mockHashAndRefs, index) => {
     it(`should parse gitlog to commitRaw(branch, tag)`, () => {
-      const result = getCommitRaws(`${COMMIT_SEPARATOR}${hashAndRefs}${testAuthorAndCommitter}${testCommitMessage}`);
+      const result = getCommitRaws(`${COMMIT_SEPARATOR}${mockHashAndRefs}${mockAuthorAndCommitter}${mockCommitMessage}`);
       const expectedResult = {
         ...commonExpectatedResult,
         branches: expectedBranches[index],
@@ -127,9 +127,9 @@ describe("getCommitRaws", () => {
     });
   });
 
-  testCommitFileChanges.forEach((fileChange, index) => {
+  mockCommitFileChanges.forEach((mockFileChange, index) => {
     it(`should parse gitlog to commitRaw(file changed)`, () => {
-      const mock = `${COMMIT_SEPARATOR}${testCommitHashAndRefs[0]}${testAuthorAndCommitter}${testCommitMessage}\n${fileChange}`;
+      const mock = `${COMMIT_SEPARATOR}${mockCommitHashAndRefs[0]}${mockAuthorAndCommitter}${mockCommitMessage}\n${mockFileChange}`;
       const result = getCommitRaws(mock);
       const expectedResult = { ...commonExpectatedResult, differenceStatistic: expectedFileChanged[index] };
 

--- a/packages/analysis-engine/src/parser.spec.ts
+++ b/packages/analysis-engine/src/parser.spec.ts
@@ -56,13 +56,21 @@ describe("getCommitRaws", () => {
   ];
   const expectedCommitMessageBody = "commit message title\n\ncommit message body";
 
-  const mockCommitHashAndRef = `a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD`;
-  const mockCommitHashAndRefs = [
-    `a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD`,
-    `a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD -> main, origin/main, origin/HEAD`,
-    `a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD, tag: v1.0.0`,
-    `a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD -> main, origin/main, origin/HEAD, tag: v2.0.0`,
-    `a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD, tag: v2.0.0, tag: v1.4`,
+  const mockCommitHash = `a${GIT_LOG_SEPARATOR}b`;
+  const mockCommitHashs = [`a${GIT_LOG_SEPARATOR}`, `c${GIT_LOG_SEPARATOR}b`, `d${GIT_LOG_SEPARATOR}e f`];
+  const expectedCommitHashs = [
+    { id: "a", parents: [""] },
+    { id: "c", parents: ["b"] },
+    { id: "d", parents: ["e", "f"] },
+  ];
+
+  const mockCommitRef = `${GIT_LOG_SEPARATOR}HEAD`;
+  const mockCommitRefs = [
+    `${GIT_LOG_SEPARATOR}HEAD`,
+    `${GIT_LOG_SEPARATOR}HEAD -> main, origin/main, origin/HEAD`,
+    `${GIT_LOG_SEPARATOR}HEAD, tag: v1.0.0`,
+    `${GIT_LOG_SEPARATOR}HEAD -> main, origin/main, origin/HEAD, tag: v2.0.0`,
+    `${GIT_LOG_SEPARATOR}HEAD, tag: v2.0.0, tag: v1.4`,
   ];
 
   const expectedBranches = [
@@ -140,9 +148,23 @@ describe("getCommitRaws", () => {
     commitMessageType: "",
   };
 
-  mockCommitHashAndRefs.forEach((mockHashAndRefs, index) => {
+  mockCommitHashs.forEach((mockHash, index) => {
+    it(`should parse gitlog to commitRaw(hash)`, () => {
+      const mockLog = `${COMMIT_SEPARATOR}${mockHash}${mockCommitRef}${mockAuthorAndCommitter}${mockCommitMessage}`;
+      const result = getCommitRaws(mockLog);
+      const expectedResult = {
+        ...commonExpectatedResult,
+        id: expectedCommitHashs[index].id,
+        parents: expectedCommitHashs[index].parents,
+      };
+
+      expect(result).toEqual([expectedResult]);
+    });
+  });
+
+  mockCommitRefs.forEach((mockRefs, index) => {
     it(`should parse gitlog to commitRaw(branch, tag)`, () => {
-      const mockLog = `${COMMIT_SEPARATOR}${mockHashAndRefs}${mockAuthorAndCommitter}${mockCommitMessage}`;
+      const mockLog = `${COMMIT_SEPARATOR}${mockCommitHash}${mockRefs}${mockAuthorAndCommitter}${mockCommitMessage}`;
       const result = getCommitRaws(mockLog);
       const expectedResult = {
         ...commonExpectatedResult,
@@ -156,7 +178,7 @@ describe("getCommitRaws", () => {
 
   mockCommitFileChanges.forEach((mockFileChange, index) => {
     it(`should parse gitlog to commitRaw(file changed)`, () => {
-      const mockLog = `${COMMIT_SEPARATOR}${mockCommitHashAndRef}${mockAuthorAndCommitter}${mockCommitMessage}\n${mockFileChange}`;
+      const mockLog = `${COMMIT_SEPARATOR}${mockCommitHash}${mockCommitRef}${mockAuthorAndCommitter}${mockCommitMessage}\n${mockFileChange}`;
       const result = getCommitRaws(mockLog);
       const expectedResult = { ...commonExpectatedResult, differenceStatistic: expectedFileChanges[index] };
 
@@ -165,7 +187,7 @@ describe("getCommitRaws", () => {
   });
 
   it(`should parse gitlog to commitRaw(multiple commits)`, () => {
-    const mockLog = `${COMMIT_SEPARATOR}${mockCommitHashAndRef}${mockAuthorAndCommitter}${mockCommitMessage}\n${mockCommitFileChange}${COMMIT_SEPARATOR}${mockCommitHashAndRefs[0]}${mockAuthorAndCommitter}${mockCommitMessage}`;
+    const mockLog = `${COMMIT_SEPARATOR}${mockCommitHash}${mockCommitRef}${mockAuthorAndCommitter}${mockCommitMessage}\n${mockCommitFileChange}${COMMIT_SEPARATOR}${mockCommitHash}${mockCommitRef}${mockAuthorAndCommitter}${mockCommitMessage}`;
     const result = getCommitRaws(mockLog);
     const expectedResult = [
       { ...commonExpectatedResult, differenceStatistic: expectedFileChange },
@@ -177,7 +199,7 @@ describe("getCommitRaws", () => {
 
   mockCommitMessages.forEach((mockMessage, index) => {
     it(`should parse gitlog to commitRaw(commit message)`, () => {
-      const mockLog = `${COMMIT_SEPARATOR}${mockCommitHashAndRef}${mockAuthorAndCommitter}${mockMessage}`;
+      const mockLog = `${COMMIT_SEPARATOR}${mockCommitHash}${mockCommitRef}${mockAuthorAndCommitter}${mockMessage}`;
       const result = getCommitRaws(mockLog);
       const expectedResult = { ...commonExpectatedResult, message: expectedCommitMessages[index] };
 
@@ -186,7 +208,7 @@ describe("getCommitRaws", () => {
   });
 
   it(`should parse gitlog to commitRaw(commit message body and file change)`, () => {
-    const mockLog = `${COMMIT_SEPARATOR}${mockCommitHashAndRef}${mockAuthorAndCommitter}${mockCommitMessageAndBody}\n${mockCommitFileChange}`;
+    const mockLog = `${COMMIT_SEPARATOR}${mockCommitHash}${mockCommitRef}${mockAuthorAndCommitter}${mockCommitMessageAndBody}\n${mockCommitFileChange}`;
     const result = getCommitRaws(mockLog);
     const expectedResult = {
       ...commonExpectatedResult,

--- a/packages/analysis-engine/src/parser.spec.ts
+++ b/packages/analysis-engine/src/parser.spec.ts
@@ -39,22 +39,9 @@ describe("getCommitRaws", () => {
   const fakeAuthorAndCommitter = `${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900`;
   const fakeCommitMessage = `${GIT_LOG_SEPARATOR}commit message${GIT_LOG_SEPARATOR}`;
   const fakeCommitMessageAndBody = `${GIT_LOG_SEPARATOR}commit message title\n\ncommit message body${GIT_LOG_SEPARATOR}`;
-  const expectedCommitMessageBody = "commit message title\n\ncommit message body";
-
   const fakeCommitHash = `a${GIT_LOG_SEPARATOR}b`;
-
   const fakeCommitRef = `${GIT_LOG_SEPARATOR}HEAD`;
-
   const fakeCommitFileChange = "10\t0\ta.ts\n1\t0\tREADME.md";
-
-  const expectedFileChange: DifferenceStatistic = {
-    totalInsertionCount: 11,
-    totalDeletionCount: 0,
-    fileDictionary: {
-      "a.ts": { insertionCount: 10, deletionCount: 0 },
-      "README.md": { insertionCount: 1, deletionCount: 0 },
-    },
-  };
 
   const commonExpectatedResult: CommitRaw = {
     sequence: 0,
@@ -73,6 +60,15 @@ describe("getCommitRaws", () => {
       fileDictionary: {},
     },
     commitMessageType: "",
+  };
+  const expectedCommitMessageBody = "commit message title\n\ncommit message body";
+  const expectedFileChange: DifferenceStatistic = {
+    totalInsertionCount: 11,
+    totalDeletionCount: 0,
+    fileDictionary: {
+      "a.ts": { insertionCount: 10, deletionCount: 0 },
+      "README.md": { insertionCount: 1, deletionCount: 0 },
+    },
   };
 
   it.each([

--- a/packages/analysis-engine/src/parser.spec.ts
+++ b/packages/analysis-engine/src/parser.spec.ts
@@ -116,7 +116,8 @@ describe("getCommitRaws", () => {
 
   mockCommitHashAndRefs.forEach((mockHashAndRefs, index) => {
     it(`should parse gitlog to commitRaw(branch, tag)`, () => {
-      const result = getCommitRaws(`${COMMIT_SEPARATOR}${mockHashAndRefs}${mockAuthorAndCommitter}${mockCommitMessage}`);
+      const mockLog = `${COMMIT_SEPARATOR}${mockHashAndRefs}${mockAuthorAndCommitter}${mockCommitMessage}`;
+      const result = getCommitRaws(mockLog);
       const expectedResult = {
         ...commonExpectatedResult,
         branches: expectedBranches[index],
@@ -129,8 +130,8 @@ describe("getCommitRaws", () => {
 
   mockCommitFileChanges.forEach((mockFileChange, index) => {
     it(`should parse gitlog to commitRaw(file changed)`, () => {
-      const mock = `${COMMIT_SEPARATOR}${mockCommitHashAndRefs[0]}${mockAuthorAndCommitter}${mockCommitMessage}\n${mockFileChange}`;
-      const result = getCommitRaws(mock);
+      const mockLog = `${COMMIT_SEPARATOR}${mockCommitHashAndRefs[0]}${mockAuthorAndCommitter}${mockCommitMessage}\n${mockFileChange}`;
+      const result = getCommitRaws(mockLog);
       const expectedResult = { ...commonExpectatedResult, differenceStatistic: expectedFileChanged[index] };
 
       expect(result).toEqual([expectedResult]);

--- a/packages/analysis-engine/src/parser.spec.ts
+++ b/packages/analysis-engine/src/parser.spec.ts
@@ -36,11 +36,11 @@ describe("commit message type", () => {
 });
 
 describe("getCommitRaws", () => {
-  const mockAuthorAndCommitter = `${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900`;
+  const fakeAuthorAndCommitter = `${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900`;
 
-  const mockCommitMessage = `${GIT_LOG_SEPARATOR}commit message${GIT_LOG_SEPARATOR}`;
-  const mockCommitMessageAndBody = `${GIT_LOG_SEPARATOR}commit message title\n\ncommit message body${GIT_LOG_SEPARATOR}`;
-  const mockCommitMessages = [
+  const fakeCommitMessage = `${GIT_LOG_SEPARATOR}commit message${GIT_LOG_SEPARATOR}`;
+  const fakeCommitMessageAndBody = `${GIT_LOG_SEPARATOR}commit message title\n\ncommit message body${GIT_LOG_SEPARATOR}`;
+  const fakeCommitMessages = [
     `${GIT_LOG_SEPARATOR}commit message title${GIT_LOG_SEPARATOR}`,
     `${GIT_LOG_SEPARATOR}commit message title\ncommit message${GIT_LOG_SEPARATOR}`,
     `${GIT_LOG_SEPARATOR}commit message title\n\ncommit message body${GIT_LOG_SEPARATOR}`,
@@ -56,16 +56,16 @@ describe("getCommitRaws", () => {
   ];
   const expectedCommitMessageBody = "commit message title\n\ncommit message body";
 
-  const mockCommitHash = `a${GIT_LOG_SEPARATOR}b`;
-  const mockCommitHashs = [`a${GIT_LOG_SEPARATOR}`, `c${GIT_LOG_SEPARATOR}b`, `d${GIT_LOG_SEPARATOR}e f`];
+  const fakeCommitHash = `a${GIT_LOG_SEPARATOR}b`;
+  const fakeCommitHashs = [`a${GIT_LOG_SEPARATOR}`, `c${GIT_LOG_SEPARATOR}b`, `d${GIT_LOG_SEPARATOR}e f`];
   const expectedCommitHashs = [
     { id: "a", parents: [""] },
     { id: "c", parents: ["b"] },
     { id: "d", parents: ["e", "f"] },
   ];
 
-  const mockCommitRef = `${GIT_LOG_SEPARATOR}HEAD`;
-  const mockCommitRefs = [
+  const fakeCommitRef = `${GIT_LOG_SEPARATOR}HEAD`;
+  const fakeCommitRefs = [
     `${GIT_LOG_SEPARATOR}HEAD`,
     `${GIT_LOG_SEPARATOR}HEAD -> main, origin/main, origin/HEAD`,
     `${GIT_LOG_SEPARATOR}HEAD, tag: v1.0.0`,
@@ -83,8 +83,8 @@ describe("getCommitRaws", () => {
 
   const expectedTags = [[], [], ["v1.0.0"], ["v2.0.0"], ["v2.0.0", "v1.4"]];
 
-  const mockCommitFileChange = "10\t0\ta.ts\n1\t0\tREADME.md";
-  const mockCommitFileChanges = [
+  const fakeCommitFileChange = "10\t0\ta.ts\n1\t0\tREADME.md";
+  const fakeCommitFileChanges = [
     "10\t0\ta.ts\n1\t0\tREADME.md",
     "3\t3\ta.ts",
     "4\t0\ta.ts",
@@ -148,9 +148,9 @@ describe("getCommitRaws", () => {
     commitMessageType: "",
   };
 
-  mockCommitHashs.forEach((mockHash, index) => {
+  fakeCommitHashs.forEach((fakeHash, index) => {
     it(`should parse gitlog to commitRaw(hash)`, () => {
-      const mockLog = `${COMMIT_SEPARATOR}${mockHash}${mockCommitRef}${mockAuthorAndCommitter}${mockCommitMessage}`;
+      const mockLog = `${COMMIT_SEPARATOR}${fakeHash}${fakeCommitRef}${fakeAuthorAndCommitter}${fakeCommitMessage}`;
       const result = getCommitRaws(mockLog);
       const expectedResult = {
         ...commonExpectatedResult,
@@ -162,9 +162,9 @@ describe("getCommitRaws", () => {
     });
   });
 
-  mockCommitRefs.forEach((mockRefs, index) => {
+  fakeCommitRefs.forEach((fakeRefs, index) => {
     it(`should parse gitlog to commitRaw(branch, tag)`, () => {
-      const mockLog = `${COMMIT_SEPARATOR}${mockCommitHash}${mockRefs}${mockAuthorAndCommitter}${mockCommitMessage}`;
+      const mockLog = `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeRefs}${fakeAuthorAndCommitter}${fakeCommitMessage}`;
       const result = getCommitRaws(mockLog);
       const expectedResult = {
         ...commonExpectatedResult,
@@ -176,9 +176,9 @@ describe("getCommitRaws", () => {
     });
   });
 
-  mockCommitFileChanges.forEach((mockFileChange, index) => {
+  fakeCommitFileChanges.forEach((fakeFileChange, index) => {
     it(`should parse gitlog to commitRaw(file changed)`, () => {
-      const mockLog = `${COMMIT_SEPARATOR}${mockCommitHash}${mockCommitRef}${mockAuthorAndCommitter}${mockCommitMessage}\n${mockFileChange}`;
+      const mockLog = `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${fakeCommitMessage}\n${fakeFileChange}`;
       const result = getCommitRaws(mockLog);
       const expectedResult = { ...commonExpectatedResult, differenceStatistic: expectedFileChanges[index] };
 
@@ -187,7 +187,7 @@ describe("getCommitRaws", () => {
   });
 
   it(`should parse gitlog to commitRaw(multiple commits)`, () => {
-    const mockLog = `${COMMIT_SEPARATOR}${mockCommitHash}${mockCommitRef}${mockAuthorAndCommitter}${mockCommitMessage}\n${mockCommitFileChange}${COMMIT_SEPARATOR}${mockCommitHash}${mockCommitRef}${mockAuthorAndCommitter}${mockCommitMessage}`;
+    const mockLog = `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${fakeCommitMessage}\n${fakeCommitFileChange}${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${fakeCommitMessage}`;
     const result = getCommitRaws(mockLog);
     const expectedResult = [
       { ...commonExpectatedResult, differenceStatistic: expectedFileChange },
@@ -197,9 +197,9 @@ describe("getCommitRaws", () => {
     expect(result).toEqual(expectedResult);
   });
 
-  mockCommitMessages.forEach((mockMessage, index) => {
+  fakeCommitMessages.forEach((fakeMessage, index) => {
     it(`should parse gitlog to commitRaw(commit message)`, () => {
-      const mockLog = `${COMMIT_SEPARATOR}${mockCommitHash}${mockCommitRef}${mockAuthorAndCommitter}${mockMessage}`;
+      const mockLog = `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${fakeMessage}`;
       const result = getCommitRaws(mockLog);
       const expectedResult = { ...commonExpectatedResult, message: expectedCommitMessages[index] };
 
@@ -208,7 +208,7 @@ describe("getCommitRaws", () => {
   });
 
   it(`should parse gitlog to commitRaw(commit message body and file change)`, () => {
-    const mockLog = `${COMMIT_SEPARATOR}${mockCommitHash}${mockCommitRef}${mockAuthorAndCommitter}${mockCommitMessageAndBody}\n${mockCommitFileChange}`;
+    const mockLog = `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${fakeCommitMessageAndBody}\n${fakeCommitFileChange}`;
     const result = getCommitRaws(mockLog);
     const expectedResult = {
       ...commonExpectatedResult,

--- a/packages/analysis-engine/src/parser.spec.ts
+++ b/packages/analysis-engine/src/parser.spec.ts
@@ -48,13 +48,13 @@ describe("getCommitRaws", () => {
     `${GIT_LOG_SEPARATOR}${GIT_LOG_SEPARATOR}`,
   ];
   const expectedCommitMessages = [
-  'commit message title',
-  'commit message title\ncommit message',
-  'commit message title\n\ncommit message body',
-  'commit message title\n\n\ncommit message body',
-  '',
+    "commit message title",
+    "commit message title\ncommit message",
+    "commit message title\n\ncommit message body",
+    "commit message title\n\n\ncommit message body",
+    "",
   ];
-  const expectedCommitMessageBody = "commit message title\n\ncommit message body"
+  const expectedCommitMessageBody = "commit message title\n\ncommit message body";
 
   const mockCommitHashAndRef = `a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD`;
   const mockCommitHashAndRefs = [
@@ -169,7 +169,7 @@ describe("getCommitRaws", () => {
     const result = getCommitRaws(mockLog);
     const expectedResult = [
       { ...commonExpectatedResult, differenceStatistic: expectedFileChange },
-      { ...commonExpectatedResult, sequence: 1},
+      { ...commonExpectatedResult, sequence: 1 },
     ];
 
     expect(result).toEqual(expectedResult);
@@ -185,10 +185,14 @@ describe("getCommitRaws", () => {
     });
   });
 
-  it (`should parse gitlog to commitRaw(commit message body and file change)`, () => {
+  it(`should parse gitlog to commitRaw(commit message body and file change)`, () => {
     const mockLog = `${COMMIT_SEPARATOR}${mockCommitHashAndRef}${mockAuthorAndCommitter}${mockCommitMessageAndBody}\n${mockCommitFileChange}`;
     const result = getCommitRaws(mockLog);
-    const expectedResult = { ...commonExpectatedResult, message: expectedCommitMessageBody, differenceStatistic: expectedFileChange };
+    const expectedResult = {
+      ...commonExpectatedResult,
+      message: expectedCommitMessageBody,
+      differenceStatistic: expectedFileChange,
+    };
 
     expect(result).toEqual([expectedResult]);
   });

--- a/packages/analysis-engine/src/parser.spec.ts
+++ b/packages/analysis-engine/src/parser.spec.ts
@@ -38,7 +38,23 @@ describe("commit message type", () => {
 describe("getCommitRaws", () => {
   const mockAuthorAndCommitter = `${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900`;
 
-  const mockCommitMessage = `${GIT_LOG_SEPARATOR}commit message`;
+  const mockCommitMessage = `${GIT_LOG_SEPARATOR}commit message${GIT_LOG_SEPARATOR}`;
+  const mockCommitMessageAndBody = `${GIT_LOG_SEPARATOR}commit message title\n\ncommit message body${GIT_LOG_SEPARATOR}`;
+  const mockCommitMessages = [
+    `${GIT_LOG_SEPARATOR}commit message title${GIT_LOG_SEPARATOR}`,
+    `${GIT_LOG_SEPARATOR}commit message title\ncommit message${GIT_LOG_SEPARATOR}`,
+    `${GIT_LOG_SEPARATOR}commit message title\n\ncommit message body${GIT_LOG_SEPARATOR}`,
+    `${GIT_LOG_SEPARATOR}commit message title\n\n\ncommit message body${GIT_LOG_SEPARATOR}`,
+    `${GIT_LOG_SEPARATOR}${GIT_LOG_SEPARATOR}`,
+  ];
+  const expectedCommitMessages = [
+  'commit message title',
+  'commit message title\ncommit message',
+  'commit message title\n\ncommit message body',
+  'commit message title\n\n\ncommit message body',
+  '',
+  ];
+  const expectedCommitMessageBody = "commit message title\n\ncommit message body"
 
   const mockCommitHashAndRef = `a${GIT_LOG_SEPARATOR}b${GIT_LOG_SEPARATOR}HEAD`;
   const mockCommitHashAndRefs = [
@@ -157,5 +173,23 @@ describe("getCommitRaws", () => {
     ];
 
     expect(result).toEqual(expectedResult);
+  });
+
+  mockCommitMessages.forEach((mockMessage, index) => {
+    it(`should parse gitlog to commitRaw(commit message)`, () => {
+      const mockLog = `${COMMIT_SEPARATOR}${mockCommitHashAndRef}${mockAuthorAndCommitter}${mockMessage}`;
+      const result = getCommitRaws(mockLog);
+      const expectedResult = { ...commonExpectatedResult, message: expectedCommitMessages[index] };
+
+      expect(result).toEqual([expectedResult]);
+    });
+  });
+
+  it (`should parse gitlog to commitRaw(commit message body and file change)`, () => {
+    const mockLog = `${COMMIT_SEPARATOR}${mockCommitHashAndRef}${mockAuthorAndCommitter}${mockCommitMessageAndBody}\n${mockCommitFileChange}`;
+    const result = getCommitRaws(mockLog);
+    const expectedResult = { ...commonExpectatedResult, message: expectedCommitMessageBody, differenceStatistic: expectedFileChange };
+
+    expect(result).toEqual([expectedResult]);
   });
 });

--- a/packages/analysis-engine/src/parser.ts
+++ b/packages/analysis-engine/src/parser.ts
@@ -11,10 +11,8 @@ export default function getCommitRaws(log: string) {
   const commitRaws: CommitRaw[] = [];
   // skip the first empty element
   for (let commitIdx = 1; commitIdx < commits.length; commitIdx += 1) {
-    const commitLines = commits[commitIdx].split(EOL_REGEX);
-
     // step 1: Extract commitData from the first line of the commit
-    const commitData = commitLines[0].split(GIT_LOG_SEPARATOR);
+    const commitData = commits[commitIdx].split(GIT_LOG_SEPARATOR);
     // Extract branch and tag data from commitData[2]
     const refs = commitData[2].replace(" -> ", ", ").split(", ");
     const [branches, tags]: string[][] = refs.reduce(
@@ -56,9 +54,14 @@ export default function getCommitRaws(log: string) {
     };
 
     // step 2: Extract diffStats from the rest of the commit
-    for (let diffIdx = 1; diffIdx < commitLines.length; diffIdx += 1) {
-      if (commitLines[diffIdx] === "") continue;
-      const [insertions, deletions, path] = commitLines[diffIdx].split("\t");
+    if (!commitData[10]) {
+      commitRaws.push(commitRaw);
+      continue;
+    }
+    const diffStats = commitData[10].split(EOL_REGEX);
+    for (let diffIdx = 1; diffIdx < diffStats.length; diffIdx += 1) {
+      if (diffStats[diffIdx] === "") continue;
+      const [insertions, deletions, path] = diffStats[diffIdx].split("\t");
       const numberedInsertions = insertions === "-" ? 0 : Number(insertions);
       const numberedDeletions = deletions === "-" ? 0 : Number(deletions);
       commitRaw.differenceStatistic.totalInsertionCount += numberedInsertions;

--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -168,9 +168,8 @@ export async function getGitLog(gitPath: string, currentWorkspacePath: string): 
         "%ce",
         "%cd", // committer name, committer email and committer date
         "%B", // commit message  (subject and body)
-      ].join(GIT_LOG_SEPARATOR)
-      + GIT_LOG_SEPARATOR
-      ;
+      ].join(GIT_LOG_SEPARATOR) +
+      GIT_LOG_SEPARATOR;
     const args = [
       "--no-pager",
       "log",

--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -167,8 +167,10 @@ export async function getGitLog(gitPath: string, currentWorkspacePath: string): 
         "%cn",
         "%ce",
         "%cd", // committer name, committer email and committer date
-        "%s", // subject (commit message)
-      ].join(GIT_LOG_SEPARATOR);
+        "%B", // commit message  (subject and body)
+      ].join(GIT_LOG_SEPARATOR)
+      + GIT_LOG_SEPARATOR
+      ;
     const args = [
       "--no-pager",
       "log",


### PR DESCRIPTION
## Related issue

- closes #691
- related with #675

## Result

<img alt="Screen_Shot 2024-09-28 15 36 19" src="https://github.com/user-attachments/assets/64975802-565c-4f6e-9c1c-d4bf238b5592" width="70%"/>

## Work list

- 테스트 input으로 쓰이는 데이터 이름의 prefix를 `test`에서 `mock`으로 변경했습니다. (https://github.com/githru/githru-vscode-ext/pull/708#pullrequestreview-2283403106 반영)
- `getCommitRaws`를 수정하다 누락되었던 commit message body를 파싱하는 로직을 추가했습니다.

- test case 추가 1 : Commit이 여러 개인 경우
  fuller format 예시
  ```
  commit a b HEAD
  Author:     John Park <mail@gmail.com>
  AuthorDate: Sun Sep 4 20:17:59 2022 +0900
  Commit:     John Park 2 <mail2@gmail.com>
  CommitDate: Sun Sep 5 20:17:59 2022 +0900
  
      commit message
  
  10  0       a.ts
  1   0       README.md
  
  commit a b HEAD
  Author:     John Park <mail@gmail.com>
  AuthorDate: Sun Sep 4 20:17:59 2022 +0900
  Commit:     John Park 2 <mail2@gmail.com>
  CommitDate: Sun Sep 5 20:17:59 2022 +0900
  
      commit message
  ```
  실제 format
  ```
  4itc2s8hH-oA64s08h19a
  bI9M-0XOzvHlYPegVPpzbHEADI9M-0XOzvHlYPegVPpzbJohn ParkI9M-0XOzvHlYPegVPpzbmail@gmail.comI9M-0XOzvHlYPegVPpzbSun Sep 4 20:17:59 2022 +0900I9M-0XOzvHlYPegVPpzbJohn Park 2I9M-0XOzvHlYPegVPpzbmail2@gmail.comI9M-0XOzvHlYPegVPpzbSun Sep 5 20:17:59 2022 +0900I9M-0XOzvHlYPegVPpzbcommit messageI9M-0XOzvHlYPegVPpzb
      10  0       a.ts
      1   0       README.md4itc2s8hH-oA64s08h19aI9M-0XOzvHlYPegVPpzbbI9M-0XOzvHlYPegVPpzbHEADI9M-0XOzvHlYPegVPpzbJohn ParkI9M-0XOzvHlYPegVPpzbmail@gmail.comI9M-0XOzvHlYPegVPpzbSun Sep 4 20:17:59 2022 +0900I9M-0XOzvHlYPegVPpzbJohn Park 2I9M-0XOzvHlYPegVPpzbmail2@gmail.comI9M-0XOzvHlYPegVPpzbSun Sep 5 20:17:59 2022 +0900I9M-0XOzvHlYPegVPpzbcommit messageI9M-0XOzvHlYPegVPpzb
  ```
- test case 추가 2 : commit message body가 있는 경우
  fuller format 예시
  ```
  commit a b HEAD
  Author:     John Park <mail@gmail.com>
  AuthorDate: Sun Sep 4 20:17:59 2022 +0900
  Commit:     John Park 2 <mail2@gmail.com>
  CommitDate: Sun Sep 5 20:17:59 2022 +0900
  
      commit message title
      
      commit message body
  ```
  실제 format
  ```
  4itc2s8hH-oA64s08h19aI9M-0XOzvHlYPegVPpzbbI9M-0XOzvHlYPegVPpzbHEADI9M-0XOzvHlYPegVPpzbJohn ParkI9M-0XOzvHlYPegVPpzbmail@gmail.comI9M-0XOzvHlYPegVPpzbSun Sep 4 20:17:59 2022 +0900I9M-0XOzvHlYPegVPpzbJohn Park 2I9M-0XOzvHlYPegVPpzbmail2@gmail.comI9M-0XOzvHlYPegVPpzbSun Sep 5 20:17:59 2022 +0900I9M-0XOzvHlYPegVPpzbcommit message title
      
      commit message bodyI9M-0XOzvHlYPegVPpzb
  ```
- test case 추가 3 : commit message가 없는 경우
  fuller format 예시
  ```
  commit a b HEAD
  Author:     John Park <mail@gmail.com>
  AuthorDate: Sun Sep 4 20:17:59 2022 +0900
  Commit:     John Park 2 <mail2@gmail.com>
  CommitDate: Sun Sep 5 20:17:59 2022 +0900
  ```
  실제 format
  ```
  4itc2s8hH-oA64s08h19aI9M-0XOzvHlYPegVPpzbbI9M-0XOzvHlYPegVPpzbHEADI9M-0XOzvHlYPegVPpzbJohn ParkI9M-0XOzvHlYPegVPpzbmail@gmail.comI9M-0XOzvHlYPegVPpzbSun Sep 4 20:17:59 2022 +0900I9M-0XOzvHlYPegVPpzbJohn Park 2I9M-0XOzvHlYPegVPpzbmail2@gmail.comI9M-0XOzvHlYPegVPpzbSun Sep 5 20:17:59 2022 +0900I9M-0XOzvHlYPegVPpzbI9M-0XOzvHlYPegVPpzb
  ```
- test case 추가 4 : Commit Message(title + body)와 file changes가 함께 있는 경우 
  fuller format 예시
  ```
  commit a b HEAD
  Author:     John Park <mail@gmail.com>
  AuthorDate: Sun Sep 4 20:17:59 2022 +0900
  Commit:     John Park 2 <mail2@gmail.com>
  CommitDate: Sun Sep 5 20:17:59 2022 +0900
  
      commit message title
      
      commit message body
  
  10  0       a.ts
  1   0       README.md
  ```
  실제 format
  ```
  4itc2s8hH-oA64s08h19aI9M-0XOzvHlYPegVPpzbbI9M-0XOzvHlYPegVPpzbHEADI9M-0XOzvHlYPegVPpzbJohn ParkI9M-0XOzvHlYPegVPpzbmail@gmail.comI9M-0XOzvHlYPegVPpzbSun Sep 4 20:17:59 2022 +0900I9M-0XOzvHlYPegVPpzbJohn Park 2I9M-0XOzvHlYPegVPpzbmail2@gmail.comI9M-0XOzvHlYPegVPpzbSun Sep 5 20:17:59 2022 +0900I9M-0XOzvHlYPegVPpzbcommit message title
      
      commit message bodyI9M-0XOzvHlYPegVPpzb
      10  0       a.ts
      1   0       README.md
  ```
- test case 추가 5 : parent hash가 없는 경우 (첫번째 commit)
  fuller format 예시
  ```
  commit a HEAD
  Author:     John Park <mail@gmail.com>
  AuthorDate: Sun Sep 4 20:17:59 2022 +0900
  Commit:     John Park 2 <mail2@gmail.com>
  CommitDate: Sun Sep 5 20:17:59 2022 +0900
  
      commit message
  ```
  실제 format
  ```
  4itc2s8hH-oA64s08h19aI9M-0XOzvHlYPegVPpzbI9M-0XOzvHlYPegVPpzbHEADI9M-0XOzvHlYPegVPpzbJohn ParkI9M-0XOzvHlYPegVPpzbmail@gmail.comI9M-0XOzvHlYPegVPpzbSun Sep 4 20:17:59 2022 +0900I9M-0XOzvHlYPegVPpzbJohn Park 2I9M-0XOzvHlYPegVPpzbmail2@gmail.comI9M-0XOzvHlYPegVPpzbSun Sep 5 20:17:59 2022 +0900I9M-0XOzvHlYPegVPpzbcommit messageI9M-0XOzvHlYPegVPpzb
  ```
- test case 추가 6 : parent hash가 2개인 경우 (Merge commit)
  fuller format 예시
  ```
  commit d e f HEAD
  Author:     John Park <mail@gmail.com>
  AuthorDate: Sun Sep 4 20:17:59 2022 +0900
  Commit:     John Park 2 <mail2@gmail.com>
  CommitDate: Sun Sep 5 20:17:59 2022 +0900
  ```
  실제 format
  ```
  4itc2s8hH-oA64s08h19dI9M-0XOzvHlYPegVPpzbe fI9M-0XOzvHlYPegVPpzbHEADI9M-0XOzvHlYPegVPpzbJohn ParkI9M-0XOzvHlYPegVPpzbmail@gmail.comI9M-0XOzvHlYPegVPpzbSun Sep 4 20:17:59 2022 +0900I9M-0XOzvHlYPegVPpzbJohn Park 2I9M-0XOzvHlYPegVPpzbmail2@gmail.comI9M-0XOzvHlYPegVPpzbSun Sep 5 20:17:59 2022 +0900I9M-0XOzvHlYPegVPpzbcommit messageI9M-0XOzvHlYPegVPpzb
  ```

## Discussion
