### PR TITLE
[engine] 최대 쓰레드 수 3개 제한 및 git 로그 최초 한 번만 불러오기

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -53,14 +53,14 @@ export async function activate(context: vscode.ExtensionContext) {
 
       const currentWorkspacePath = normalizeFsPath(currentWorkspaceUri.fsPath);
 
-      const gitLog = await fetchGitLogInParallel(gitPath, currentWorkspacePath);
-
       const githubToken: string | undefined = await getGithubToken(secrets);
       if (!githubToken) {
         throw new GithubTokenUndefinedError("Cannot find your GitHub token. Retrying github authentication...");
       }
 
       const fetchBranches = async () => await getBranches(gitPath, currentWorkspacePath);
+
+      const gitLog = await fetchGitLogInParallel(gitPath, currentWorkspacePath);
 
       const fetchCurrentBranch = async () => {
         let branchName;

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -53,6 +53,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
       const currentWorkspacePath = normalizeFsPath(currentWorkspaceUri.fsPath);
 
+      const gitLog = await fetchGitLogInParallel(gitPath, currentWorkspacePath);
+
       const githubToken: string | undefined = await getGithubToken(secrets);
       if (!githubToken) {
         throw new GithubTokenUndefinedError("Cannot find your GitHub token. Retrying github authentication...");
@@ -76,14 +78,9 @@ export async function activate(context: vscode.ExtensionContext) {
       };
 
       const initialBaseBranchName = await fetchCurrentBranch();
-      const fetchClusterNodes = async (baseBranchName = initialBaseBranchName) => {
-        const startTime = Date.now();
-        const gitLog = await fetchGitLogInParallel(gitPath, currentWorkspacePath);
-        const endTime = Date.now();
-        const elapsedTime = (endTime - startTime) / 1000;
-        console.log(`${elapsedTime.toFixed(3)}s`);
+    
 
-        
+      const fetchClusterNodes = async (baseBranchName = initialBaseBranchName) => {
         const gitConfig = await getGitConfig(gitPath, currentWorkspacePath, "origin");
 
         const { owner, repo: initialRepo } = getRepo(gitConfig);

--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -217,7 +217,6 @@ export async function getLogCount(gitPath: string, currentWorkspacePath: string)
 
 export async function fetchGitLogInParallel(gitPath: string, currentWorkspacePath: string): Promise<string> {
   const numCores = os.cpus().length;
-  console.log("!!!!!!!!!!!!!!!GetLog!!!!!!!!!!!");
   
   const totalCnt = await getLogCount(gitPath, currentWorkspacePath);
   let numberOfThreads = 1;

--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -217,11 +217,15 @@ export async function getLogCount(gitPath: string, currentWorkspacePath: string)
 
 export async function fetchGitLogInParallel(gitPath: string, currentWorkspacePath: string): Promise<string> {
   const numCores = os.cpus().length;
+  console.log("!!!!!!!!!!!!!!!GetLog!!!!!!!!!!!");
   
   const totalCnt = await getLogCount(gitPath, currentWorkspacePath);
   let numberOfThreads = 1;
-  if(totalCnt > 1000) numberOfThreads = Math.max(numCores/2,1);
-  console.log("thread nums ",numberOfThreads);
+  if(totalCnt > 1000){
+    if(numCores < 4) numberOfThreads = 2;
+    else numberOfThreads = 3;
+  }
+ 
   const chunkSize = Math.ceil(totalCnt/ numberOfThreads);
   const promises: Promise<string>[] = [];
 

--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -220,10 +220,14 @@ export async function fetchGitLogInParallel(gitPath: string, currentWorkspacePat
   
   const totalCnt = await getLogCount(gitPath, currentWorkspacePath);
   let numberOfThreads = 1;
-  if(totalCnt > 1000){
-    if(numCores < 4) numberOfThreads = 2;
-    else numberOfThreads = 3;
-  }
+
+  const taskThreshold = 1000;
+  const coreCountThreshold = 4;
+
+if (totalCnt > taskThreshold) {
+  if (numCores < coreCountThreshold) numberOfThreads = 2;
+  else numberOfThreads = 3;
+}
  
   const chunkSize = Math.ceil(totalCnt/ numberOfThreads);
   const promises: Promise<string>[] = [];

--- a/packages/vscode/src/webview-loader.ts
+++ b/packages/vscode/src/webview-loader.ts
@@ -37,13 +37,12 @@ export default class WebviewLoader implements vscode.Disposable {
         const { command, payload } = message;
 
         if (command === "fetchAnalyzedData" || command === "refresh") {
-          const baseBranchName = (payload && JSON.parse(payload)) ?? (await fetchCurrentBranch());
           try {
             const baseBranchName = (payload && JSON.parse(payload)) ?? (await fetchCurrentBranch());
             const storedAnalyzedData = context.workspaceState.get<ClusterNode[]>(
               `${ANALYZE_DATA_KEY}_${baseBranchName}`
             );
-            let analyzedData = storedAnalyzedData;
+            analyzedData = storedAnalyzedData;
             if (!storedAnalyzedData) {
               console.log("No cache Data");
               console.log("baseBranchName : ", baseBranchName);


### PR DESCRIPTION
## Related issue
- #672 
- #743 

## Result
- 기존 브랜치를 변경 할 때마다 git 로그를 불러오는 방식에서 최초 실행 시 한 번만 불러오는 방식으로 바꿨습니다.
- 1000개 이상의 로그 수를 받아오는 경우 생성되는 쓰레드의 수를 최대 3개로 제한하였습니다.
- webview-loader에 있는 불필요한 코드를 정리하였습니다.

## Work list
- `fetchClusterNodes`에 있던 `fetchGitLogInParallel` 함수 밖으로 이전
-  불필요한 `baseBranchName` 함수 제거
- 로그가 1000개 이상 일때, 코어 수가 4개 미만이라면 2개의 쓰레드, 이상이라면 3개의 쓰레드가 생성되도록 변경

## Discussion
혹시 위 작업을 마지막으로 해당 브랜치를 메인 브랜치와 병합해도 괜찮을까요?