### PR TITLE
[view] tag와 releaseTag에 대한 테스트 코드 추가

### DIFF
--- a/packages/view/src/components/Detail/Detail.util.test.ts
+++ b/packages/view/src/components/Detail/Detail.util.test.ts
@@ -208,7 +208,6 @@ const fakeCommitNodeListInCluster: CommitNode[] = [
   },
 ];
 
-/** authorLength, fileLength, commitLength, insertions, deletions 검증 */
 test("getCommitListDetail test", () => {
   const result = getCommitListDetail({
     commitNodeListInCluster: fakeCommitNodeListInCluster,
@@ -224,19 +223,16 @@ test("getCommitListDetail test", () => {
   expect(result.releaseTagLength).toBe(2);
 });
 
-/** commit ID 검증 */
 test("getSummaryCommitList test", () => {
   const result1 = getSummaryCommitList(fakeCommitNodeListInCluster);
 
   expect(result1).not.toBeUndefined();
   expect(result1).toHaveLength(3);
 
-  // ID 검증
   expect(result1[0].commit.id).toBe(fakeCommitNodeListInCluster[0].commit.id);
   expect(result1[1].commit.id).toBe(fakeCommitNodeListInCluster[1].commit.id);
   expect(result1[2].commit.id).toBe(fakeCommitNodeListInCluster[2].commit.id);
 
-  // 태그 정보 검증
   expect(result1[0].commit.tags).toBe(fakeCommitNodeListInCluster[0].commit.tags);
   expect(result1[0].commit.releaseTags).toBe(fakeCommitNodeListInCluster[0].commit.releaseTags);
   expect(result1[1].commit.tags).toBe(fakeCommitNodeListInCluster[1].commit.tags);

--- a/packages/view/src/components/Detail/Detail.util.test.ts
+++ b/packages/view/src/components/Detail/Detail.util.test.ts
@@ -220,6 +220,8 @@ test("getCommitListDetail test", () => {
   expect(result.commitLength).toBe(3);
   expect(result.insertions).toBe(1100);
   expect(result.deletions).toBe(278);
+  expect(result.tagLength).toBe(9);
+  expect(result.releaseTagLength).toBe(2);
 });
 
 /** commit ID 검증 */

--- a/packages/view/src/components/Detail/Detail.util.test.ts
+++ b/packages/view/src/components/Detail/Detail.util.test.ts
@@ -240,4 +240,3 @@ test("getSummaryCommitList test", () => {
   expect(result1[2].commit.tags).toBe(fakeCommitNodeListInCluster[2].commit.tags);
   expect(result1[2].commit.releaseTags).toBe(fakeCommitNodeListInCluster[2].commit.releaseTags);
 });
-

--- a/packages/view/src/components/Detail/Detail.util.test.ts
+++ b/packages/view/src/components/Detail/Detail.util.test.ts
@@ -46,8 +46,8 @@ const fakeCommitNodeListInCluster: CommitNode[] = [
         },
       },
       message: "feat(webview): add typescript structure",
-      tags: [],
-      releaseTags: [],
+      tags: ["v1.1.0", "feature", "typescript"],
+      releaseTags: ["v1.1.0"],
     },
     seq: 0,
     clusterId: 4,
@@ -125,8 +125,8 @@ const fakeCommitNodeListInCluster: CommitNode[] = [
         },
       },
       message: "feat(vscode): launch webview for webviewApp",
-      tags: [],
-      releaseTags: [],
+      tags: ["v1.2.0", "vscode", "webview"],
+      releaseTags: ["v1.2.0"],
     },
     clusterId: 4,
     seq: 1,
@@ -200,7 +200,7 @@ const fakeCommitNodeListInCluster: CommitNode[] = [
         },
       },
       message: "setup(vscode): add webview loader",
-      tags: [],
+      tags: ["setup", "initial", "webview-loader"],
       releaseTags: [],
     },
     seq: 2,
@@ -208,6 +208,7 @@ const fakeCommitNodeListInCluster: CommitNode[] = [
   },
 ];
 
+/** authorLength, fileLength, commitLength, insertions, deletions 검증 */
 test("getCommitListDetail test", () => {
   const result = getCommitListDetail({
     commitNodeListInCluster: fakeCommitNodeListInCluster,
@@ -221,12 +222,24 @@ test("getCommitListDetail test", () => {
   expect(result.deletions).toBe(278);
 });
 
+/** commit ID 검증 */
 test("getSummaryCommitList test", () => {
   const result1 = getSummaryCommitList(fakeCommitNodeListInCluster);
 
   expect(result1).not.toBeUndefined();
   expect(result1).toHaveLength(3);
+
+  // ID 검증
   expect(result1[0].commit.id).toBe(fakeCommitNodeListInCluster[0].commit.id);
   expect(result1[1].commit.id).toBe(fakeCommitNodeListInCluster[1].commit.id);
   expect(result1[2].commit.id).toBe(fakeCommitNodeListInCluster[2].commit.id);
+
+  // 태그 정보 검증
+  expect(result1[0].commit.tags).toBe(fakeCommitNodeListInCluster[0].commit.tags);
+  expect(result1[0].commit.releaseTags).toBe(fakeCommitNodeListInCluster[0].commit.releaseTags);
+  expect(result1[1].commit.tags).toBe(fakeCommitNodeListInCluster[1].commit.tags);
+  expect(result1[1].commit.releaseTags).toBe(fakeCommitNodeListInCluster[1].commit.releaseTags);
+  expect(result1[2].commit.tags).toBe(fakeCommitNodeListInCluster[2].commit.tags);
+  expect(result1[2].commit.releaseTags).toBe(fakeCommitNodeListInCluster[2].commit.releaseTags);
 });
+

--- a/packages/view/src/components/Detail/Detail.util.ts
+++ b/packages/view/src/components/Detail/Detail.util.ts
@@ -24,7 +24,6 @@ const getChangeFileLength = (commitNodes: CommitNode[]) => {
   return getDataSetSize(commitNodes.map((d) => Object.keys(d.commit.diffStatistics.files)).flat());
 };
 
-// 태그 관련 유틸함수 추가
 const getCommitListTagsLength = (commitNodes: CommitNode[]) => {
   return getDataSetSize(commitNodes.map((d) => d.commit.tags).flat());
 };
@@ -63,7 +62,6 @@ export const getCommitListDetail = ({ commitNodeListInCluster }: GetCommitListDe
   };
 };
 
-/** 커밋 목록을 반환하는 함수 */
 export const getSummaryCommitList = (arr: CommitNode[]) => {
   return arr.length > FIRST_SHOW_NUM ? arr.slice(0, FIRST_SHOW_NUM) : [...arr];
 };

--- a/packages/view/src/components/Detail/Detail.util.ts
+++ b/packages/view/src/components/Detail/Detail.util.ts
@@ -24,6 +24,17 @@ const getChangeFileLength = (commitNodes: CommitNode[]) => {
   return getDataSetSize(commitNodes.map((d) => Object.keys(d.commit.diffStatistics.files)).flat());
 };
 
+// 태그 관련 유틸함수 추가
+const getCommitListTagsLength = (commitNodes: CommitNode[]) => {
+  return getDataSetSize(commitNodes.map((d) => d.commit.tags).flat());
+};
+
+const getCommitListReleaseTagsLength = (commitNodes: CommitNode[]) => {
+  return getDataSetSize(commitNodes.map((d) => d.commit.releaseTags).flat());
+};
+
+
+
 type GetCommitListDetail = { commitNodeListInCluster: CommitNode[] };
 export const getCommitListDetail = ({ commitNodeListInCluster }: GetCommitListDetail) => {
   const authorLength = getCommitListAuthorLength(commitNodeListInCluster);
@@ -38,6 +49,8 @@ export const getCommitListDetail = ({ commitNodeListInCluster }: GetCommitListDe
       deletions: 0,
     }
   );
+  const tagLength = getCommitListTagsLength(commitNodeListInCluster);
+  const releaseTagLength = getCommitListReleaseTagsLength(commitNodeListInCluster);
 
   return {
     authorLength,
@@ -45,9 +58,12 @@ export const getCommitListDetail = ({ commitNodeListInCluster }: GetCommitListDe
     commitLength: commitNodeListInCluster.length,
     insertions: diffStatistics.insertions,
     deletions: diffStatistics.deletions,
+    tagLength,
+    releaseTagLength,
   };
 };
 
+/** 커밋 목록을 반환하는 함수 */
 export const getSummaryCommitList = (arr: CommitNode[]) => {
   return arr.length > FIRST_SHOW_NUM ? arr.slice(0, FIRST_SHOW_NUM) : [...arr];
 };

--- a/packages/view/src/components/Detail/Detail.util.ts
+++ b/packages/view/src/components/Detail/Detail.util.ts
@@ -32,8 +32,6 @@ const getCommitListReleaseTagsLength = (commitNodes: CommitNode[]) => {
   return getDataSetSize(commitNodes.map((d) => d.commit.releaseTags).flat());
 };
 
-
-
 type GetCommitListDetail = { commitNodeListInCluster: CommitNode[] };
 export const getCommitListDetail = ({ commitNodeListInCluster }: GetCommitListDetail) => {
   const authorLength = getCommitListAuthorLength(commitNodeListInCluster);

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.util.test.ts
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.util.test.ts
@@ -200,7 +200,14 @@ describe("getInitData test", () => {
   });
 });
 
-test("getCommitLatestTag test", () => {
-  const clusters = getInitData(clusterNodeMockData);
-  expect(getCommitLatestTag(clusters[2].clusterTags)).toBe("v1.2.0");
+describe("getCommitLatestTag test", () => {
+  test("should return empty string when clusterTags is empty", () => {
+    const clusters = getInitData(clusterNodeMockData);
+    expect(getCommitLatestTag(clusters[0].clusterTags)).toBe("");
+  });
+
+  test("Get the latest release tag from the cluster", () => {
+    const clusters = getInitData(clusterNodeMockData);
+    expect(getCommitLatestTag(clusters[2].clusterTags)).toBe("v1.2.0");
+  });
 });

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.util.test.ts
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.util.test.ts
@@ -1,6 +1,6 @@
 import type { ClusterNode } from "types";
 
-import { getClusterById, getClusterIds, getInitData } from "./Summary.util";
+import { getClusterById, getClusterIds, getInitData, getCommitLatestTag } from "./Summary.util";
 
 const clusterNodeMockData: ClusterNode[] = [
   {
@@ -47,8 +47,8 @@ const clusterNodeMockData: ClusterNode[] = [
           },
           id: "71627b0568035fcf923e18a36b4f3f09fc1632c5",
           message: "Initial commit",
-          tags: [],
-          releaseTags: [],
+          tags: ["feature", "enhancement", "ui", "performance"],
+          releaseTags: ["v1.0.0"],
           parentIds: [],
         },
         nodeTypeName: "COMMIT",
@@ -58,7 +58,6 @@ const clusterNodeMockData: ClusterNode[] = [
     nodeTypeName: "CLUSTER",
   },
   {
-    nodeTypeName: "CLUSTER",
     commitNodeList: [
       {
         nodeTypeName: "COMMIT",
@@ -89,8 +88,8 @@ const clusterNodeMockData: ClusterNode[] = [
             },
           },
           message: "Merge pull request #158 from jin-Pro/main/n/nadd View CONTRIBUTING.md Template",
-          tags: [],
-          releaseTags: [],
+          tags: ["merge", "docs"],
+          releaseTags: ["v1.1.0"],
         },
         clusterId: 89,
         seq: 1,
@@ -124,13 +123,14 @@ const clusterNodeMockData: ClusterNode[] = [
             },
           },
           message: "docs(view): add View CONTRIBUTING.md Template",
-          tags: [],
-          releaseTags: [],
+          tags: ["docs", "template"],
+          releaseTags: ["v1.2.0", "v1.1.0", "v1.0.0"],
         },
         clusterId: 89,
         seq: 2,
       },
     ],
+    nodeTypeName: "CLUSTER",
   },
 ];
 
@@ -148,6 +148,8 @@ test("getClusterById test", () => {
   expect(result.commitNodeList[0].commit.diffStatistics.changedFileCount).toBe(2);
   expect(result.commitNodeList[0].commit.diffStatistics.insertions).toBe(203);
   expect(result.commitNodeList[0].commit.diffStatistics.deletions).toBe(0);
+  expect(result.commitNodeList[0].commit.tags).toEqual([]);
+  expect(result.commitNodeList[0].commit.releaseTags).toEqual([]);
 });
 
 test("getClusterIds test", () => {
@@ -174,4 +176,31 @@ describe("getInitData test", () => {
   test("the commit author names in the cluster are not duplicated.", () => {
     expect(result[2].summary.authorNames.length).toBe(1);
   });
+
+  test("clusterTags should be empty when no releaseTags exist", () => {
+    expect(result[0].clusterTags).toEqual([]);
+  });
+
+  test("clusterTags should contain releaseTags from single commit cluster", () => {
+    expect(result[1].clusterTags).toContain("v1.0.0");
+    expect(result[1].clusterTags).toHaveLength(1);
+  });
+
+  test("clusterTags should contain all releaseTags from multiple commits in the cluster", () => {
+    expect(result[2].clusterTags).toContain("v1.0.0");
+    expect(result[2].clusterTags).toContain("v1.1.0");
+    expect(result[2].clusterTags).toContain("v1.2.0");
+    expect(result[2].clusterTags).toHaveLength(3);
+  });
+
+  test("clusterTags should not contain duplicate releaseTags", () => {
+    const uniqueTags = new Set(result[2].clusterTags);
+    expect(uniqueTags.size).toBe(result[2].clusterTags.length);
+    expect(result[2].clusterTags).toHaveLength(3);
+  });
+});
+
+test("getCommitLatestTag test", () => {
+  const clusters = getInitData(clusterNodeMockData);
+  expect(getCommitLatestTag(clusters[2].clusterTags)).toBe("v1.2.0");
 });


### PR DESCRIPTION
## Related issue
https://github.com/githru/githru-vscode-ext/issues/725
<br>
## Result

| Detail.util.test.ts | Summary.util.test.ts | 
|----|----|
|  <img width="400" alt="스크린샷 2025-08-10 오후 6 55 49" src="https://github.com/user-attachments/assets/667f252e-e47d-4185-a1ff-936a56eeeb2a" />  | <img width="400" alt="image" src="https://github.com/user-attachments/assets/7ffdf940-bb15-4278-9bf8-dfab181cf930" /> | 
<br>

## Work list
- PR #724에서 추가된 tag와 releaseTag 기능에 대한 테스트 커버리지를 추가했습니다.
- `getCommitListDetail`의 `tagLength`, `releaseTagLength` 계산을 추가했습니다.

### 테스트 시나리오

#### getCommitListDetail
- tags와 releaseTags가 포함된 커밋 데이터에서 tagLength, releaseTagLength 계산이 정확한지
- 태그 정보가 정확히 반환되는지

#### getInitData
- 클러스터에 태그가 없을 경우 빈 배열을 반환하는지
- 단일 커밋 클러스터의 태그를 정확히 집계하는지
- 다중 커밋 클러스터의 태그를 병합하고 중복을 제거하는지
- 모든 예상 태그가 포함되어 있는지

#### getCommitLatestTag
- 클러스터에 릴리즈 태그가 없을 경우 빈 문자열을 반환하는지
- 여러 릴리즈 태그가 있을 경우 최신 버전 태그를 반환하는지
<br>

## Discussion
- 추가로 필요한 테스트 시나리오가 있다면 알려주시면 감사하겠습니다 !
<br>