### PR TITLE
 [Refactor] SummaryUtil 리팩토링(#723)

### DIFF
--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.util.test.ts
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.util.test.ts
@@ -57,6 +57,81 @@ const clusterNodeMockData: ClusterNode[] = [
     ],
     nodeTypeName: "CLUSTER",
   },
+  {
+    nodeTypeName: "CLUSTER",
+    commitNodeList: [
+      {
+        nodeTypeName: "COMMIT",
+        commit: {
+          id: "dbb3beec12a66788b126101d5b2e6c0b4bb86379",
+          parentIds: ["0dca5a0e77c9c3cf99f55544721078141a551670", "b3caa9b6c71f72bec6fe44cad13e92555de3f54c"],
+          author: {
+            id: "no-id",
+            names: ["jin-Pro"],
+            emails: ["70205497+jin-Pro@users.noreply.github.com"],
+          },
+          committer: {
+            id: "no-id",
+            names: ["GitHub"],
+            emails: ["noreply@github.com"],
+          },
+          authorDate: "Tue Sep 13 2022 15:50:57 GMT+0900 (Korean Standard Time)",
+          commitDate: "Tue Sep 13 2022 15:50:57 GMT+0900 (Korean Standard Time)",
+          diffStatistics: {
+            changedFileCount: 1,
+            insertions: 66,
+            deletions: 0,
+            files: {
+              "packages/view/CONTRIBUTING.md": {
+                insertions: 66,
+                deletions: 0,
+              },
+            },
+          },
+          message: "Merge pull request #158 from jin-Pro/main/n/nadd View CONTRIBUTING.md Template",
+          tags: [],
+          releaseTags: [],
+        },
+        clusterId: 89,
+        seq: 1,
+      },
+      {
+        nodeTypeName: "COMMIT",
+        commit: {
+          id: "b3caa9b6c71f72bec6fe44cad13e92555de3f54c",
+          parentIds: ["2719afd7716153c9318dad48482c8245bea82eb5"],
+          author: {
+            id: "no-id",
+            names: ["jin-Pro"],
+            emails: ["dnjun2@ajou.ac.kr"],
+          },
+          committer: {
+            id: "no-id",
+            names: ["jin-Pro"],
+            emails: ["dnjun2@ajou.ac.kr"],
+          },
+          authorDate: "Tue Sep 13 2022 14:50:26 GMT+0900 (Korean Standard Time)",
+          commitDate: "Tue Sep 13 2022 14:50:26 GMT+0900 (Korean Standard Time)",
+          diffStatistics: {
+            changedFileCount: 1,
+            insertions: 66,
+            deletions: 0,
+            files: {
+              "packages/view/CONTRIBUTING.md": {
+                insertions: 66,
+                deletions: 0,
+              },
+            },
+          },
+          message: "docs(view): add View CONTRIBUTING.md Template",
+          tags: [],
+          releaseTags: [],
+        },
+        clusterId: 89,
+        seq: 2,
+      },
+    ],
+  },
 ];
 
 test("getClusterById test", () => {
@@ -81,7 +156,9 @@ test("getClusterIds test", () => {
   expect(result).not.toBeUndefined();
   expect(result[0]).toBe(0);
   expect(result[1]).toBe(1);
-  expect(result).toHaveLength(2);
+  expect(result[2]).toBe(89);
+
+  expect(result).toHaveLength(3);
 });
 
 describe("getInitData test", () => {
@@ -94,11 +171,7 @@ describe("getInitData test", () => {
     expect(result[0].summary.content.message).toBe("Initial commit");
   });
 
-  test("클러스터의 커밋 작성자 이름이 중복되지 않는다.", () => {
-    const isUnique = result
-      .map((data) => data.summary.authorNames.length === new Set(data.summary.authorNames).size)
-      .every((value) => value === true);
-
-    expect(isUnique).toBe(true);
+  test("the commit author names in the cluster are not duplicated.", () => {
+    expect(result[2].summary.authorNames.length).toBe(1);
   });
 });

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.util.test.ts
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.util.test.ts
@@ -84,11 +84,21 @@ test("getClusterIds test", () => {
   expect(result).toHaveLength(2);
 });
 
-test("getInitData test", () => {
+describe("getInitData test", () => {
   const result = getInitData(clusterNodeMockData);
 
-  expect(result).not.toBeUndefined();
-  expect(result[0].clusterId).toBe(0);
-  expect(result[0].summary.authorNames[0][0]).toBe("ytaek");
-  expect(result[0].summary.content.message).toBe("Initial commit");
+  test("getInitData test", () => {
+    expect(result).not.toBeUndefined();
+    expect(result[0].clusterId).toBe(0);
+    expect(result[0].summary.authorNames[0][0]).toBe("ytaek");
+    expect(result[0].summary.content.message).toBe("Initial commit");
+  });
+
+  test("클러스터의 커밋 작성자 이름이 중복되지 않는다.", () => {
+    const isUnique = result
+      .map((data) => data.summary.authorNames.length === new Set(data.summary.authorNames).size)
+      .every((value) => value === true);
+
+    expect(isUnique).toBe(true);
+  });
 });


### PR DESCRIPTION
## Related issue
#723 

## Result

* 리팩토링 전, 테스트를 진행했습니다.
getInitData 의 주요 역할이 
1. 한 클러스터 내의 author들을 중복없이 보여준다. 
2. 클러스터의 첫번째 커밋 메세지를 노출한다. 
3. 가장 최신의 릴리스 태그를 노출한다 
 로 보았는데,  1번에 대한 테스트코드를 추가해보았습니다.

<img width="766" alt="image" src="https://github.com/user-attachments/assets/89ded1bb-1961-415b-a56f-08a4ae7046bf">


## Work list
1. map -> forEach로 변경
2. authorSet을 여러 군데에서 변경 및 혼동되는 변수 네이밍 변경
3. 최종 리턴값에 담길 cluster 변수를 마지막에 세팅 (여러번 객체의 값 변경 하는 방식 지양)

## Discussion
