### PR TITLE
[engine] git log 파싱에 사용되는 separator 개선

### DIFF
--- a/packages/analysis-engine/src/constant.ts
+++ b/packages/analysis-engine/src/constant.ts
@@ -1,2 +1,0 @@
-export const COMMIT_SEPARATOR = "4itc2s8hH-oA64s08h19";
-export const GIT_LOG_SEPARATOR = "I9M-0XOzvHlYPegVPpzb";

--- a/packages/analysis-engine/src/index.ts
+++ b/packages/analysis-engine/src/index.ts
@@ -75,7 +75,7 @@ export class AnalysisEngine {
     if (this.isDebugMode) console.log("stemDict: ", stemDict);
     const csmDict = buildCSMDict(commitDict, stemDict, this.baseBranchName, pullRequests);
     if (this.isDebugMode) console.log("csmDict: ", csmDict);
-    const nodes = stemDict.get(this.baseBranchName)?.nodes?.map(({commit}) => commit);
+    const nodes = stemDict.get(this.baseBranchName)?.nodes?.map(({ commit }) => commit);
     const geminiCommitSummary = await getSummary(nodes ? nodes?.slice(-10) : []);
     if (this.isDebugMode) console.log("GeminiCommitSummary: ", geminiCommitSummary);
 
@@ -92,4 +92,3 @@ export class AnalysisEngine {
 }
 
 export default AnalysisEngine;
-export { COMMIT_SEPARATOR, GIT_LOG_SEPARATOR } from "./constant";

--- a/packages/analysis-engine/src/parser.spec.ts
+++ b/packages/analysis-engine/src/parser.spec.ts
@@ -1,5 +1,4 @@
 import { getCommitMessageType } from "./commit.util";
-import { COMMIT_SEPARATOR, GIT_LOG_SEPARATOR } from "./constant";
 import getCommitRaws from "./parser";
 import type { CommitRaw, DifferenceStatistic } from "./types";
 
@@ -36,11 +35,23 @@ describe("commit message type", () => {
 });
 
 describe("getCommitRaws", () => {
-  const fakeAuthorAndCommitter = `${GIT_LOG_SEPARATOR}John Park${GIT_LOG_SEPARATOR}mail@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 4 20:17:59 2022 +0900${GIT_LOG_SEPARATOR}John Park 2${GIT_LOG_SEPARATOR}mail2@gmail.com${GIT_LOG_SEPARATOR}Sun Sep 5 20:17:59 2022 +0900`;
-  const fakeCommitMessage = `${GIT_LOG_SEPARATOR}commit message${GIT_LOG_SEPARATOR}`;
-  const fakeCommitMessageAndBody = `${GIT_LOG_SEPARATOR}commit message title\n\ncommit message body${GIT_LOG_SEPARATOR}`;
-  const fakeCommitHash = `a${GIT_LOG_SEPARATOR}b`;
-  const fakeCommitRef = `${GIT_LOG_SEPARATOR}HEAD`;
+  const FRONT_NEW_LINE = "\n\n";
+  const COMMIT_MESSAGE_BODY_INDENTATION = "    ";
+
+  const fakeAuthor = `John Park
+mail@gmail.com
+Sun Sep 4 20:17:59 2022 +0900`;
+  const fakeCommitter = `John Park 2
+mail2@gmail.com
+Sun Sep 5 20:17:59 2022 +0900`;
+  const fakeCommitMessage = `commit message
+${COMMIT_MESSAGE_BODY_INDENTATION}`;
+  const fakeCommitMessageAndBody = `commit message title
+
+${COMMIT_MESSAGE_BODY_INDENTATION}commit message body`;
+  const fakeCommitHash = `a
+b`;
+  const fakeCommitRef = "HEAD";
   const fakeCommitFileChange = "10\t0\ta.ts\n1\t0\tREADME.md";
 
   const commonExpectatedResult: CommitRaw = {
@@ -73,15 +84,27 @@ describe("getCommitRaws", () => {
 
   it.each([
     [
-      `${COMMIT_SEPARATOR}${`a${GIT_LOG_SEPARATOR}`}${fakeCommitRef}${fakeAuthorAndCommitter}${fakeCommitMessage}`,
+      FRONT_NEW_LINE +
+        `a
+
+${fakeCommitRef}
+${fakeAuthor}
+${fakeCommitter}
+${fakeCommitMessage}`,
       {
         ...commonExpectatedResult,
         id: "a",
-        parents: [""],
+        parents: [],
       },
     ],
     [
-      `${COMMIT_SEPARATOR}${`c${GIT_LOG_SEPARATOR}b`}${fakeCommitRef}${fakeAuthorAndCommitter}${fakeCommitMessage}`,
+      FRONT_NEW_LINE +
+        `c
+b
+${fakeCommitRef}
+${fakeAuthor}
+${fakeCommitter}
+${fakeCommitMessage}`,
       {
         ...commonExpectatedResult,
         id: "c",
@@ -89,7 +112,13 @@ describe("getCommitRaws", () => {
       },
     ],
     [
-      `${COMMIT_SEPARATOR}${`d${GIT_LOG_SEPARATOR}e f`}${fakeCommitRef}${fakeAuthorAndCommitter}${fakeCommitMessage}`,
+      FRONT_NEW_LINE +
+        `d
+e f
+${fakeCommitRef}
+${fakeAuthor}
+${fakeCommitter}
+${fakeCommitMessage}`,
       {
         ...commonExpectatedResult,
         id: "d",
@@ -103,7 +132,12 @@ describe("getCommitRaws", () => {
 
   it.each([
     [
-      `${COMMIT_SEPARATOR}${fakeCommitHash}${`${GIT_LOG_SEPARATOR}HEAD`}${fakeAuthorAndCommitter}${fakeCommitMessage}`,
+      FRONT_NEW_LINE +
+        `${fakeCommitHash}
+HEAD
+${fakeAuthor}
+${fakeCommitter}
+${fakeCommitMessage}`,
       {
         ...commonExpectatedResult,
         branches: ["HEAD"],
@@ -111,7 +145,12 @@ describe("getCommitRaws", () => {
       },
     ],
     [
-      `${COMMIT_SEPARATOR}${fakeCommitHash}${`${GIT_LOG_SEPARATOR}HEAD -> main, origin/main, origin/HEAD`}${fakeAuthorAndCommitter}${fakeCommitMessage}`,
+      FRONT_NEW_LINE +
+        `${fakeCommitHash}
+HEAD -> main, origin/main, origin/HEAD
+${fakeAuthor}
+${fakeCommitter}
+${fakeCommitMessage}`,
       {
         ...commonExpectatedResult,
         branches: ["HEAD", "main", "origin/main", "origin/HEAD"],
@@ -119,7 +158,12 @@ describe("getCommitRaws", () => {
       },
     ],
     [
-      `${COMMIT_SEPARATOR}${fakeCommitHash}${`${GIT_LOG_SEPARATOR}HEAD, tag: v1.0.0`}${fakeAuthorAndCommitter}${fakeCommitMessage}`,
+      FRONT_NEW_LINE +
+        `${fakeCommitHash}
+HEAD, tag: v1.0.0
+${fakeAuthor}
+${fakeCommitter}
+${fakeCommitMessage}`,
       {
         ...commonExpectatedResult,
         branches: ["HEAD"],
@@ -127,7 +171,12 @@ describe("getCommitRaws", () => {
       },
     ],
     [
-      `${COMMIT_SEPARATOR}${fakeCommitHash}${`${GIT_LOG_SEPARATOR}HEAD -> main, origin/main, origin/HEAD, tag: v2.0.0`}${fakeAuthorAndCommitter}${fakeCommitMessage}`,
+      FRONT_NEW_LINE +
+        `${fakeCommitHash}
+HEAD -> main, origin/main, origin/HEAD, tag: v2.0.0
+${fakeAuthor}
+${fakeCommitter}
+${fakeCommitMessage}`,
       {
         ...commonExpectatedResult,
         branches: ["HEAD", "main", "origin/main", "origin/HEAD"],
@@ -135,7 +184,12 @@ describe("getCommitRaws", () => {
       },
     ],
     [
-      `${COMMIT_SEPARATOR}${fakeCommitHash}${`${GIT_LOG_SEPARATOR}HEAD, tag: v2.0.0, tag: v1.4`}${fakeAuthorAndCommitter}${fakeCommitMessage}`,
+      FRONT_NEW_LINE +
+        `${fakeCommitHash}
+HEAD, tag: v2.0.0, tag: v1.4
+${fakeAuthor}
+${fakeCommitter}
+${fakeCommitMessage}`,
       {
         ...commonExpectatedResult,
         branches: ["HEAD"],
@@ -143,7 +197,12 @@ describe("getCommitRaws", () => {
       },
     ],
     [
-      `${COMMIT_SEPARATOR}${fakeCommitHash}${GIT_LOG_SEPARATOR}${fakeAuthorAndCommitter}${fakeCommitMessage}`,
+      FRONT_NEW_LINE +
+        `${fakeCommitHash}
+
+${fakeAuthor}
+${fakeCommitter}
+${fakeCommitMessage}`,
       {
         ...commonExpectatedResult,
         branches: [],
@@ -157,7 +216,14 @@ describe("getCommitRaws", () => {
 
   it.each([
     [
-      `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${fakeCommitMessage}\n${"10\t0\ta.ts\n1\t0\tREADME.md"}`,
+      FRONT_NEW_LINE +
+        `${fakeCommitHash}
+${fakeCommitRef}
+${fakeAuthor}
+${fakeCommitter}
+${fakeCommitMessage}
+10\t0\ta.ts
+1\t0\tREADME.md`,
       {
         ...commonExpectatedResult,
         differenceStatistic: {
@@ -171,7 +237,13 @@ describe("getCommitRaws", () => {
       },
     ],
     [
-      `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${fakeCommitMessage}\n${"3\t3\ta.ts"}`,
+      FRONT_NEW_LINE +
+        `${fakeCommitHash}
+${fakeCommitRef}
+${fakeAuthor}
+${fakeCommitter}
+${fakeCommitMessage}
+3\t3\ta.ts`,
       {
         ...commonExpectatedResult,
         differenceStatistic: {
@@ -182,7 +254,13 @@ describe("getCommitRaws", () => {
       },
     ],
     [
-      `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${fakeCommitMessage}\n${"4\t0\ta.ts"}`,
+      FRONT_NEW_LINE +
+        `${fakeCommitHash}
+${fakeCommitRef}
+${fakeAuthor}
+${fakeCommitter}
+${fakeCommitMessage}
+4\t0\ta.ts`,
       {
         ...commonExpectatedResult,
         differenceStatistic: {
@@ -193,7 +271,15 @@ describe("getCommitRaws", () => {
       },
     ],
     [
-      `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${fakeCommitMessage}\n${"0\t6\ta.ts\n2\t0\tb.ts\n3\t3\tc.ts"}`,
+      FRONT_NEW_LINE +
+        `${fakeCommitHash}
+${fakeCommitRef}
+${fakeAuthor}
+${fakeCommitter}
+${fakeCommitMessage}
+0\t6\ta.ts
+2\t0\tb.ts
+3\t3\tc.ts`,
       {
         ...commonExpectatedResult,
         differenceStatistic: {
@@ -213,8 +299,25 @@ describe("getCommitRaws", () => {
   });
 
   it(`should parse gitlog to commitRaw(multiple commits)`, () => {
-    const mockLog = `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${fakeCommitMessage}\n${fakeCommitFileChange}${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${fakeCommitMessage}`;
+    const mockLog =
+      FRONT_NEW_LINE +
+      `${fakeCommitHash}
+${fakeCommitRef}
+${fakeAuthor}
+${fakeCommitter}
+${fakeCommitMessage}
+${fakeCommitFileChange}
+
+
+
+${fakeCommitHash}
+${fakeCommitRef}
+${fakeAuthor}
+${fakeCommitter}
+${fakeCommitMessage}`;
+    console.log(mockLog);
     const result = getCommitRaws(mockLog);
+    console.log(result);
     const expectedResult = [
       { ...commonExpectatedResult, differenceStatistic: expectedFileChange },
       { ...commonExpectatedResult, sequence: 1 },
@@ -225,23 +328,56 @@ describe("getCommitRaws", () => {
 
   it.each([
     [
-      `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${`${GIT_LOG_SEPARATOR}commit message title${GIT_LOG_SEPARATOR}`}`,
+      FRONT_NEW_LINE +
+        `${fakeCommitHash}
+${fakeCommitRef}
+${fakeAuthor}
+${fakeCommitter}
+commit message title
+${COMMIT_MESSAGE_BODY_INDENTATION}`,
       { ...commonExpectatedResult, message: "commit message title" },
     ],
     [
-      `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${`${GIT_LOG_SEPARATOR}commit message title\ncommit message${GIT_LOG_SEPARATOR}`}`,
-      { ...commonExpectatedResult, message: "commit message title\ncommit message" },
+      FRONT_NEW_LINE +
+        `${fakeCommitHash}
+${fakeCommitRef}
+${fakeAuthor}
+${fakeCommitter}
+commit message title
+${COMMIT_MESSAGE_BODY_INDENTATION}commit message body`,
+      { ...commonExpectatedResult, message: "commit message title\ncommit message body" },
     ],
     [
-      `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${`${GIT_LOG_SEPARATOR}commit message title\n\ncommit message body${GIT_LOG_SEPARATOR}`}`,
+      FRONT_NEW_LINE +
+        `${fakeCommitHash}
+${fakeCommitRef}
+${fakeAuthor}
+${fakeCommitter}
+commit message title
+${COMMIT_MESSAGE_BODY_INDENTATION}
+${COMMIT_MESSAGE_BODY_INDENTATION}commit message body`,
       { ...commonExpectatedResult, message: "commit message title\n\ncommit message body" },
     ],
     [
-      `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${`${GIT_LOG_SEPARATOR}commit message title\n\n\ncommit message body${GIT_LOG_SEPARATOR}`}`,
+      FRONT_NEW_LINE +
+        `${fakeCommitHash}
+${fakeCommitRef}
+${fakeAuthor}
+${fakeCommitter}
+commit message title
+${COMMIT_MESSAGE_BODY_INDENTATION}
+${COMMIT_MESSAGE_BODY_INDENTATION}
+${COMMIT_MESSAGE_BODY_INDENTATION}commit message body`,
       { ...commonExpectatedResult, message: "commit message title\n\n\ncommit message body" },
     ],
     [
-      `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${`${GIT_LOG_SEPARATOR}${GIT_LOG_SEPARATOR}`}`,
+      FRONT_NEW_LINE +
+        `${fakeCommitHash}
+${fakeCommitRef}
+${fakeAuthor}
+${fakeCommitter}
+
+${COMMIT_MESSAGE_BODY_INDENTATION}`,
       { ...commonExpectatedResult, message: "" },
     ],
   ])("should parse gitlog to commitRaw(commit message)", (mockLog, expectedResult) => {
@@ -250,7 +386,14 @@ describe("getCommitRaws", () => {
   });
 
   it(`should parse gitlog to commitRaw(commit message body and file change)`, () => {
-    const mockLog = `${COMMIT_SEPARATOR}${fakeCommitHash}${fakeCommitRef}${fakeAuthorAndCommitter}${fakeCommitMessageAndBody}\n${fakeCommitFileChange}`;
+    const mockLog =
+      FRONT_NEW_LINE +
+      `${fakeCommitHash}
+${fakeCommitRef}
+${fakeAuthor}
+${fakeCommitter}
+${fakeCommitMessageAndBody}
+${fakeCommitFileChange}`;
     const result = getCommitRaws(mockLog);
     const expectedResult = {
       ...commonExpectatedResult,

--- a/packages/analysis-engine/src/parser.spec.ts
+++ b/packages/analysis-engine/src/parser.spec.ts
@@ -36,21 +36,13 @@ describe("commit message type", () => {
 
 describe("getCommitRaws", () => {
   const FRONT_NEW_LINE = "\n\n";
-  const COMMIT_MESSAGE_BODY_INDENTATION = "    ";
+  const INDENTATION = "    ";
 
-  const fakeAuthor = `John Park
-mail@gmail.com
-Sun Sep 4 20:17:59 2022 +0900`;
-  const fakeCommitter = `John Park 2
-mail2@gmail.com
-Sun Sep 5 20:17:59 2022 +0900`;
-  const fakeCommitMessage = `commit message
-${COMMIT_MESSAGE_BODY_INDENTATION}`;
-  const fakeCommitMessageAndBody = `commit message title
-
-${COMMIT_MESSAGE_BODY_INDENTATION}commit message body`;
-  const fakeCommitHash = `a
-b`;
+  const fakeAuthor = "John Park\nmail@gmail.com\nSun Sep 4 20:17:59 2022 +0900";
+  const fakeCommitter = `John Park 2\nmail2@gmail.com\nSun Sep 5 20:17:59 2022 +0900`;
+  const fakeCommitMessage = `commit message\n${INDENTATION}`;
+  const fakeCommitMessageAndBody = `commit message title\n${INDENTATION}\n${INDENTATION}commit message body`;
+  const fakeCommitHash = "a\nb";
   const fakeCommitRef = "HEAD";
   const fakeCommitFileChange = "10\t0\ta.ts\n1\t0\tREADME.md";
 
@@ -84,13 +76,7 @@ b`;
 
   it.each([
     [
-      FRONT_NEW_LINE +
-        `a
-
-${fakeCommitRef}
-${fakeAuthor}
-${fakeCommitter}
-${fakeCommitMessage}`,
+      `${FRONT_NEW_LINE}${"a\n"}\n${fakeCommitRef}\n${fakeAuthor}\n${fakeCommitter}\n${fakeCommitMessage}`,
       {
         ...commonExpectatedResult,
         id: "a",
@@ -98,27 +84,15 @@ ${fakeCommitMessage}`,
       },
     ],
     [
-      FRONT_NEW_LINE +
-        `c
-b
-${fakeCommitRef}
-${fakeAuthor}
-${fakeCommitter}
-${fakeCommitMessage}`,
+      `${FRONT_NEW_LINE}${"c\nd"}\n${fakeCommitRef}\n${fakeAuthor}\n${fakeCommitter}\n${fakeCommitMessage}`,
       {
         ...commonExpectatedResult,
         id: "c",
-        parents: ["b"],
+        parents: ["d"],
       },
     ],
     [
-      FRONT_NEW_LINE +
-        `d
-e f
-${fakeCommitRef}
-${fakeAuthor}
-${fakeCommitter}
-${fakeCommitMessage}`,
+      `${FRONT_NEW_LINE}${"d\ne f"}\n${fakeCommitRef}\n${fakeAuthor}\n${fakeCommitter}\n${fakeCommitMessage}`,
       {
         ...commonExpectatedResult,
         id: "d",
@@ -132,12 +106,7 @@ ${fakeCommitMessage}`,
 
   it.each([
     [
-      FRONT_NEW_LINE +
-        `${fakeCommitHash}
-HEAD
-${fakeAuthor}
-${fakeCommitter}
-${fakeCommitMessage}`,
+      `${FRONT_NEW_LINE}${fakeCommitHash}\n${"HEAD"}\n${fakeAuthor}\n${fakeCommitter}\n${fakeCommitMessage}`,
       {
         ...commonExpectatedResult,
         branches: ["HEAD"],
@@ -145,12 +114,7 @@ ${fakeCommitMessage}`,
       },
     ],
     [
-      FRONT_NEW_LINE +
-        `${fakeCommitHash}
-HEAD -> main, origin/main, origin/HEAD
-${fakeAuthor}
-${fakeCommitter}
-${fakeCommitMessage}`,
+      `${FRONT_NEW_LINE}${fakeCommitHash}\n${"HEAD -> main, origin/main, origin/HEAD"}\n${fakeAuthor}\n${fakeCommitter}\n${fakeCommitMessage}`,
       {
         ...commonExpectatedResult,
         branches: ["HEAD", "main", "origin/main", "origin/HEAD"],
@@ -158,12 +122,7 @@ ${fakeCommitMessage}`,
       },
     ],
     [
-      FRONT_NEW_LINE +
-        `${fakeCommitHash}
-HEAD, tag: v1.0.0
-${fakeAuthor}
-${fakeCommitter}
-${fakeCommitMessage}`,
+      `${FRONT_NEW_LINE}${fakeCommitHash}\n${"HEAD, tag: v1.0.0"}\n${fakeAuthor}\n${fakeCommitter}$\n${fakeCommitMessage}`,
       {
         ...commonExpectatedResult,
         branches: ["HEAD"],
@@ -171,12 +130,7 @@ ${fakeCommitMessage}`,
       },
     ],
     [
-      FRONT_NEW_LINE +
-        `${fakeCommitHash}
-HEAD -> main, origin/main, origin/HEAD, tag: v2.0.0
-${fakeAuthor}
-${fakeCommitter}
-${fakeCommitMessage}`,
+      `${FRONT_NEW_LINE}${fakeCommitHash}\n${"HEAD -> main, origin/main, origin/HEAD, tag: v2.0.0"}\n${fakeAuthor}\n${fakeCommitter}\n${fakeCommitMessage}`,
       {
         ...commonExpectatedResult,
         branches: ["HEAD", "main", "origin/main", "origin/HEAD"],
@@ -184,12 +138,7 @@ ${fakeCommitMessage}`,
       },
     ],
     [
-      FRONT_NEW_LINE +
-        `${fakeCommitHash}
-HEAD, tag: v2.0.0, tag: v1.4
-${fakeAuthor}
-${fakeCommitter}
-${fakeCommitMessage}`,
+      `${FRONT_NEW_LINE}${fakeCommitHash}\n${"HEAD, tag: v2.0.0, tag: v1.4"}\n${fakeAuthor}\n${fakeCommitter}\n${fakeCommitMessage}`,
       {
         ...commonExpectatedResult,
         branches: ["HEAD"],
@@ -197,12 +146,7 @@ ${fakeCommitMessage}`,
       },
     ],
     [
-      FRONT_NEW_LINE +
-        `${fakeCommitHash}
-
-${fakeAuthor}
-${fakeCommitter}
-${fakeCommitMessage}`,
+      `${FRONT_NEW_LINE}${fakeCommitHash}\n${""}\n${fakeAuthor}\n${fakeCommitter}\n${fakeCommitMessage}`,
       {
         ...commonExpectatedResult,
         branches: [],
@@ -216,14 +160,7 @@ ${fakeCommitMessage}`,
 
   it.each([
     [
-      FRONT_NEW_LINE +
-        `${fakeCommitHash}
-${fakeCommitRef}
-${fakeAuthor}
-${fakeCommitter}
-${fakeCommitMessage}
-10\t0\ta.ts
-1\t0\tREADME.md`,
+      `${FRONT_NEW_LINE}${fakeCommitHash}\n${fakeCommitRef}\n${fakeAuthor}\n${fakeCommitter}\n${fakeCommitMessage}\n${"10\t0\ta.ts\n1\t0\tREADME.md"}`,
       {
         ...commonExpectatedResult,
         differenceStatistic: {
@@ -237,13 +174,7 @@ ${fakeCommitMessage}
       },
     ],
     [
-      FRONT_NEW_LINE +
-        `${fakeCommitHash}
-${fakeCommitRef}
-${fakeAuthor}
-${fakeCommitter}
-${fakeCommitMessage}
-3\t3\ta.ts`,
+      `${FRONT_NEW_LINE}${fakeCommitHash}\n${fakeCommitRef}\n${fakeAuthor}\n${fakeCommitter}\n${fakeCommitMessage}\n${"3\t3\ta.ts"}`,
       {
         ...commonExpectatedResult,
         differenceStatistic: {
@@ -254,13 +185,7 @@ ${fakeCommitMessage}
       },
     ],
     [
-      FRONT_NEW_LINE +
-        `${fakeCommitHash}
-${fakeCommitRef}
-${fakeAuthor}
-${fakeCommitter}
-${fakeCommitMessage}
-4\t0\ta.ts`,
+      `${FRONT_NEW_LINE}${fakeCommitHash}\n${fakeCommitRef}\n${fakeAuthor}\n${fakeCommitter}\n${fakeCommitMessage}\n${"4\t0\ta.ts"}`,
       {
         ...commonExpectatedResult,
         differenceStatistic: {
@@ -271,15 +196,7 @@ ${fakeCommitMessage}
       },
     ],
     [
-      FRONT_NEW_LINE +
-        `${fakeCommitHash}
-${fakeCommitRef}
-${fakeAuthor}
-${fakeCommitter}
-${fakeCommitMessage}
-0\t6\ta.ts
-2\t0\tb.ts
-3\t3\tc.ts`,
+      `${FRONT_NEW_LINE}${fakeCommitHash}\n${fakeCommitRef}\n${fakeAuthor}\n${fakeCommitter}\n${fakeCommitMessage}\n${"0\t6\ta.ts\n2\t0\tb.ts\n3\t3\tc.ts"}`,
       {
         ...commonExpectatedResult,
         differenceStatistic: {
@@ -299,25 +216,8 @@ ${fakeCommitMessage}
   });
 
   it(`should parse gitlog to commitRaw(multiple commits)`, () => {
-    const mockLog =
-      FRONT_NEW_LINE +
-      `${fakeCommitHash}
-${fakeCommitRef}
-${fakeAuthor}
-${fakeCommitter}
-${fakeCommitMessage}
-${fakeCommitFileChange}
-
-
-
-${fakeCommitHash}
-${fakeCommitRef}
-${fakeAuthor}
-${fakeCommitter}
-${fakeCommitMessage}`;
-    console.log(mockLog);
+    const mockLog = `${FRONT_NEW_LINE}${fakeCommitHash}\n${fakeCommitRef}\n${fakeAuthor}\n${fakeCommitter}\n${fakeCommitMessage}\n${fakeCommitFileChange}\n\n\n\n${fakeCommitHash}\n${fakeCommitRef}\n${fakeAuthor}\n${fakeCommitter}\n${fakeCommitMessage}`;
     const result = getCommitRaws(mockLog);
-    console.log(result);
     const expectedResult = [
       { ...commonExpectatedResult, differenceStatistic: expectedFileChange },
       { ...commonExpectatedResult, sequence: 1 },
@@ -328,56 +228,23 @@ ${fakeCommitMessage}`;
 
   it.each([
     [
-      FRONT_NEW_LINE +
-        `${fakeCommitHash}
-${fakeCommitRef}
-${fakeAuthor}
-${fakeCommitter}
-commit message title
-${COMMIT_MESSAGE_BODY_INDENTATION}`,
+      `${FRONT_NEW_LINE}${fakeCommitHash}\n${fakeCommitRef}\n${fakeAuthor}\n${fakeCommitter}\n${"commit message title"}\n${INDENTATION}`,
       { ...commonExpectatedResult, message: "commit message title" },
     ],
     [
-      FRONT_NEW_LINE +
-        `${fakeCommitHash}
-${fakeCommitRef}
-${fakeAuthor}
-${fakeCommitter}
-commit message title
-${COMMIT_MESSAGE_BODY_INDENTATION}commit message body`,
+      `${FRONT_NEW_LINE}${fakeCommitHash}\n${fakeCommitRef}\n${fakeAuthor}\n${fakeCommitter}\n${"commit message title"}\n${INDENTATION}${"commit message body"}`,
       { ...commonExpectatedResult, message: "commit message title\ncommit message body" },
     ],
     [
-      FRONT_NEW_LINE +
-        `${fakeCommitHash}
-${fakeCommitRef}
-${fakeAuthor}
-${fakeCommitter}
-commit message title
-${COMMIT_MESSAGE_BODY_INDENTATION}
-${COMMIT_MESSAGE_BODY_INDENTATION}commit message body`,
+      `${FRONT_NEW_LINE}${fakeCommitHash}\n${fakeCommitRef}\n${fakeAuthor}\n${fakeCommitter}\n${"commit message title"}\n${INDENTATION}\n${INDENTATION}${"commit message body"}`,
       { ...commonExpectatedResult, message: "commit message title\n\ncommit message body" },
     ],
     [
-      FRONT_NEW_LINE +
-        `${fakeCommitHash}
-${fakeCommitRef}
-${fakeAuthor}
-${fakeCommitter}
-commit message title
-${COMMIT_MESSAGE_BODY_INDENTATION}
-${COMMIT_MESSAGE_BODY_INDENTATION}
-${COMMIT_MESSAGE_BODY_INDENTATION}commit message body`,
+      `${FRONT_NEW_LINE}${fakeCommitHash}\n${fakeCommitRef}\n${fakeAuthor}\n${fakeCommitter}\n${"commit message title"}\n${INDENTATION}\n${INDENTATION}\n${INDENTATION}${"commit message body"}`,
       { ...commonExpectatedResult, message: "commit message title\n\n\ncommit message body" },
     ],
     [
-      FRONT_NEW_LINE +
-        `${fakeCommitHash}
-${fakeCommitRef}
-${fakeAuthor}
-${fakeCommitter}
-
-${COMMIT_MESSAGE_BODY_INDENTATION}`,
+      `${FRONT_NEW_LINE}${fakeCommitHash}\n${fakeCommitRef}\n${fakeAuthor}\n${fakeCommitter}\n\n${INDENTATION}`,
       { ...commonExpectatedResult, message: "" },
     ],
   ])("should parse gitlog to commitRaw(commit message)", (mockLog, expectedResult) => {
@@ -386,14 +253,7 @@ ${COMMIT_MESSAGE_BODY_INDENTATION}`,
   });
 
   it(`should parse gitlog to commitRaw(commit message body and file change)`, () => {
-    const mockLog =
-      FRONT_NEW_LINE +
-      `${fakeCommitHash}
-${fakeCommitRef}
-${fakeAuthor}
-${fakeCommitter}
-${fakeCommitMessageAndBody}
-${fakeCommitFileChange}`;
+    const mockLog = `${FRONT_NEW_LINE}${fakeCommitHash}\n${fakeCommitRef}\n${fakeAuthor}\n${fakeCommitter}\n${fakeCommitMessageAndBody}\n${fakeCommitFileChange}`;
     const result = getCommitRaws(mockLog);
     const expectedResult = {
       ...commonExpectatedResult,

--- a/packages/analysis-engine/src/parser.ts
+++ b/packages/analysis-engine/src/parser.ts
@@ -3,7 +3,6 @@ import type { CommitRaw, DifferenceStatistic } from "./types";
 
 export default function getCommitRaws(log: string) {
   if (!log) return [];
-  console.log(log);
   const EOL_REGEX = /\r?\n/;
   const COMMIT_SEPARATOR = new RegExp(`${EOL_REGEX.source}{4}`);
   const COMMIT_MESSAGE_BODY_INDENTATION = "    ";
@@ -11,10 +10,6 @@ export default function getCommitRaws(log: string) {
   // step 0: Split log into commits
   const commits = log.substring(2).split(COMMIT_SEPARATOR);
   const commitRaws: CommitRaw[] = [];
-  console.log("length: ", commits.length);
-  console.log(commits[0]);
-  console.log("-----------------");
-  console.log(commits[commits.length - 1]);
   for (let commitIdx = 0; commitIdx < commits.length; commitIdx += 1) {
     // step 1: Extract commitData
     const commitData = commits[commitIdx].split(EOL_REGEX);

--- a/packages/analysis-engine/src/parser.ts
+++ b/packages/analysis-engine/src/parser.ts
@@ -5,7 +5,7 @@ export default function getCommitRaws(log: string) {
   if (!log) return [];
   const EOL_REGEX = /\r?\n/;
   const COMMIT_SEPARATOR = new RegExp(`${EOL_REGEX.source}{4}`);
-  const COMMIT_MESSAGE_BODY_INDENTATION = "    ";
+  const INDENTATION = "    ";
 
   // step 0: Split log into commits
   const commits = log.substring(2).split(COMMIT_SEPARATOR);
@@ -53,7 +53,7 @@ export default function getCommitRaws(log: string) {
       if (idx === 0)
         // message subject
         messageSubject = line;
-      else if (line.startsWith(COMMIT_MESSAGE_BODY_INDENTATION)) {
+      else if (line.startsWith(INDENTATION)) {
         // message body (add newline if not first line)
         messageBody += idx === 1 ? line.trim() : `\n${line.trim()}`;
       } else if (line === "")

--- a/packages/analysis-engine/src/parser.ts
+++ b/packages/analysis-engine/src/parser.ts
@@ -83,7 +83,7 @@ export default function getCommitRaws(log: string) {
     const commitRaw: CommitRaw = {
       sequence: commitIdx,
       id,
-      parents: parents.split(" "),
+      parents: parents.length === 0 ? [] : parents.split(" "),
       branches,
       tags,
       author: {

--- a/packages/analysis-engine/src/parser.ts
+++ b/packages/analysis-engine/src/parser.ts
@@ -1,18 +1,23 @@
 import { getCommitMessageType } from "./commit.util";
-import { COMMIT_SEPARATOR, GIT_LOG_SEPARATOR } from "./constant";
-import type { CommitRaw } from "./types";
+import type { CommitRaw, DifferenceStatistic } from "./types";
 
 export default function getCommitRaws(log: string) {
   if (!log) return [];
+  console.log(log);
   const EOL_REGEX = /\r?\n/;
+  const COMMIT_SEPARATOR = new RegExp(`${EOL_REGEX.source}{4}`);
+  const COMMIT_MESSAGE_BODY_INDENTATION = "    ";
 
   // step 0: Split log into commits
-  const commits = log.split(COMMIT_SEPARATOR);
+  const commits = log.substring(2).split(COMMIT_SEPARATOR);
   const commitRaws: CommitRaw[] = [];
-  // skip the first empty element
-  for (let commitIdx = 1; commitIdx < commits.length; commitIdx += 1) {
-    // step 1: Extract commitData from the first line of the commit
-    const commitData = commits[commitIdx].split(GIT_LOG_SEPARATOR);
+  console.log("length: ", commits.length);
+  console.log(commits[0]);
+  console.log("-----------------");
+  console.log(commits[commits.length - 1]);
+  for (let commitIdx = 0; commitIdx < commits.length; commitIdx += 1) {
+    // step 1: Extract commitData
+    const commitData = commits[commitIdx].split(EOL_REGEX);
     const [
       id,
       parents,
@@ -23,10 +28,9 @@ export default function getCommitRaws(log: string) {
       committerName,
       committerEmail,
       committerDate,
-      message,
-      diffStats,
+      ...messageAndDiffStats
     ] = commitData;
-    // Extract branch and tag data from refs
+    // step 2: Extract branch and tag data from refs
     const refsArray = refs.replace(" -> ", ", ").split(", ");
     const [branches, tags]: string[][] = refsArray.reduce(
       ([branches, tags], ref) => {
@@ -41,7 +45,41 @@ export default function getCommitRaws(log: string) {
       [new Array<string>(), new Array<string>()]
     );
 
-    // make base commitRaw object
+    // step 3: Extract message and diffStats
+    let messageAndDiffStatsIdx = 0;
+    let message = "";
+    const diffStats: DifferenceStatistic = {
+      totalInsertionCount: 0,
+      totalDeletionCount: 0,
+      fileDictionary: {},
+    };
+    // Extract message
+    while (messageAndDiffStatsIdx < messageAndDiffStats.length && messageAndDiffStats[messageAndDiffStatsIdx] !== "") {
+      const line = messageAndDiffStats[messageAndDiffStatsIdx];
+      if (line.startsWith(COMMIT_MESSAGE_BODY_INDENTATION)) message += "\n" + line.trim();
+      else message += line;
+      messageAndDiffStatsIdx++;
+    }
+    // Extract diffStats
+    while (messageAndDiffStatsIdx < messageAndDiffStats.length) {
+      const line = messageAndDiffStats[messageAndDiffStatsIdx];
+      if (line === "") {
+        messageAndDiffStatsIdx++;
+        continue;
+      }
+      const [insertions, deletions, path] = line.split("\t");
+      const numberedInsertions = insertions === "-" ? 0 : Number(insertions);
+      const numberedDeletions = deletions === "-" ? 0 : Number(deletions);
+      diffStats.totalInsertionCount += numberedInsertions;
+      diffStats.totalDeletionCount += numberedDeletions;
+      diffStats.fileDictionary[path] = {
+        insertionCount: numberedInsertions,
+        deletionCount: numberedDeletions,
+      };
+      messageAndDiffStatsIdx++;
+    }
+
+    // step 4: Construct commitRaw
     const commitRaw: CommitRaw = {
       sequence: commitIdx - 1,
       id,
@@ -60,32 +98,8 @@ export default function getCommitRaws(log: string) {
       committerDate: new Date(committerDate),
       message,
       commitMessageType: getCommitMessageType(message),
-      differenceStatistic: {
-        totalInsertionCount: 0,
-        totalDeletionCount: 0,
-        fileDictionary: {},
-      },
+      differenceStatistic: diffStats,
     };
-
-    // step 2: Extract diffStats from the rest of the commit
-    if (!diffStats) {
-      commitRaws.push(commitRaw);
-      continue;
-    }
-    const diffStatsArray = diffStats.split(EOL_REGEX);
-    // pass the first empty element
-    for (let diffIdx = 1; diffIdx < diffStatsArray.length; diffIdx += 1) {
-      if (diffStatsArray[diffIdx] === "") continue;
-      const [insertions, deletions, path] = diffStatsArray[diffIdx].split("\t");
-      const numberedInsertions = insertions === "-" ? 0 : Number(insertions);
-      const numberedDeletions = deletions === "-" ? 0 : Number(deletions);
-      commitRaw.differenceStatistic.totalInsertionCount += numberedInsertions;
-      commitRaw.differenceStatistic.totalDeletionCount += numberedDeletions;
-      commitRaw.differenceStatistic.fileDictionary[path] = {
-        insertionCount: numberedInsertions,
-        deletionCount: numberedDeletions,
-      };
-    }
     commitRaws.push(commitRaw);
   }
 

--- a/packages/analysis-engine/src/parser.ts
+++ b/packages/analysis-engine/src/parser.ts
@@ -81,7 +81,7 @@ export default function getCommitRaws(log: string) {
 
     // step 4: Construct commitRaw
     const commitRaw: CommitRaw = {
-      sequence: commitIdx - 1,
+      sequence: commitIdx,
       id,
       parents: parents.split(" "),
       branches,

--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -154,8 +154,6 @@ export async function getGitExecutableFromPaths(paths: string[]): Promise<GitExe
 
 export async function getGitLog(gitPath: string, currentWorkspacePath: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    const GIT_LOG_SEPARATOR = "%n"; // newline
-
     const gitLogFormat =
       "%n%n" +
       [
@@ -170,7 +168,7 @@ export async function getGitLog(gitPath: string, currentWorkspacePath: string): 
         "%cd", // committer date
         "%w(0,0,4)%s", // commit message subject
         "%b", // commit message body
-      ].join(GIT_LOG_SEPARATOR);
+      ].join("%n");
     const args = [
       "--no-pager",
       "log",

--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -155,8 +155,10 @@ export async function getGitExecutableFromPaths(paths: string[]): Promise<GitExe
 
 export async function getGitLog(gitPath: string, currentWorkspacePath: string): Promise<string> {
   return new Promise((resolve, reject) => {
+    const GIT_LOG_SEPARATOR = "%n"; // newline
+
     const gitLogFormat =
-      COMMIT_SEPARATOR +
+      "%n%n" +
       [
         "%H", // commit hash (id)
         "%P", // parent hashes
@@ -164,12 +166,13 @@ export async function getGitLog(gitPath: string, currentWorkspacePath: string): 
         "%an", // author name
         "%ae", // author email
         "%ad", // author date
-        "%cn",
-        "%ce",
-        "%cd", // committer name, committer email and committer date
-        "%B", // commit message  (subject and body)
-      ].join(GIT_LOG_SEPARATOR) +
-      GIT_LOG_SEPARATOR;
+        "%cn", // committer name
+        "%ce", // committer email
+        "%cd", // committer date
+        "%w(0,0,4)%s", // commit message subject
+        "%b", // commit message body
+      ].join(GIT_LOG_SEPARATOR);
+    console.log("gitLogFormat: ", gitLogFormat);
     const args = [
       "--no-pager",
       "log",

--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -171,7 +171,6 @@ export async function getGitLog(gitPath: string, currentWorkspacePath: string): 
         "%w(0,0,4)%s", // commit message subject
         "%b", // commit message body
       ].join(GIT_LOG_SEPARATOR);
-    console.log("gitLogFormat: ", gitLogFormat);
     const args = [
       "--no-pager",
       "log",

--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -1,4 +1,3 @@
-import { COMMIT_SEPARATOR, GIT_LOG_SEPARATOR } from "@githru-vscode-ext/analysis-engine";
 import * as cp from "child_process";
 import * as fs from "fs";
 import * as path from "path";


### PR DESCRIPTION
## Related issue

- closes #759

## Result

### AS-IS

`COMMIT_SEPARATOR`와 `GIT_LOG_SEPARATOR`를 난수 문자열로 사용

git log format

```
<COMMIT_SEPARATOR><commit hash><GIT_LOG_SEPARATOR><parent hashes><GIT_LOG_SEPARATOR><refs(branches, tags><GIT_LOG_SEPARATOR><author name><GIT_LOG_SEPARATOR><author email><GIT_LOG_SEPARATOR><author date><GIT_LOG_SEPARATOR><committer name><GIT_LOG_SEPARATOR><committer email><GIT_LOG_SEPARATOR><committer date><GIT_LOG_SEPARATOR><commit message><GIT_LOG_SEPARATOR>
<diffstat>
```

format example

```
4itc2s8hH-oA64s08h19ofyms0k2vdw7l3yjed2xwranqa0bx0oyeji6ult2I9M-0XOzvHlYPegVPpzbuiugrjiony42hzos0x8rz6aopsx3euzp6sxxthncI9M-0XOzvHlYPegVPpzbHEAD -> mainI9M-0XOzvHlYPegVPpzbJohn ParkI9M-0XOzvHlYPegVPpzbmail@gmail.comI9M-0XOzvHlYPegVPpzbSun Sep 4 20:17:59 2022 +0900I9M-0XOzvHlYPegVPpzbJohn Park 2I9M-0XOzvHlYPegVPpzbmail2@gmail.comI9M-0XOzvHlYPegVPpzbSun Sep 5 20:17:59 2022 +0900I9M-0XOzvHlYPegVPpzbcommit message title
commit message bodyI9M-0XOzvHlYPegVPpzb
1	0	a.ts
```

### TO-BE

- commit separator: `\n` 4개 (`--numstat` 옵션에서 기본적으로 적용되는 `\n` 2개 + 직접 지정한 `\n` 2개)
- git log separator: `\n`

git log format

```

<commit hash>
<parent hashes>
<refs(branches, tags>
<author name>
<author email>
<author date>
<committer name>
<committer email>
<committer date>
<commit message subject>
<commit message body>
<diffstat>


```

format example

```


ofyms0k2vdw7l3yjed2xwranqa0bx0oyeji6ult2
uiugrjiony42hzos0x8rz6aopsx3euzp6sxxthnc
HEAD -> main
John Park
mail@gmail.com
Sun Sep 4 20:17:59 2022 +0900
John Park 2
mail2@gmail.com
Sun Sep 5 20:17:59 2022 +0900
commit message title
    commit message body
1	0	a.ts


```

test result

<img src="https://github.com/user-attachments/assets/b8a9b1a7-5535-47af-aab5-e9c7c4976fba" alt="Screen_Shot 2024-10-15 20 48 14" width="50%" />

## Work list

- commit을 구분하는 separator를 난수에서 "\n"의 조합으로 변경했습니다.
  - commit separator: `\n` 4개 (`--numstat` 옵션에서 기본적으로 적용되는 `\n` 2개 + 직접 지정한 `\n` 2개)
  - git log separator: `\n`
- commit message 데이터를 subject와 body로 분리하고, body 앞에 space(" ") 4개의 indentation을 두었습니다.
- 변경된 format에 맞게 TC를 수정했습니다.

## Discussion
