### PR TITLE
[view] Summary 내 Detail 컴포넌트 내부 콘텐츠 스타일 개선 작업

### DIFF
--- a/packages/view/src/components/Detail/Detail.scss
+++ b/packages/view/src/components/Detail/Detail.scss
@@ -46,9 +46,9 @@
 }
 
 .detail__commit-list {
+  width: 100%;
   display: flex;
   flex-direction: column;
-  row-gap: 0.4375rem;
   padding: 1.25rem;
   font-size: $font-size-body;
 
@@ -56,27 +56,32 @@
     width: 100%;
     display: flex;
     justify-content: space-between;
+    row-gap: 0.4375rem;
+    align-items: flex-start;
     color: $color-medium-gray;
 
     .commit-item__detail {
       color: $color-white;
       display: flex;
       justify-content: space-between;
-      align-items: center;
+      align-items: flex-start;
       width: 100%;
+      flex-grow: 1;
       padding-left: 0.3125rem;
+      padding-bottom: 1rem;
 
-      .commit-item__avatar-message {
+      .commit-item__left {
         display: flex;
-        align-items: center;
+        align-items: flex-start;
+        gap: 0.625rem;
         width: 100%;
 
         .commit-item__message-container {
           position: relative;
           overflow: visible;
           flex-grow: 1;
+          padding-top: 0.3rem;
           padding-right: 3.125rem;
-          width: auto;
 
           .commit-item__message {
             display: -webkit-box;
@@ -85,45 +90,46 @@
             overflow: hidden;
             color: $color-white;
             margin: 0 0.25rem 0 0.9375rem;
+            cursor: pointer;
 
             &:hover {
               display: block;
-              cursor: pointer;
+              -webkit-line-clamp: unset;
+              white-space: normal;
               overflow: visible;
-              position: absolute;
-              z-index: 10;
-              background-color: $color-dark-gray;
-              padding-bottom: 0.3125rem;
-              top: -0.4375rem;
             }
           }
         }
       }
 
-      .commit-item__author-date {
-        display: block;
-        position: relative;
+      .commit-item__right {
+        display: flex;
+        padding-top: 0.3rem;
+        align-items: flex-end;
+        text-align: right;
+        gap: 0.625rem;
         white-space: nowrap;
-      }
-    }
 
-    .commit-item__commit-id {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      width: 6em;
-      position: relative;
+        .commit-item__commit-id {
+          width: fit-content;
 
-      .commit-id__link {
-        text-decoration: none;
-        color: $color-light-gray;
+          .commit-id__link {
+            text-decoration: none;
+            color: $color-light-gray;
 
-        &:visited {
-          color: $color-light-gray;
+            &:visited {
+              color: $color-light-gray;
+            }
+
+            &:hover {
+              color: var(--color-primary);
+            }
+          }
         }
 
-        &:hover {
-          color: var(--color-primary);
+        .commit-item__author-date {
+          display: block;
+          position: relative;
         }
       }
     }

--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -75,7 +75,7 @@ const Detail = ({ selectedData, clusterId, authSrcMap }: DetailProps) => {
               className="detail__commit-item"
             >
               <div className="commit-item__detail">
-                <div className="commit-item__avatar-message">
+                <div className="commit-item__left">
                   {authSrcMap && (
                     <Author
                       name={author.names.toString()}
@@ -86,27 +86,29 @@ const Detail = ({ selectedData, clusterId, authSrcMap }: DetailProps) => {
                     <span className="commit-item__message">{message}</span>
                   </div>
                 </div>
-                <span className="commit-item__author-date">
-                  {author.names[0]}, {dayjs(commitDate).format("YY. M. DD. a h:mm")}
-                </span>
-              </div>
-              <div className="commit-item__commit-id">
-                <a
-                  href={`https://github.com/${owner}/${repo}/commit/${id}`}
-                  onClick={handleCommitIdCopy(id)}
-                  tabIndex={0}
-                  onKeyDown={handleCommitIdCopy(id)}
-                  className="commit-id__link"
-                >
-                  <Tooltip
-                    className="commit-id__tooltip"
-                    placement="right"
-                    title={id}
-                    PopperProps={{ sx: { ".MuiTooltip-tooltip": { bgcolor: "#3c4048" } } }}
-                  >
-                    <p>{`${id.slice(0, 6)}`}</p>
-                  </Tooltip>
-                </a>
+                <div className="commit-item__right">
+                  <span className="commit-item__author-date">
+                    {author.names[0]}, {dayjs(commitDate).format("YY. M. DD. a h:mm")}
+                  </span>
+                  <div className="commit-item__commit-id">
+                    <a
+                      href={`https://github.com/${owner}/${repo}/commit/${id}`}
+                      onClick={handleCommitIdCopy(id)}
+                      tabIndex={0}
+                      onKeyDown={handleCommitIdCopy(id)}
+                      className="commit-id__link"
+                    >
+                      <Tooltip
+                        className="commit-id__tooltip"
+                        placement="right"
+                        title={id}
+                        PopperProps={{ sx: { ".MuiTooltip-tooltip": { bgcolor: "#3c4048" } } }}
+                      >
+                        <p>{id.slice(0, 6)}</p>
+                      </Tooltip>
+                    </a>
+                  </div>
+                </div>
               </div>
             </li>
           );

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  padding-left: 0.625rem;;
+  padding-left: 0.625rem;
   padding-right: 10px;
   width: 100%;
   height: 100%;

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -28,6 +28,7 @@
       @extend .cluster-summary__info;
       border-radius: 1.5625rem;
       background-color: $color-dark-gray;
+      overflow: hidden;
     }
   }
 }

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -118,6 +118,6 @@
 .detail {
   overflow: auto;
   height: 13.75rem;
-  max-height: 17.5rem;
-  padding: 0.625rem 1.875rem;
+  max-height: fit-content;
+  padding: 0.625rem 1.075rem;
 }


### PR DESCRIPTION
## Related issue

Closes #790 

## Result

Summary의 cluster-summary__info 클릭 시 나오는 Detail 컴포넌트의 내부 콘텐츠 스타일링 개선 작업을 진행했습니다.

| 기존 | 개선 후 |
|:----:|:-------:|
<img width="786" height="188" alt="image" src="https://github.com/user-attachments/assets/d388a7eb-3091-46cb-aa13-8db891d242eb" /> <img width="736" height="264" alt="image" src="https://github.com/user-attachments/assets/ce3c661b-0d4e-46a3-977f-0eab80de0b2c" /> | <img width="651" height="210" alt="image" src="https://github.com/user-attachments/assets/92e3b63b-1c56-40b4-a06d-104e4cd87dd5" /><img width="651" height="210" alt="image" src="https://github.com/user-attachments/assets/aa9f9c64-84e8-4fd3-8a80-a6b0e07513dc" /> 

### 기존
 `commit_id가 commit date와 겹쳐 보이는 현상` + `commit message hover 시, 주변 내용들을 완전히 뒤덮는 상황`

### 수정
`detail__commit-item 구조 개선` + 그 외 추가적인 스타일 개선 작업(`cluster-summary 박스 overflow 개선`과 `detail max-height 조정`)

### 효과
- commit message hover 시, 다른 커밋 내역들을 가리지 않은 채 상세 메시지 확인 가능
- commit_id 겹침 현상 해결

## Work list

###  detail__commit-item 구조 리팩토링
일렬로 flex 처리 되어있었던 detail__commit-item 내부 요소들을 `commit-item__left(author, commit message)`와 `commit-item__right(author, date, commit_id)`로 이분화하여 구조를 개선하였습니다. 해당 작업을 기반으로, **space-between**으로 item 간 간격 정리를 해주었습니다.

추가적으로 commit message hover 시, 확대하고자 하는 메시지가 다른 내용들을 가리지 않도록 `absolute 되어 있던 관련 코드를 삭제시켰고`, 기존 align-items: center 처리 되었던 부분을 `flex-start 상태로 변경`시켜 깔끔한 ui로 개선시켜보았습니다.

### cluster-summary 박스 overflow 개선
기존 cluster-summary 박스 내부 콘텐츠들이 박스 밖으로 overflow되는 문제를 발견하여 `hidden` 처리해주었습니다.

### detail max-height 조정
max-height가 17.5rem로 고정으로 박혀있어서 커밋 수가 적을 콘텐츠에는 하단에 공백이 크게 생기는 상황을 확인하여 이를 방지하기 위해 `fit-content` 처리를 해주었습니다.


## Discussion

위 작업들을 기반으로 문제되었던 이슈들이 잘 해결됐는지 확인부탁드립니다:)
