### PR TITLE
[vibe] (boot)  Git 커밋 메시지 prefix 분석 및 LLM 기반 요약 생성기 추가

### DIFF
--- a/packages/vscode/src/boot/jiyoung/LLMClient.ts
+++ b/packages/vscode/src/boot/jiyoung/LLMClient.ts
@@ -1,0 +1,41 @@
+import axios from "axios";
+
+import { LLM_API_TOKEN, LLM_API_URL } from "./config";
+import type { GeminiRequest, GeminiResponse } from "./types";
+
+export class LLMClient {
+  async sendPrompt(prompt: string): Promise<string> {
+    const requestBody: GeminiRequest = {
+      contents: [
+        {
+          parts: [
+            {
+              text: prompt,
+            },
+          ],
+        },
+      ],
+      generationConfig: {
+        maxOutputTokens: 300,
+        temperature: 0.7,
+      },
+    };
+
+    try {
+      const response = await axios.post<GeminiResponse>(
+        `${LLM_API_URL}?key=${LLM_API_TOKEN}`,
+        requestBody,
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      return response.data.candidates?.[0]?.content?.parts?.[0]?.text?.trim() ?? "";
+    } catch (error) {
+      console.error("❌ Gemini API call failed:", error);
+      throw error;
+    }
+  }
+}

--- a/packages/vscode/src/boot/jiyoung/config.ts
+++ b/packages/vscode/src/boot/jiyoung/config.ts
@@ -1,0 +1,15 @@
+import * as dotenv from "dotenv";
+
+dotenv.config();
+
+function getEnvOrThrow(key: string): string {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(`❌ Environment variable ${key} is not set.`);
+  }
+  return value;
+}
+
+
+export const LLM_API_URL = getEnvOrThrow("LLM_API_URL");
+export const LLM_API_TOKEN = getEnvOrThrow("LLM_API_TOKEN");

--- a/packages/vscode/src/boot/jiyoung/prefixAnalyzer.ts
+++ b/packages/vscode/src/boot/jiyoung/prefixAnalyzer.ts
@@ -1,0 +1,25 @@
+import { execSync } from "child_process";
+
+export function getCommitPrefixStats(since = "1 month ago"): string {
+  const log = execSync(`git log main --since="${since}" --pretty=format:"%s"`, {
+    encoding: "utf-8",
+  });
+
+  const lines = log.split("\n");
+  const counts: Record<string, number> = {};
+
+  for (const line of lines) {
+    const match = line.match(/^(\w+):/);
+    if (match) {
+      const prefix = match[1];
+      counts[prefix] = (counts[prefix] || 0) + 1;
+    }
+  }
+
+  const sorted = Object.entries(counts)
+    .sort((a, b) => b[1] - a[1])
+    .map(([prefix, count], idx) => `${idx + 1}. ${prefix} (${count} times)`)
+    .join("\n");
+
+  return sorted;
+}

--- a/packages/vscode/src/boot/jiyoung/runPrefixTest.ts
+++ b/packages/vscode/src/boot/jiyoung/runPrefixTest.ts
@@ -1,0 +1,21 @@
+import { LLMClient } from "./LLMClient";
+import { getCommitPrefixStats } from "./prefixAnalyzer";
+
+async function run() {
+  const prefixStats = getCommitPrefixStats();
+
+  const prompt = `
+    I analyzed the Git commit message prefixes for the past month. Here is the prefix usage ranking:
+
+      ${prefixStats}
+
+    Please summarize the most common types of tasks and the project's direction.
+  `;
+
+  const client = new LLMClient();
+  const result = await client.sendPrompt(prompt);
+
+  console.log("📈 LLM analysis result:\n", result);
+}
+
+run();

--- a/packages/vscode/src/boot/jiyoung/types.ts
+++ b/packages/vscode/src/boot/jiyoung/types.ts
@@ -1,0 +1,38 @@
+export interface GeminiRequest {
+  contents: Array<{
+    parts: Array<{
+      text: string;
+    }>;
+  }>;
+  generationConfig?: {
+    temperature?: number;
+    maxOutputTokens?: number;
+    topP?: number;
+    topK?: number;
+  };
+  safetySettings?: Array<{
+    category: string;
+    threshold: string;
+  }>;
+}
+
+export interface GeminiResponse {
+  candidates?: Array<{
+    content: {
+      parts: Array<{
+        text: string;
+      }>;
+    };
+    finishReason: string;
+    safetyRatings: Array<{
+      category: string;
+      probability: string;
+    }>;
+  }>;
+  promptFeedback?: {
+    safetyRatings: Array<{
+      category: string;
+      probability: string;
+    }>;
+  };
+}


### PR DESCRIPTION
## Related issue

## Result
- Git 커밋 메시지의 prefix를 분석하여 사용량 순서대로 보여줍니다.
- 가장 일반적인 작업 유형과 프로젝트의 방향을 요약합니다.

## Work list
- 메인 브랜치에 있는 한달 전부터 지금까지 Git 커밋 메시지의 prefix를 분석하여 가장 일반적인 작업 유형과 프로젝트의 방향을 요약합니다.
- 프로젝트의 방향과 작업 유형을 자동으로 요약하여 프로젝트 현황 관리를 효율적으로 할 수 있을 것 같습니다.

## Discussion
- 처음 연결하는거라 찾아보면서 간단하게 생각해본 것을 boot로 해보았습니다!!