### PR TITLE
fix(view): 날짜별 커밋 및 코드 변경량 계산 오류 수정

### DIFF
--- a/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.tsx
@@ -54,8 +54,8 @@ const TemporalFilter = () => {
 
       const clocValue = commit.diffStatistics.insertions + commit.diffStatistics.deletions;
 
-      commitMap.set(formattedDate, clocMapItem ? clocMapItem + 1 : 1);
-      clocMap.set(formattedDate, commitMapItem ? commitMapItem + clocValue : clocValue);
+      commitMap.set(formattedDate, commitMapItem ? commitMapItem + 1 : 1);
+      clocMap.set(formattedDate, clocMapItem ? clocMapItem + clocValue : clocValue);
     });
 
     const buildReturnArray = (map: Map<string, number>) =>


### PR DESCRIPTION
## Related issue

#807 

## Result

같은 날짜 복수 커밋 처리 시 TemporalFilter 통계 계산 오류 수정

- 기존: 변수명이 서로 바뀌어 참조되어 잘못 계산됨
- 수정: commitMap/clocMap 각각 올바른 변수 참조하도록 개선
- 효과: 같은 날짜에 여러 커밋이 있어도 정확한 통계 표시

## Work list

- TemporalFilter.tsx 57-58줄 변수명 수정
  - `commitMap.set()` 에서 `commitMapItem` 사용하도록 변경
  - `clocMap.set()` 에서 `clocMapItem` 사용하도록 변경

## Discussion

버그 상세 분석
- 발생 조건: 같은 날짜에 2개 이상 커밋이 있을 때만 발생 (1개일 때는 우연히 정상 동작)
- 영향: 날짜별 커밋 개수와 코드 변경량이 비정상적으로 계산됨

문제 재현 최소 코드

```typescript
const testData = [
  { commit: { commitDate: "2022-08-21T14:04:23", diffStatistics: { insertions: 444, deletions: 7 } } },
  { commit: { commitDate: "2022-08-21T13:58:42", diffStatistics: { insertions: 2, deletions: 6 } } },
  { commit: { commitDate: "2022-08-21T13:58:42", diffStatistics: { insertions: 5, deletions: 0 } } },
];

function buggyLogic(data) {
  const clocMap = new Map();
  const commitMap = new Map();
  data.forEach(({ commit }) => {
    const date = new Date(commit.commitDate).toISOString().split("T")[0];
    const cloc = commit.diffStatistics.insertions + commit.diffStatistics.deletions;
    const clocMapItem = clocMap.get(date);
    const commitMapItem = commitMap.get(date);
    commitMap.set(date, clocMapItem ? clocMapItem + 1 : 1);
    clocMap.set(date, commitMapItem ? commitMapItem + cloc : cloc);
  });
  return { clocMap, commitMap };
}

const { clocMap, commitMap } = buggyLogic(testData);
console.log(clocMap.get("2022-08-21")); // 출력 3 (❌ 기대: 464)
console.log(commitMap.get("2022-08-21")); // 출력 464 (❌ 기대: 3)
```
