### PR TITLE
[view] refactor(theme): window.theme 제거 및 zustand + persist 기반 상태관리 적용

### DIFF
--- a/packages/view/public/index.html
+++ b/packages/view/public/index.html
@@ -8,7 +8,6 @@
     />
     <script>
       window.isProduction = false;
-      window.theme = "githru";
     </script>
     <title>Githru</title>
   </head>

--- a/packages/view/src/App.tsx
+++ b/packages/view/src/App.tsx
@@ -10,7 +10,7 @@ import type IDEPort from "ide/IDEPort";
 import { useAnalayzedData } from "hooks";
 import { RefreshButton } from "components/RefreshButton";
 import type { IDESentEvents } from "types/IDESentEvents";
-import { useBranchStore, useDataStore, useGithubInfo, useLoadingStore } from "store";
+import { useBranchStore, useDataStore, useGithubInfo, useLoadingStore, useThemeStore } from "store";
 import { THEME_INFO } from "components/ThemeSelector/ThemeSelector.const";
 
 const App = () => {
@@ -20,6 +20,7 @@ const App = () => {
   const { handleChangeBranchList } = useBranchStore();
   const { handleGithubInfo } = useGithubInfo();
   const { loading, setLoading } = useLoadingStore();
+  const { theme } = useThemeStore();
   const ideAdapter = container.resolve<IDEPort>("IDEAdapter");
 
   useEffect(() => {
@@ -41,7 +42,7 @@ const App = () => {
   if (loading) {
     return (
       <BounceLoader
-        color={THEME_INFO[window.theme as keyof typeof THEME_INFO].colors.primary}
+        color={THEME_INFO[theme as keyof typeof THEME_INFO].colors.primary}
         loading={loading}
         cssOverride={{
           position: "fixed",

--- a/packages/view/src/components/ThemeSelector/ThemeSelector.tsx
+++ b/packages/view/src/components/ThemeSelector/ThemeSelector.tsx
@@ -7,15 +7,17 @@ import { sendUpdateThemeCommand } from "services";
 
 import { THEME_INFO } from "./ThemeSelector.const";
 import type { ThemeInfo } from "./ThemeSelector.type";
+import { useThemeStore } from "store/theme";
 
 type ThemeIconsProps = ThemeInfo[keyof ThemeInfo] & {
+  theme: string;
   onClick: () => void;
 };
 
-const ThemeIcons = ({ title, value, colors, onClick }: ThemeIconsProps) => {
+const ThemeIcons = ({ title, value, colors, theme, onClick }: ThemeIconsProps) => {
   return (
     <div
-      className={`theme-icon${window.theme === value ? "--selected" : ""}`}
+      className={`theme-icon${theme === value ? "--selected" : ""}`}
       onClick={onClick}
       role="presentation"
     >
@@ -34,12 +36,14 @@ const ThemeIcons = ({ title, value, colors, onClick }: ThemeIconsProps) => {
 };
 
 const ThemeSelector = () => {
-  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const { theme, setTheme } = useThemeStore();
+
   const themeSelectorRef = useRef<HTMLDivElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
 
   const handleTheme = (value: string) => {
+    setTheme(value);
     sendUpdateThemeCommand(value);
-    window.theme = value;
     document.documentElement.setAttribute("theme", value);
   };
 
@@ -56,8 +60,8 @@ const ThemeSelector = () => {
   }, []);
 
   useEffect(() => {
-    document.documentElement.setAttribute("theme", window.theme);
-  }, []);
+    document.documentElement.setAttribute("theme", theme);
+  }, [theme]);
 
   return (
     <div
@@ -75,12 +79,13 @@ const ThemeSelector = () => {
             />
           </div>
           <div className="theme-selector__list">
-            {Object.entries(THEME_INFO).map(([_, theme]) => (
+            {Object.entries(THEME_INFO).map(([_, themeInfo]) => (
               <ThemeIcons
-                key={theme.value}
-                {...theme}
+                key={themeInfo.value}
+                {...themeInfo}
+                theme={theme}
                 onClick={() => {
-                  handleTheme(theme.value);
+                  handleTheme(themeInfo.value);
                   setIsOpen(false);
                 }}
               />

--- a/packages/view/src/components/ThemeSelector/ThemeSelector.tsx
+++ b/packages/view/src/components/ThemeSelector/ThemeSelector.tsx
@@ -36,10 +36,11 @@ const ThemeIcons = ({ title, value, colors, theme, onClick }: ThemeIconsProps) =
 };
 
 const ThemeSelector = () => {
-  const { theme, setTheme } = useThemeStore();
+  const [isOpen, setIsOpen] = useState(false);
 
   const themeSelectorRef = useRef<HTMLDivElement>(null);
-  const [isOpen, setIsOpen] = useState(false);
+
+  const { theme, setTheme } = useThemeStore();
 
   const handleTheme = (value: string) => {
     setTheme(value);

--- a/packages/view/src/store/index.ts
+++ b/packages/view/src/store/index.ts
@@ -3,3 +3,4 @@ export * from "./filteredRange";
 export * from "./branch";
 export * from "./githubInfo";
 export * from "./data";
+export * from "./theme";

--- a/packages/view/src/store/theme.ts
+++ b/packages/view/src/store/theme.ts
@@ -13,7 +13,7 @@ export const useThemeStore = create<ThemeState>()(
       setTheme: (theme) => set({ theme }),
     }),
     {
-      name: "theme", // localStorage key
+      name: "theme",
     }
   )
 );

--- a/packages/view/src/store/theme.ts
+++ b/packages/view/src/store/theme.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface ThemeState {
+  theme: string;
+  setTheme: (theme: string) => void;
+}
+
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set) => ({
+      theme: "githru",
+      setTheme: (theme) => set({ theme }),
+    }),
+    {
+      name: "theme", // localStorage key
+    }
+  )
+);


### PR DESCRIPTION
## Related issue
#783 이슈를 확인하고,
해당이슈 관련하여 해결된 [#767 ](https://github.com/githru/githru-vscode-ext/pull/767) PR을 보다가 zustand를 적용이 안되어있음을 확인하여 작업하였습니다.

## Result
기존의 window.theme 방식 대신 Zustand를 도입하여 테마 상태를 보다 효율적으로 관리하도록 개선했습니다.
persist 미들웨어를 활용해 테마 설정을 localStorage에 저장함으로써, 웹뷰를 종료 후 다시 열더라도 마지막으로 선택한 테마가 유지됩니다.

## Work list
- window.theme 전역 변수 제거
- Zustand를 이용한 테마 상태 전역 관리 구조 도입
- persist 미들웨어 적용으로 localStorage 자동 저장/복원
- 테마 초기화 useEffect를 App.tsx에도 반영하여 UX 개선

## Discussion
window.theme 방식은 유지보수에 불리했으며, 상태 추적이 어려웠습니다.
Zustand + persist 구조를 통해 상태 관리가 중앙화되었고, UX 및 코드 구조의 일관성이 향상되었습니다.