### PR TITLE
test(vscode): getRepo 함수, 기존 URL 파싱 테스트 케이스에 타입/구조 검증 추가

### DIFF
--- a/packages/vscode/src/test/utils/getRepo.spec.ts
+++ b/packages/vscode/src/test/utils/getRepo.spec.ts
@@ -53,6 +53,8 @@ describe("getRepo", () => {
     it.each(validTestCases)("%s", (_, url, expected) => {
       const result = getRepo(url);
       expect(result).toEqual(expected);
+      expect(typeof result.owner).toBe("string");
+      expect(typeof result.repo).toBe("string");
     });
   });
 
@@ -67,6 +69,16 @@ describe("getRepo", () => {
       expect(() => getRepo(invalidUrl)).toThrow(
         `Invalid Git remote config format: "${invalidUrl}". Expected format: [https?://|git@]github.com/owner/repo[.git] or https://organization@dev.azure.com/organization/project/_git/repository-name`
       );
+    });
+  });
+
+  describe("Return type contract", () => {
+    it("should return { owner: string, repo: string } object", () => {
+      const result = getRepo("https://github.com/owner/repo.git");
+      expect(result).toMatchObject({
+        owner: expect.any(String),
+        repo: expect.any(String),
+      });
     });
   });
 });


### PR DESCRIPTION
## Related issue
Closes #848
#843
## Result
- 모든 케이스에서 반환 값과 owner/repo 필드의 타입(string)을 함께 검증하도록 개선
- 함수 반환 구조(Contract)를 명확히 하는 테스트를 별도로 추가
## Work list
- 각 테스트 케이스에서 값뿐 아니라 owner/repo 필드의 타입까지 동시에 검증
- 반환 구조 명세(Contract)를 위한 별도의 구조 테스트 추가(문서화 목적)
## Discussion
### 변경 배경 및 기대 효과
- 값, 타입, 구조를 모든 케이스에서 한 번에 검증함으로써 테스트의 신뢰성을 강화했습니다.
- 함수 반환 타입을 명확하게 문서화하여, 동일한 문제의 재발을 예방하고 유지보수성을 높였습니다.

