### PR TITLE
[engine] git.worker.ts에 새로운 git format 적용

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -60,8 +60,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
       const fetchBranches = async () => await getBranches(gitPath, currentWorkspacePath);
 
-      // const gitLog = await fetchGitLogInParallel(gitPath, currentWorkspacePath);
-      const gitLog = await getGitLog(gitPath, currentWorkspacePath);
+      const gitLog = await fetchGitLogInParallel(gitPath, currentWorkspacePath);
 
       const fetchCurrentBranch = async () => {
         let branchName;

--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -259,6 +259,8 @@ if (totalCnt > taskThreshold) {
         currentWorkspacePath,
         skipCount,
         limitCount,
+        COMMIT_SEPARATOR, 
+        GIT_LOG_SEPARATOR 
       },
     });
 

--- a/packages/vscode/src/utils/git.worker.ts
+++ b/packages/vscode/src/utils/git.worker.ts
@@ -3,9 +3,28 @@ import { parentPort, workerData } from 'worker_threads';
 
 import { resolveSpawnOutput } from './git.util'
 
-const { gitPath, currentWorkspacePath, skipCount, limitCount } = workerData;
+const { gitPath, currentWorkspacePath, skipCount, limitCount,COMMIT_SEPARATOR,GIT_LOG_SEPARATOR } = workerData;
+
+    
+
 
 async function getPartialGitLog() {
+    const gitLogFormat =
+      COMMIT_SEPARATOR +
+      [
+        "%H", // commit hash (id)
+        "%P", // parent hashes
+        "%D", // ref names (branches, tags)
+        "%an", // author name
+        "%ae", // author email
+        "%ad", // author date
+        "%cn",
+        "%ce",
+        "%cd", // committer name, committer email and committer date
+        "%B", // commit message  (subject and body)
+      ].join(GIT_LOG_SEPARATOR) +
+      GIT_LOG_SEPARATOR;
+
     const args = [
         '--no-pager',
         'log',
@@ -13,7 +32,7 @@ async function getPartialGitLog() {
         '--parents',
         '--numstat',
         '--date-order',
-        '--pretty=fuller',
+        `--pretty=format:${gitLogFormat}`,
         '--decorate',
         '-c',
         `--skip=${skipCount}`,


### PR DESCRIPTION
## Related issue
- #753 

## Result
git.worker.ts에 #753에서 적용하신 새로운 git format을 적용하였습니다.

## Work list
- git.worker.ts에 새로운 git format 적용

## Discussion
@yoouyeon 님이 작성하신 코드를 보고 그대로 적용했는데 잘 동작하는 것 같습니다.
제 예상에는 `getGitLog`에서 진행 되었던 테스트가 `fetchGitLogInParallel`에서도 진행되어야 할 것 같은데 한 번 검토 부탁드립니다.