### PR TITLE
[view] Theme Selector 테마 전역 저장 및 코드 리팩토링

### DIFF
--- a/packages/view/public/index.html
+++ b/packages/view/public/index.html
@@ -1,11 +1,14 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1"
+    />
     <script>
-      window.isProduction = false;   
-      window.primaryColor = '#ffbbff';                     
+      window.isProduction = false;
+      window.theme = "githru";
     </script>
     <title>Githru</title>
   </head>

--- a/packages/view/src/components/ThemeSelector/ThemeSelector.tsx
+++ b/packages/view/src/components/ThemeSelector/ThemeSelector.tsx
@@ -69,32 +69,27 @@ const themeInfo: ThemeInfo[] = [
 ];
 
 const ThemeIcons = ({ title, value, colors, onClick }: ThemeIconsProps) => {
-  const [isSelected, setIsSelected] = useState<string>("");
+  const [selectedItem, setSelectedItem] = useState<string>("");
 
   useEffect(() => {
     const selectedTheme = document.documentElement.getAttribute("custom-type");
-    if (selectedTheme) setIsSelected(selectedTheme);
+    if (selectedTheme) setSelectedItem(selectedTheme);
   }, []);
 
   return (
     <div
-      className={`theme-icon${isSelected === value ? "--selected" : ""}`}
+      className={`theme-icon${selectedItem === value ? "--selected" : ""}`}
       onClick={onClick}
       role="presentation"
     >
       <div className="theme-icon__container">
-        <div
-          className="theme-icon__color"
-          style={{ backgroundColor: colors.primary }}
-        />
-        <div
-          className="theme-icon__color"
-          style={{ backgroundColor: colors.secondary }}
-        />
-        <div
-          className="theme-icon__color"
-          style={{ backgroundColor: colors.tertiary }}
-        />
+        {Object.values(colors).map((color, index) => (
+          <div
+            key={Number(index)}
+            className="theme-icon__color"
+            style={{ backgroundColor: color }}
+          />
+        ))}
       </div>
       <p className="theme-icon__title">{title}</p>
     </div>
@@ -102,9 +97,10 @@ const ThemeIcons = ({ title, value, colors, onClick }: ThemeIconsProps) => {
 };
 
 const ThemeSelector = () => {
-  const [open, setOpen] = useState<boolean>(false);
+  const [isOpen, setIsOpen] = useState<boolean>(false);
 
   const handleTheme = (value: string) => {
+    setCustomTheme(value);
     document.documentElement.setAttribute("custom-type", value);
   };
 
@@ -114,26 +110,24 @@ const ThemeSelector = () => {
 
   return (
     <div className="theme-selector">
-      <AutoAwesomeIcon onClick={() => setOpen(true)} />
-      {open && (
+      <AutoAwesomeIcon onClick={() => setIsOpen(true)} />
+      {isOpen && (
         <div className="theme-selector__container">
           <div className="theme-selector__header">
             <p>Theme</p>
             <CloseIcon
               fontSize="small"
-              onClick={() => setOpen(false)}
+              onClick={() => setIsOpen(false)}
             />
           </div>
           <div className="theme-selector__list">
-            {themes.map((theme) => (
+            {themeInfo.map((theme) => (
               <ThemeIcons
                 key={theme.value}
-                title={theme.title}
-                value={theme.value}
-                colors={theme.colors}
+                {...theme}
                 onClick={() => {
                   handleTheme(theme.value);
-                  setOpen(false);
+                  setIsOpen(false);
                 }}
               />
             ))}

--- a/packages/view/src/components/ThemeSelector/ThemeSelector.tsx
+++ b/packages/view/src/components/ThemeSelector/ThemeSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import "./ThemeSelector.scss";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import CloseIcon from "@mui/icons-material/Close";
@@ -98,6 +98,7 @@ const ThemeIcons = ({ title, value, colors, onClick }: ThemeIconsProps) => {
 
 const ThemeSelector = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
+  const themeSelectorRef = useRef<HTMLDivElement>(null);
 
   const handleTheme = (value: string) => {
     setCustomTheme(value);
@@ -105,11 +106,26 @@ const ThemeSelector = () => {
   };
 
   useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (themeSelectorRef.current && !themeSelectorRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  useEffect(() => {
     document.documentElement.setAttribute("custom-type", window.theme);
   }, []);
 
   return (
-    <div className="theme-selector">
+    <div
+      className="theme-selector"
+      ref={themeSelectorRef}
+    >
       <AutoAwesomeIcon onClick={() => setIsOpen(true)} />
       {isOpen && (
         <div className="theme-selector__container">

--- a/packages/view/src/components/ThemeSelector/ThemeSelector.tsx
+++ b/packages/view/src/components/ThemeSelector/ThemeSelector.tsx
@@ -104,7 +104,7 @@ const ThemeSelector = () => {
   };
 
   useEffect(() => {
-    document.documentElement.setAttribute("custom-type", "githru");
+    document.documentElement.setAttribute("custom-type", window.theme);
   }, []);
 
   return (

--- a/packages/view/src/components/ThemeSelector/ThemeSelector.tsx
+++ b/packages/view/src/components/ThemeSelector/ThemeSelector.tsx
@@ -3,7 +3,23 @@ import "./ThemeSelector.scss";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import CloseIcon from "@mui/icons-material/Close";
 
-const themes = [
+import { setCustomTheme } from "services";
+
+type ThemeInfo = {
+  title: string;
+  value: string;
+  colors: {
+    primary: string;
+    secondary: string;
+    tertiary: string;
+  };
+};
+
+type ThemeIconsProps = ThemeInfo & {
+  onClick: () => void;
+};
+
+const themeInfo: ThemeInfo[] = [
   {
     title: "Githru",
     value: "githru",
@@ -51,17 +67,6 @@ const themes = [
     },
   },
 ];
-
-type ThemeIconsProps = {
-  title: string;
-  value: string;
-  colors: {
-    primary: string;
-    secondary: string;
-    tertiary: string;
-  };
-  onClick: () => void;
-};
 
 const ThemeIcons = ({ title, value, colors, onClick }: ThemeIconsProps) => {
   const [isSelected, setIsSelected] = useState<string>("");

--- a/packages/view/src/ide/FakeIDEAdapter.ts
+++ b/packages/view/src/ide/FakeIDEAdapter.ts
@@ -54,10 +54,10 @@ export default class FakeIDEAdapter implements IDEPort {
     this.sendMessageToMe(message);
   }
 
-  public setPrimaryColor(color: string) {
+  public setCustomTheme(color: string) {
     sessionStorage.setItem("PRIMARY_COLOR", color);
     const message: IDEMessage = {
-      command: "updatePrimaryColor",
+      command: "updateCustomTheme",
     };
     this.sendMessageToMe(message);
   }
@@ -76,10 +76,10 @@ export default class FakeIDEAdapter implements IDEPort {
           command,
           payload: JSON.stringify(fakeBranchList),
         };
-      case "updatePrimaryColor":
+      case "updateCustomTheme":
         return {
           command,
-          payload: sessionStorage.getItem("PRIMARY_COLOR") as string,
+          payload: sessionStorage.getItem("CUSTOM_THEME") as string,
         };
       default:
         return {

--- a/packages/view/src/ide/IDEPort.ts
+++ b/packages/view/src/ide/IDEPort.ts
@@ -10,5 +10,5 @@ export default interface IDEPort {
   sendRefreshDataMessage: (payload?: string) => void;
   sendFetchAnalyzedDataMessage: (payload?: string) => void;
   sendFetchBranchListMessage: () => void;
-  setPrimaryColor: (color: string) => void;
+  setCustomTheme: (theme: string) => void;
 }

--- a/packages/view/src/ide/VSCodeIDEAdapter.ts
+++ b/packages/view/src/ide/VSCodeIDEAdapter.ts
@@ -49,10 +49,10 @@ export default class VSCodeIDEAdapter implements IDEPort {
     this.sendMessageToIDE(message);
   }
 
-  public setPrimaryColor(color: string) {
+  public setCustomTheme(theme: string) {
     const message: IDEMessage = {
-      command: "updatePrimaryColor",
-      payload: JSON.stringify({ primary: color }),
+      command: "updateCustomTheme",
+      payload: JSON.stringify({ theme }),
     };
     this.sendMessageToIDE(message);
   }

--- a/packages/view/src/services/index.ts
+++ b/packages/view/src/services/index.ts
@@ -2,9 +2,9 @@ import { container } from "tsyringe";
 
 import type IDEPort from "ide/IDEPort";
 
-export const setPrimaryColor = (color: string) => {
+export const setCustomTheme = (color: string) => {
   const ideAdapter = container.resolve<IDEPort>("IDEAdapter");
-  ideAdapter.setPrimaryColor(color);
+  ideAdapter.setCustomTheme(color);
 };
 
 export const sendFetchAnalyzedDataCommand = (selectedBranch?: string) => {

--- a/packages/view/src/types/IDEMessage.ts
+++ b/packages/view/src/types/IDEMessage.ts
@@ -12,4 +12,4 @@ export type IDEMessageCommandNames =
   | "fetchAnalyzedData"
   | "fetchBranchList"
   | "fetchCurrentBranch"
-  | "updatePrimaryColor";
+  | "updateCustomTheme";

--- a/packages/view/src/types/custom.d.ts
+++ b/packages/view/src/types/custom.d.ts
@@ -3,7 +3,7 @@ interface Window {
   githruNodesData: unknown;
   githruBranchesData: unknown;
   isProduction: boolean;
-  primaryColor: string;
+  theme: string;
 }
 
 declare module "*.svg" {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -62,10 +62,10 @@
     "configuration": {
       "title": "Githru",
       "properties": {
-        "githru.color.primary": {
+        "githru.theme": {
           "type": "string",
-          "default": "#ff8272",
-          "description": "Insert your primary color."
+          "default": "githru",
+          "description": "Insert your theme name: githru, hacker-blue, aqua, cotton-candy, mono"
         }
       }
     }

--- a/packages/vscode/src/setting-repository.ts
+++ b/packages/vscode/src/setting-repository.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 
 const SETTING_PROPERTY_NAMES = {
   GITHUB_TOKEN: "githru.github.token",
-  PRIMARY_COLOR: "githru.color.primary",
+  THEME: "githru.theme",
 };
 
 export const getGithubToken = async (secrets: vscode.SecretStorage) => {
@@ -14,22 +14,21 @@ export const setGithubToken = async (secrets: vscode.SecretStorage, newGithubTok
 };
 
 export const deleteGithubToken = async (secrets: vscode.SecretStorage) => {
-    return await secrets.delete(SETTING_PROPERTY_NAMES.GITHUB_TOKEN);
-}
-
-export const setPrimaryColor = (color: string) => {
-  const configuration = vscode.workspace.getConfiguration();
-  configuration.update(SETTING_PROPERTY_NAMES.PRIMARY_COLOR, color);
+  return await secrets.delete(SETTING_PROPERTY_NAMES.GITHUB_TOKEN);
 };
 
-export const getPrimaryColor = (): string => {
+export const setTheme = async (newTheme: string) => {
   const configuration = vscode.workspace.getConfiguration();
-  const primaryColor = configuration.get(SETTING_PROPERTY_NAMES.PRIMARY_COLOR) as string;
+  configuration.update(SETTING_PROPERTY_NAMES.THEME, newTheme);
+};
 
-  if (!primaryColor) {
-    configuration.update(SETTING_PROPERTY_NAMES.PRIMARY_COLOR, "#ff8272");
-    return "#ff8272";
-  } else {
-    return primaryColor;
+export const getTheme = async (): Promise<string> => {
+  const configuration = vscode.workspace.getConfiguration();
+  const theme = configuration.get(SETTING_PROPERTY_NAMES.THEME) as string;
+
+  if (!theme) {
+    await setTheme("githru");
+    return "githru";
   }
+  return theme;
 };

--- a/packages/vscode/src/webview-loader.ts
+++ b/packages/vscode/src/webview-loader.ts
@@ -92,7 +92,7 @@ export default class WebviewLoader implements vscode.Disposable {
     //   this.dispose();
     //   throw new Error("Project not connected to Git.");
     // }
-    this._panel.webview.html = this.getWebviewContent(this._panel.webview);
+    this.setWebviewContent();
   }
 
   dispose() {
@@ -111,13 +111,12 @@ export default class WebviewLoader implements vscode.Disposable {
     });
   }
 
-  private getWebviewContent(webview: vscode.Webview): string {
+  private async getWebviewContent(webview: vscode.Webview): Promise<string> {
     const reactAppPathOnDisk = vscode.Uri.file(path.join(this.extensionPath, "dist", "webviewApp.js"));
     const reactAppUri = webview.asWebviewUri(reactAppPathOnDisk);
     // const reactAppUri = reactAppPathOnDisk.with({ scheme: "vscode-resource" });
 
-    const primaryColor = getPrimaryColor();
-
+    const theme = await getTheme();
     const returnString = `
             <!DOCTYPE html>
             <html lang="en">
@@ -127,7 +126,7 @@ export default class WebviewLoader implements vscode.Disposable {
                     <title>githru-vscode-ext webview</title>
                     <script>
                         window.isProduction = true;   
-                        window.primaryColor = "${primaryColor}";                     
+                        window.theme = "${theme}";                       
                     </script>
                 </head>
                 <body>
@@ -141,6 +140,13 @@ export default class WebviewLoader implements vscode.Disposable {
         `;
     return returnString;
   }
+
+  private async setWebviewContent() {
+    if (this._panel) {
+      this._panel.webview.html = await this.getWebviewContent(this._panel.webview);
+    }
+  }
+
   public setGlobalOwnerAndRepo(owner: string, repo: string) {
     if (this._panel) {
       this._panel.webview.postMessage({

--- a/packages/vscode/src/webview-loader.ts
+++ b/packages/vscode/src/webview-loader.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import * as vscode from "vscode";
 
-import { getPrimaryColor, setPrimaryColor } from "./setting-repository";
+import { getTheme, setTheme } from "./setting-repository";
 import type { ClusterNode } from "./types/Node";
 
 const ANALYZE_DATA_KEY = "memento_analyzed_data";
@@ -77,10 +77,10 @@ export default class WebviewLoader implements vscode.Disposable {
           });
         }
 
-        if (command === "updatePrimaryColor") {
+        if (command === "updateCustomTheme") {
           const colorCode = payload && JSON.parse(payload);
-          if (colorCode.primary) {
-            setPrimaryColor(colorCode.primary);
+          if (colorCode.theme) {
+            setTheme(colorCode.theme);
           }
         }
       } catch (e) {


### PR DESCRIPTION
## Related issue
#752 
## Result

https://github.com/user-attachments/assets/02f269d7-debb-4be9-8a18-c23ef81604eb

## Work list
#### 1. Theme Selector 테마 전역 저장
ThemeSelector를 이용해 선택한 테마를 재접속 시 유지할 수 있도록 구현했습니다.
로직은 다음과 같습니다: 
1. ThemeSelector 컴포넌트를 통해 테마를 선택하여 변경합니다.
2. vscode api를 통해, vscode에 메시지를 보냅니다. (`view/services`)
``` ts
 public setCustomTheme(theme: string) {
    const message: IDEMessage = {
      command: "updateCustomTheme",
      payload: JSON.stringify({ theme }),
    };
    this.sendMessageToIDE(message);
  }
```
3. vscode가 메시지를 수신, command에 맞는 동작을 수행합니다. 
여기서는 `setTheme()` 함수를 호출하여, vscode의 configuration 중 githru.theme 값을 업데이트 합니다.
```ts
 // vscode/webview-loader.ts
 if (command === "updateCustomTheme") {
   const colorCode = payload && JSON.parse(payload);
   if (colorCode.theme) {
     setTheme(colorCode.theme);
   }
 }

// vscode/setting-repository.ts
export const setTheme = async (newTheme: string) => {
  const configuration = vscode.workspace.getConfiguration();
  configuration.update(SETTING_PROPERTY_NAMES.THEME, newTheme);
};
```

4. 저장된 값은 다음 webview를 로드할 때 `getTheme()`함수를 통해 vscode configuration에 업데이트 한 theme 값을 가져와 `window` 객체에 저장합니다. (`vscode/webview-loader.ts`)
5. ThemeSelector 컴포넌트에서 `window.theme` 값을 가져와 테마를 업데이트 합니다. 

#### 2. 코드 리팩토링
#687 의 피드백을 반영하여 코드를 리팩토링 했습니다. 
type 설정, 변수명 변경, 그리고 selector 영역 외 클릭 시 창이 닫히도록 구현했습니다. 

## Discussion
