### PR TITLE
fix: 한글 파일명이 유니코드 이스케이프 시퀀스로 나타나는 문제 해결

### DIFF
--- a/packages/vscode/src/utils/git.util.ts
+++ b/packages/vscode/src/utils/git.util.ts
@@ -173,6 +173,7 @@ export async function getGitLog(gitPath: string, currentWorkspacePath: string): 
       ].join("%n");
     const args = [
       "--no-pager",
+      "-c", "core.quotepath=false",
       "log",
       "--all",
       "--parents",


### PR DESCRIPTION
## Related issue
Closes #772

## Result
### 해당 이슈의 원인 파악
이름에 비ASCII 문자(한글, 중국어, 일본어 등)가 포함된 파일이 commit되는 경우, 사용자 Git의 `core.quotepath` 설정이 true인 경우, 해당 문제를 이스케이프 처리하여 보여주게 됩니다.
`core.quotepath` 을 false로 설정하는 경우, 한글 파일명이 정상적이로 표기되는 것을 확인할 수 있습니다.

### 이슈 재현 방법
1. `git config --global core.quotepath true` 명령어로 비ASCII 문자가 이스케이프되도록 설정
1. 한글 파일명으로 파일 생성 (예: `한글파일명.md`)
2. Git에 커밋
3. Githru extension에서 화면 확인
4. 파일명이 이스케이프 시퀀스로 표시됨

### 주요 변경 사항
Git log를 가져올 때 `core.quotepath=false` 옵션을 명시적으로 설정하여 비ASCII 문자(한글, 중국어, 일본어 등)가 이스케이프 처리되지 않은채로 Git log를 가져올 수 있도록 설정했습니다.