### PR TITLE
fix: FilteredAuthors의 3중 map 구조 개선

### DIFF
--- a/packages/view/src/components/FilteredAuthors/FilteredAuthors.tsx
+++ b/packages/view/src/components/FilteredAuthors/FilteredAuthors.tsx
@@ -10,33 +10,23 @@ const FilteredAuthors = () => {
   const authSrcMap = usePreLoadAuthorImg();
   const selectedClusters = getInitData(selectedData);
 
-  // 이미 선택된 사용자를 관리
-  const addedAuthors = new Set();
+  // 2차원 authorNames를 평탄화하고 중복 제거
+  const uniqueAuthorNames = Array.from(
+    new Set(selectedClusters.flatMap((cluster) => cluster.summary.authorNames.flat()))
+  );
 
   return (
     <div className="filtered-authors">
       <p className="filtered-authors__label">Authors:</p>
       <div className="filtered-authors__author">
         {authSrcMap &&
-          selectedClusters.map((selectedCluster) => {
-            return selectedCluster.summary.authorNames.map((authorArray: string[]) => {
-              return authorArray.map((authorName: string) => {
-                // 이미 추가된 사용자인지 확인 후 추가되지 않은 경우에만 추가하고 Set에 이름을 저장
-                if (!addedAuthors.has(authorName)) {
-                  addedAuthors.add(authorName);
-                  return (
-                    <Author
-                      key={authorName}
-                      name={authorName}
-                      src={authSrcMap[authorName]}
-                    />
-                  );
-                }
-                // 이미 추가된 사용자인 경우 null 반환
-                return null;
-              });
-            });
-          })}
+          uniqueAuthorNames.map((authorName) => (
+            <Author
+              key={authorName}
+              name={authorName}
+              src={authSrcMap[authorName]}
+            />
+          ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Related issue
#816

## Result
- FilteredAuthors 컴포넌트 내 3중 map 구조를 flatMap과 Set을 활용하여 중복 제거와 배열 평탄화를 적용함
- 코드 가독성이 향상됨

## Work list
- selectedClusters에서 저자 배열들을 flatMap과 flat으로 1차원 배열로 변환
- Set을 사용해 중복 저자명을 제거
- uniqueAuthorNames 배열을 기반으로 Author 컴포넌트 map 렌더링 방식 적용
- 기존 3중 map 구조 완전 제거 및 리팩토링 완료

## Discussion
- 저자 이름 중복 문제(동명이인 등)는 기존과 동일하게 이름을 기준으로만 처리되고 있습니다. 
- 따라서 향후 저자 식별에 고유 ID를 활용하는 방향을 검토해보면 좋을 것 같습니다!

