### PR TITLE
[engine] 로그 개수에 맞는 쓰레드 생성

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -77,9 +77,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
       const initialBaseBranchName = await fetchCurrentBranch();
       const fetchClusterNodes = async (baseBranchName = initialBaseBranchName) => {
-        console.time('Multi log')
+        const startTime = Date.now();
         const gitLog = await fetchGitLogInParallel(gitPath, currentWorkspacePath);
-        console.timeEnd('Multi log')
+        const endTime = Date.now();
+        const elapsedTime = (endTime - startTime) / 1000;
+        console.log(`${elapsedTime.toFixed(3)}s`);
 
         
         const gitConfig = await getGitConfig(gitPath, currentWorkspacePath, "origin");

--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -217,9 +217,11 @@ export async function getLogCount(gitPath: string, currentWorkspacePath: string)
 
 export async function fetchGitLogInParallel(gitPath: string, currentWorkspacePath: string): Promise<string> {
   const numCores = os.cpus().length;
-  const numberOfThreads = Math.max(1, numCores - 1)
+  
   const totalCnt = await getLogCount(gitPath, currentWorkspacePath);
-  console.log("total logs", totalCnt);
+  let numberOfThreads = 1;
+  if(totalCnt > 1000) numberOfThreads = Math.max(numCores/2,1);
+  console.log("thread nums ",numberOfThreads);
   const chunkSize = Math.ceil(totalCnt/ numberOfThreads);
   const promises: Promise<string>[] = [];
 


### PR DESCRIPTION
## Related issue
- #712
- #713 

## Result
이전에 Worker를 사용하여 병렬적으로 로그를 받아오는 기능을 구현했습니다.
이 과정에서 항상 `컴퓨터 코어 수 - 1`개의 쓰레드를 생성하여 로그를 받아왔는데 멘토님께서 이는 메모리를 과하게 사용하는 매우 비효율적인 작업이라고 지적해주셨습니다.

따라서 로그 수에 따른 적절한 쓰레드 개수를 찾기 위해 사용하는 소요되는 메모리 양과 걸리는 시간을 평가하였습니다.

```js
setInterval(() => {
    const memoryUsage = process.memoryUsage();
    const rssUsage = memoryUsage.rss / 1024 / 1024; // RSS 메모리(MB)로 변환
    maxMemoryUsage = Math.max(maxMemoryUsage, rssUsage);
}, 10);
 ```
소요되는 메모리의 양을 정확히 구할 수는 없기 때문에 위와 같이 `setInterval` 함수를 사용하여 코드가 실행되는 동안 메모리 사용량을 `10ms`마다 기록하여 최댓값을 구하였습니다.

```js
const startMemoryUsage = process.memoryUsage().rss / 1024 / 1024; // 단위 MB
// setInterval 실행
// 로그 받아오는 코드 실행
const memoryIncrease = maxMemoryUsedDuringTask - startMemoryUsage; // maxMemoryUsedDuringTask에는 setInterval에서 구한 메모리 최댓값 저장
```
시작하기 전에 현재 프로세스가 사용하는 메모리의 양을 구하고 로그를 받아오는 동안 사용한 메모리 사용량의 최댓값을 구하였습니다.
그 후에 이 둘의 차를 이용하여 로그를 받아오는 코드가 얼마나 많은 메모리를 사용하는지 유추해 볼 수 있었습니다.

256, 1690, 2342, 4014, 5155, 7288, 8392, 9070, 11581, 14153, 20761개의 로그에 대해 최대 8개까지 쓰레드를 사용해서 걸리는 시간과 소요하는 메모리 양을 구해보았습니다. (멘토님의 조언으로 최대 로그의 개수를 20000까지 제한하였습니다)
다음은 총 3번 평가하여 평균값을 낸 데이터입니다.

### 1. gen
https://github.com/kubernetes-client/gen
로그 수 : 256개
| 시간 그래프 | 메모리 그래프 |
| ----------- | ------------- |
| <img src="https://github.com/user-attachments/assets/503ace10-9f1a-4ee7-bbb0-faaf438c5997" alt="시간 그래프" width="400"/> | <img src="https://github.com/user-attachments/assets/52ec20b4-70fd-473a-a1b6-f7f4f769a57f" alt="메모리 그래프" width="400"/> |

### 2. C-Plus-Plus
https://github.com/TheAlgorithms/C-Plus-Plus
로그 수 : 1,690개
| 시간 그래프 | 메모리 그래프 |
| ----------- | ------------- |
| <img src="https://github.com/user-attachments/assets/f1c7c3a8-61ee-4040-acb6-99670e83b7fe" alt="시간 그래프" width="400"/> | <img src="https://github.com/user-attachments/assets/60311e18-4f7f-47c3-b454-baf16d204c3b" alt="메모리 그래프" width="400"/> |

### 3. github ranking
https://github.com/EvanLi/Github-Ranking
로그 수 : 2,342개
| 시간 그래프 | 메모리 그래프 |
| ----------- | ------------- |
| <img src="https://github.com/user-attachments/assets/7ba727d6-c8b2-49cb-a112-23da095c1252" alt="시간 그래프" width="400"/> | <img src="https://github.com/user-attachments/assets/785e54a7-f1ad-4776-a8b0-b2b7aaef5a33" alt="메모리 그래프" width="400"/> |


### 4. vitest
https://github.com/vitest-dev/vitest
로그 수 : 4,014개
| 시간 그래프 | 메모리 그래프 |
| ----------- | ------------- |
| <img src="https://github.com/user-attachments/assets/081bab1d-90bf-48d4-b88f-15f2f43dc1bb" alt="시간 그래프" width="400"/> | <img src="https://github.com/user-attachments/assets/60d291dd-a163-4a3f-bc54-8ebc23e6b228" alt="메모리 그래프" width="400"/> |



### 5. SmartThingsPublic
https://github.com/SmartThingsCommunity/SmartThingsPublic
로그 수 : 5,155개
| 시간 그래프 | 메모리 그래프 |
| ----------- | ------------- |
| <img src="https://github.com/user-attachments/assets/1e2fda23-5654-4c09-b093-4d4e8a3a72d4" alt="시간 그래프" width="400"/> | <img src="https://github.com/user-attachments/assets/21595e3b-508a-4618-b3fe-d956f91d0dc6" alt="메모리 그래프" width="400"/> |

### 6. argo-cd
https://github.com/argoproj/argo-cd
로그 수 : 7,288개

| 시간 그래프 | 메모리 그래프 |
| ----------- | ------------- |
| <img src="https://github.com/user-attachments/assets/9a948832-d7c6-43aa-b065-887ef06a9e2a" alt="시간 그래프" width="400"/> | <img src="https://github.com/user-attachments/assets/fc456247-f9d6-4f38-a161-5488184de0f9" alt="메모리 그래프" width="400"/> |

### 7. jest
https://github.com/jestjs/jest
로그 수 : 8,392개

| 시간 그래프 | 메모리 그래프 |
| ----------- | ------------- |
| <img src="https://github.com/user-attachments/assets/9a8ec7e0-ac7a-4682-9429-fff2e4d956eb" alt="시간 그래프" width="400"/> | <img src="https://github.com/user-attachments/assets/d7c7bd7a-f092-480f-8343-cb475b73c650" alt="메모리 그래프" width="400"/> |

### 8. googleapis
https://github.com/googleapis/googleapis
로그 수 : 9,070개

| 시간 그래프 | 메모리 그래프 |
| ----------- | ------------- |
| <img src="https://github.com/user-attachments/assets/0eb149a8-ffc7-4b9f-ad6b-d5bd7ce13329" alt="시간 그래프" width="400"/> | <img src="https://github.com/user-attachments/assets/969f4924-3303-47d3-996c-8485894870af" alt="메모리 그래프" width="400"/> |

### 9. github
https://github.com/atom/github
로그 수 :  11,581개
| 시간 그래프 | 메모리 그래프 |
| ----------- | ------------- |
| <img src="https://github.com/user-attachments/assets/59ef2f44-fa84-4b95-9278-7d2489510efa" alt="시간 그래프" width="400"/> | <img src="https://github.com/user-attachments/assets/9f6857b4-8b78-44e8-b4ba-d78039a49193" alt="메모리 그래프" width="400"/> |

### 10. infer
https://github.com/facebook/infer
로그 수 : 14,153개
| 시간 그래프 | 메모리 그래프 |
| ----------- | ------------- |
| <img src="https://github.com/user-attachments/assets/83a23b78-dfac-4e33-ba94-b326a288555f" alt="시간 그래프" width="400"/> | <img src="https://github.com/user-attachments/assets/519d2ca9-7d46-41f9-8bff-43b70f8ead6e" alt="메모리 그래프" width="400"/> |


### 11. cypress
https://github.com/cypress-io/cypress
로그 수 : 20,761개
| 시간 그래프 | 메모리 그래프 |
| ----------- | ------------- |
| <img src="https://github.com/user-attachments/assets/2254f43d-2b43-4085-b532-e7f1fed4666d" alt="시간 그래프" width="400"/> | <img src="https://github.com/user-attachments/assets/7bf7db59-f91f-47cf-b2e3-3e965ba8efa9" alt="메모리 그래프" width="400"/> |
---

로그가 1000개 이상인 경우, 쓰레드 수가 증가함에 따라 작업 속도가 빨라지는 경향을 확인할 수 있었습니다.
그러나 과도하게 많은 쓰레드를 사용할 경우, 메모리 사용량이 크게 증가하는 반면 작업 속도 개선은 상대적으로 미미했습니다.
정확한 수치 분석은 진행되지 않았지만, CPU 코어 수의 절반 정도의 쓰레드를 사용했을 때 가장 효율적인 성능을 보인다고 생각하였습니다. (현재 저의 코어 수는 8개 입니다.)

따라서 쓰레드의 개수가 1000개 이상일 때, 코어 수의 반 개의 쓰레드를 활용하여 작업 진행하므로써 전에 `코어 수 - 1`개의 쓰레드를 사용했을 때보다 작업 속도를 최적화하면서도 메모리 사용량을 효과적으로 관리할 수 있게 되었습니다.

## Work list
- 쓰레드의 개수가 1000개 이상일 때, 코어 수의 반 개의 쓰레드를 활용하여 작업 진행

## Discussion
코어 수의 반 개의 쓰레드를 활용하는 방식이 정확한 정답은 아닙니다. 하지만 확실히 이전 방식보다 적절한 메모리를 사용하여 작업 시간을 단축한다는 것은 맞다고 생각합니다.
 

