### PR TITLE
[vibe] 로컬 mcp 서버 연동 with claude

### DIFF
--- a/packages/githru-mcp/.gitignore
+++ b/packages/githru-mcp/.gitignore
@@ -1,0 +1,28 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+/dist
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/packages/githru-mcp/README.md
+++ b/packages/githru-mcp/README.md
@@ -1,0 +1,85 @@
+# githru-mcp
+
+Githru 레포 안에 포함된 **MCP 서버 패키지**.  
+Claude Desktop에서 **수동 등록**하여 MCP 툴(`ping`, `bmi_calculator` 등)을 바로 실행해볼 수 있습니다.
+
+---
+
+## 1. 프로젝트 구조
+
+``` 
+githru-vscode-ext/
+└─ packages/
+└─ githru-mcp/
+├─ src/
+│ └─ server.ts
+├─ package.json
+├─ tsconfig.json
+└─ .gitignore
+```
+
+---
+
+## 2. 설치 & 빌드
+
+```bash
+# githru-mcp 디렉터리로 이동
+cd packages/githru-mcp
+
+# 의존성 설치
+npm install
+
+# (zod 사용 툴이 있으므로) zod 설치
+npm install zod
+
+# TypeScript 빌드
+npm run build
+# -> dist/server.js 생성
+```
+
+---
+
+## 3. 서버 코드 요약
+
+- ping 툴: 입력 없음 → "pong" 반환
+- bmi_calculator 툴: height(cm), weight(kg) 입력 → BMI 계산 후 결과 반환
+
+```src/server.ts``` 안에 툴들이 등록되어 있고, ```npm run build```로 ```dist/server.js```에 컴파일됩니다.
+
+---
+
+## 4. Claude Desktop 수동 등록
+Claude Desktop은 claude_desktop_config.json 파일에서 MCP 서버를 읽습니다.
+```githru-mcp/claude_desktop_config.json```의 args 내부 path를 수정해주셔야합니다.
+
+- macOS: ```~/Library/Application Support/Claude/claude_desktop_config.json```
+- Windows: ```%APPDATA%\Claude\claude_desktop_config.json```
+
+```json
+{
+  "mcpServers": {
+    "githru-mcp": {
+      "command": "node",
+      "args": [
+        "/ABSOLUTE/PATH/TO/githru-vscode-ext/packages/githru-mcp/dist/server.js"
+      ],
+      "env": {
+        "NODE_NO_WARNINGS": "1"
+      }
+    }
+  }
+}
+```
+
+> ⚠️ src/server.ts를 직접 실행하지 말고, 반드시 **빌드된 JS (dist/server.js)**를 등록해야 합니다.
+> (TS 원본을 바로 실행하려면 --loader ts-node/esm 옵션이 필요하므로 권장하지 않습니다.)
+
+---
+
+## 5. Claude Desktop 재시작
+설정 파일을 수정한 후 Claude Desktop을 완전히 종료하고 다시 실행하세요.
+(MCP 서버는 Claude 시작 시 새로 연결됩니다.)
+
+---
+
+

--- a/packages/githru-mcp/claude_desktop_config.json
+++ b/packages/githru-mcp/claude_desktop_config.json
@@ -1,0 +1,13 @@
+{
+    "mcpServers": {
+        "githru-mcp": {
+        "command": "node",
+        "args": [
+            "/ABSOLUTE/PATH/TO/githru-vscode-ext/packages/githru-mcp/dist/server.js"
+        ],
+        "env": {
+            "NODE_NO_WARNINGS": "1"
+        }
+        }
+    }
+}

--- a/packages/githru-mcp/package.json
+++ b/packages/githru-mcp/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "githru-mcp",
+    "version": "0.0.1",
+    "private": true,
+    "type": "module",
+    "main": "dist/server.js",
+    "scripts": {
+        "build": "tsc -p .",
+        "start": "node dist/server.js",
+        "dev": "ts-node-esm src/server.ts"
+    },
+    "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.17.0"
+    },
+    "devDependencies": {
+        "typescript": "^5.5.4",
+        "ts-node": "^10.9.2"
+    }
+}

--- a/packages/githru-mcp/src/server.ts
+++ b/packages/githru-mcp/src/server.ts
@@ -1,0 +1,83 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+// MCP 서버 인스턴스 생성
+const server = new McpServer({
+    name: "githru-mcp",
+    version: "0.0.1"
+});
+
+// ping 툴 등록
+server.registerTool(
+    "ping",
+    {
+        title: "Ping",
+        description: "Health check tool",
+        inputSchema: {}
+    },
+    async () => {
+        return { content: [{ type: "text", text: "pong" }] };
+    }
+);
+
+// echo 툴 등록 (파라미터 받기 예제)
+server.registerTool(
+    "echo",
+    {
+        title: "Echo",
+        description: "Echoes back the input text",
+        inputSchema: {
+        text: z.string().describe("Text to echo back")
+        }
+    },
+    async ({ text }) => {
+        return { content: [{ type: "text", text: `Echo: ${text}` }] };
+    }
+);
+
+// bmi_calculator 툴 등록
+server.registerTool(
+    "bmi_calculator",
+    {
+        title: "BMI Calculator",
+        description: "키(cm)와 몸무게(kg)를 입력받아 BMI 지수를 계산합니다.",
+        inputSchema: {
+        height: z.number().int().positive().describe("키 (cm 단위)"),
+        weight: z.number().int().positive().describe("몸무게 (kg 단위)")
+        }
+    },
+
+    async ({ height, weight }) => {
+        const hMeters = height / 100; // cm → m
+        const bmi = weight / (hMeters * hMeters);
+        let category = "Unknown";
+        if (bmi < 18.5) category = "Underweight";
+        else if (bmi < 24.9) category = "Normal weight";
+        else if (bmi < 29.9) category = "Overweight";
+        else category = "Obese";
+
+    return {
+        content: [
+            {
+            type: "text",
+            text: `Height: ${height} cm, Weight: ${weight} kg\nBMI: ${bmi.toFixed(
+                2
+            )} (${category})`
+            }
+        ]
+        };
+    }
+);
+
+// 메인 실행 (STDIO 연결)
+async function main() {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+}
+
+main().catch((err) => {
+  // stdout은 프로토콜 채널이므로 로그는 stderr로만 출력
+    console.error("Server error:", err);
+    process.exit(1);
+});

--- a/packages/githru-mcp/tsconfig.json
+++ b/packages/githru-mcp/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "ES2022",
+        "moduleResolution": "Node",
+        "rootDir": "src",
+        "outDir": "dist",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true
+    },
+    "include": ["src"]
+}


### PR DESCRIPTION
## Related issue
#853 

## Result
- Githru 레포 내 MCP 서버(`githru-mcp`) 패키지 추가 및 기본 툴(ping, bmi_calculator) 구현
- Claude Desktop과의 수동 등록 연동 확인

## Work list
- [x] MCP 서버 패키지 구조 확정 (`packages/githru-mcp/`)
- [x] 기본 툴 등록 및 동작 검증 (`ping`, `bmi_calculator`)
- [x] README에 설치, 빌드, Claude 수동 등록 방법 문서화
- [ ] 향후 확장 계획 정리 (예: git_list_commits, stems, csm 등)

## Discussion
- 초기에는 수동 등록 방식으로 테스트, 이후 DXT 패키징 및 마켓플레이스 등록 여부 논의 필요
- githru-vscode-ext의 분석 산출물(JSON 캐시)와 MCP 서버를 어떻게 연계할지 설계 필요

### ping 테스트
<img width="719" height="491" alt="pingTest" src="https://github.com/user-attachments/assets/3b4ff0e7-ce3a-410c-a582-7d39f6715624" />

### BMI 테스트
<img width="709" height="542" alt="bmiTest" src="https://github.com/user-attachments/assets/72485bb6-0cd4-455f-8403-e745a5575fe7" />

### echo 테스트
<img width="706" height="344" alt="EchoTest" src="https://github.com/user-attachments/assets/7b47190f-c914-4a51-85c5-0699edfe1d42" />

