### PR TITLE
[vscode] Azure DevOps URL 파싱 지원 및 getRepo 함수 개선

### DIFF
--- a/packages/view/src/boot/raw.csv
+++ b/packages/view/src/boot/raw.csv
@@ -1,8 +1,0 @@
-source,target,value
-ytaek,core,2
-Frodo,vibe,3
-Frodo,newviz,1
-Barry,vibe,2
-cafe3,core,4
-cafe3,vibe,2
-michael,newviz,3

--- a/packages/view/src/boot/raw.csv
+++ b/packages/view/src/boot/raw.csv
@@ -1,0 +1,8 @@
+source,target,value
+ytaek,core,2
+Frodo,vibe,3
+Frodo,newviz,1
+Barry,vibe,2
+cafe3,core,4
+cafe3,vibe,2
+michael,newviz,3

--- a/packages/vscode/src/test/utils/getRepo.spec.ts
+++ b/packages/vscode/src/test/utils/getRepo.spec.ts
@@ -1,0 +1,121 @@
+import { getRepo } from "../../utils/git.util";
+
+describe("getRepo", () => {
+  describe("Valid Git URL formats", () => {
+    it("HTTPS URL with .git extension should parse correctly", () => {
+      const url = "https://github.com/owner/repo.git";
+      const result = getRepo(url);
+
+      expect(result).toEqual({
+        owner: "owner",
+        repo: "repo",
+      });
+    });
+
+    it("SSH URL with .git extension should parse correctly", () => {
+      const url = "git@github.com:owner/repo.git";
+      const result = getRepo(url);
+
+      expect(result).toEqual({
+        owner: "owner",
+        repo: "repo",
+      });
+    });
+
+    it("HTTPS URL without .git extension should parse correctly", () => {
+      const url = "https://github.com/owner/repo";
+      const result = getRepo(url);
+
+      expect(result).toEqual({
+        owner: "owner",
+        repo: "repo",
+      });
+    });
+
+    it("SSH URL without .git extension should parse correctly", () => {
+      const url = "git@github.com:owner/repo";
+      const result = getRepo(url);
+
+      expect(result).toEqual({
+        owner: "owner",
+        repo: "repo",
+      });
+    });
+
+    it("HTTPS URL with username should parse correctly", () => {
+      const url = "https://username@github.com/owner/repo.git";
+      const result = getRepo(url);
+
+      expect(result).toEqual({
+        owner: "owner",
+        repo: "repo",
+      });
+    });
+
+    it("URL with trailing slash should parse correctly", () => {
+      const url = "https://github.com/owner/repo/";
+      const result = getRepo(url);
+
+      expect(result).toEqual({
+        owner: "owner",
+        repo: "repo",
+      });
+    });
+
+    it("Complex repo name with hyphens should parse correctly", () => {
+      const url = "https://github.com/githru/githru-vscode-ext.git";
+      const result = getRepo(url);
+
+      expect(result).toEqual({
+        owner: "githru",
+        repo: "githru-vscode-ext",
+      });
+    });
+
+    it("Azure DevOps URL should parse correctly", () => {
+      const url = "https://organization@dev.azure.com/organization/organization-sub-name/_git/repository-name";
+      const result = getRepo(url);
+
+      expect(result).toEqual({
+        owner: "organization",
+        repo: "repository-name",
+      });
+    });
+
+    it("Azure DevOps URL without username should parse correctly", () => {
+      const url = "https://dev.azure.com/organization/organization-sub-name/_git/repository-name";
+      const result = getRepo(url);
+
+      expect(result).toEqual({
+        owner: "organization",
+        repo: "repository-name",
+      });
+    });
+  });
+
+  describe("Invalid Git URL formats", () => {
+    it("should throw error for invalid URL format", () => {
+      const invalidUrl = "invalid-url-format";
+
+      expect(() => getRepo(invalidUrl)).toThrow(
+        'Invalid Git remote config format: "invalid-url-format". Expected format: [https?://|git@]github.com/owner/repo[.git] or https://organization@dev.azure.com/organization/project/_git/repository-name'
+      );
+    });
+
+    it("should throw error for non-GitHub URL", () => {
+      const nonGithubUrl = "https://gitlab.com/owner/repo.git";
+
+      expect(() => getRepo(nonGithubUrl)).toThrow(
+        'Invalid Git remote config format: "https://gitlab.com/owner/repo.git". Expected format: [https?://|git@]github.com/owner/repo[.git] or https://organization@dev.azure.com/organization/project/_git/repository-name'
+      );
+    });
+
+    it("should throw error for URL without owner/repo", () => {
+      const incompleteUrl = "https://github.com/";
+
+      expect(() => getRepo(incompleteUrl)).toThrow(
+        'Invalid Git remote config format: "https://github.com/". Expected format: [https?://|git@]github.com/owner/repo[.git] or https://organization@dev.azure.com/organization/project/_git/repository-name'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Related issue
Closes #798 

## Result
Azure DevOps URL 파싱 케이스 추가 및 getRepo 함수를 개선하였습니다.

## Work list

#### 🔧 기능 개선: Azure DevOps URL 파싱 지원

기존 문제: getRepo 함수가 GitHub URL만 지원하여 Azure DevOps 저장소에서 오류 발생
해결 방안: Azure DevOps URL 패턴을 지원하도록 정규식 패턴 추가
지원 URL 형식:
https://organization@dev.azure.com/organization/project/_git/repository-name
https://dev.azure.com/organization/project/_git/repository-name

#### 🧪 테스트 코드 추가
새 파일: src/test/utils/getRepo.spec.ts
테스트 범위:
GitHub URL 다양한 형식 검증 (HTTPS/SSH, .git 확장자 유무, 사용자명 포함 등)
Azure DevOps URL 형식 검증
잘못된 URL 형식에 대한 에러 처리 검증

## Discussion

Azure DevOps 사용자들의 요청에 따라 URL 파싱 지원을 추가했습니다. 기존 GitHub URL 파싱 기능은 그대로 유지하면서 Azure DevOps URL 패턴을 추가로 지원하도록 구현했습니다.

특히 다음 부분들을 중점적으로 검토해주시면 좋겠습니다:

1. Azure DevOps URL 정규식 패턴이 올바른지
2. 에러 메시지가 사용자에게 충분히 명확한지
3. 테스트 케이스가 모든 시나리오를 커버하는지