### PR TITLE
[view] 유저 정보 매칭 실패시 유저 아이콘 클릭 비활성화

### DIFF
--- a/packages/view/src/components/@common/Author/Author.tsx
+++ b/packages/view/src/components/@common/Author/Author.tsx
@@ -5,24 +5,33 @@ import type { AuthorInfo } from "types";
 import { GITHUB_URL } from "../../../constants/constants";
 
 const Author = ({ name, src }: AuthorInfo) => {
+  const isUser = src.includes(GITHUB_URL);
   return (
     <Tooltip
       title={name}
       placement="top-start"
       PopperProps={{ sx: { ".MuiTooltip-tooltip": { bgcolor: "#3c4048" } } }}
     >
-      <a
-        href={`${GITHUB_URL}/${name}`}
-        target="_blank"
-        rel="noopener noreferrer"
-        style={{ textDecoration: "none" }}
-      >
+      {isUser ? (
+        <a
+          href={`${GITHUB_URL}/${name}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ textDecoration: "none" }}
+        >
+          <Avatar
+            alt={name}
+            src={src}
+            sx={{ width: 30, height: 30, minWidth: 30, minHeight: 30, cursor: "pointer" }}
+          />
+        </a>
+      ) : (
         <Avatar
           alt={name}
           src={src}
-          sx={{ width: 30, height: 30, minWidth: 30, minHeight: 30, cursor: "pointer" }}
+          sx={{ width: 30, height: 30, minWidth: 30, minHeight: 30 }}
         />
-      </a>
+      )}
     </Tooltip>
   );
 };


### PR DESCRIPTION
## Related issue
#571 
## Result
- 개선 이전 

https://github.com/user-attachments/assets/26ecd036-37ae-4ef9-aee4-539e832fab8b


- 개선 이후

https://github.com/user-attachments/assets/db7c7312-ee21-49a2-9d4b-ef73d2c1a0a9

## Work list
- #685 을 개선한 기능입니다.
- git log 에 가져온 user정보와 github 계정정보가 매칭이 안되는 경우 404 페이지로 이동하게 되어서 아이콘 클릭을 비활성화 처리하였습니다.
## Discussion
- 추후 다른 도메인까지 확장 적용된다면 수정이 필요합니다.