### PR TITLE
[feat] multithreads 함수 반영

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -35,6 +35,7 @@ export async function activate(context: vscode.ExtensionContext) {
   console.log('Congratulations, your extension "githru" is now active!');
 
   const disposable = vscode.commands.registerCommand(COMMAND_LAUNCH, async () => {
+    console.time("Githru-Launch-Time");
     myStatusBarItem.text = `$(sync~spin) ${projectName}`;
     try {
       console.debug("current Panel = ", currentPanel, currentPanel?.onDidDispose);
@@ -80,7 +81,8 @@ export async function activate(context: vscode.ExtensionContext) {
       const initialBaseBranchName = await fetchCurrentBranch();
 
       const fetchClusterNodes = async (baseBranchName = initialBaseBranchName) => {
-        const gitLog = await getGitLog(gitPath, currentWorkspacePath);
+        const workerPath = vscode.Uri.joinPath(context.extensionUri, "dist", "worker.js").fsPath;
+        const gitLog = await fetchGitLogInParallel(gitPath, currentWorkspacePath, workerPath);
         const { owner, repo: initialRepo } = getRepo(gitConfig);
         const repo = initialRepo;
         const engine = new AnalysisEngine({
@@ -117,6 +119,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
       subscriptions.push(webLoader);
       myStatusBarItem.text = `$(check) ${projectName}`;
+      console.timeEnd("Githru-Launch-Time");
       vscode.window.showInformationMessage("Hello Githru");
     } catch (error) {
       if (error instanceof GithubTokenUndefinedError) {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -35,7 +35,9 @@ export async function activate(context: vscode.ExtensionContext) {
   console.log('Congratulations, your extension "githru" is now active!');
 
   const disposable = vscode.commands.registerCommand(COMMAND_LAUNCH, async () => {
-    console.time("Githru-Launch-Time");
+    if (context.extensionMode === vscode.ExtensionMode.Development) {
+      console.time("Githru-Launch-Time");
+    }
     myStatusBarItem.text = `$(sync~spin) ${projectName}`;
     try {
       console.debug("current Panel = ", currentPanel, currentPanel?.onDidDispose);
@@ -119,7 +121,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
       subscriptions.push(webLoader);
       myStatusBarItem.text = `$(check) ${projectName}`;
-      console.timeEnd("Githru-Launch-Time");
+      if (context.extensionMode === vscode.ExtensionMode.Development) {
+        console.timeEnd("Githru-Launch-Time");
+      }
       vscode.window.showInformationMessage("Hello Githru");
     } catch (error) {
       if (error instanceof GithubTokenUndefinedError) {

--- a/packages/vscode/src/test/utils/gitParallel.spec.ts
+++ b/packages/vscode/src/test/utils/gitParallel.spec.ts
@@ -43,7 +43,7 @@ describe("GitParallelWorkerManager", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    workerManager = new GitParallelWorkerManager();
+    workerManager = new GitParallelWorkerManager("dummy/path/to/worker.js");
   });
 
   describe("Worker count calculation", () => {
@@ -109,7 +109,7 @@ describe("GitParallelWorkerManager", () => {
 
     beforeEach(async () => {
       const { GitParallelWorkerManager } = await import("../../utils/gitParallel");
-      errorWorkerManager = new GitParallelWorkerManager();
+      errorWorkerManager = new GitParallelWorkerManager("dummy/path/to/worker.js");
     });
 
     it("should throw an exception if the worker fails", async () => {

--- a/packages/vscode/src/utils/gitParallel.ts
+++ b/packages/vscode/src/utils/gitParallel.ts
@@ -34,11 +34,11 @@ export class GitParallelWorkerManager {
   private readonly config: WorkerConfig;
   private workers: Worker[] = [];
 
-  constructor(config: Partial<WorkerConfig> = {}) {
+  constructor(workerScriptPath: string, config: Partial<WorkerConfig> = {}) {
     this.config = {
       taskThreshold: TASK_THRESHOLD,
       coreCountThreshold: CORE_COUNT_THRESHOLD,
-      workerScriptPath: path.resolve(__dirname, "./gitWorker.js"),
+      workerScriptPath,
       ...config,
     };
   }

--- a/packages/vscode/src/utils/gitUtil.ts
+++ b/packages/vscode/src/utils/gitUtil.ts
@@ -204,9 +204,13 @@ export async function getLogCount(gitPath: string, currentWorkspacePath: string)
   return parseInt(stdout.toString().trim(), BASE_10);
 }
 
-export async function fetchGitLogInParallel(gitPath: string, currentWorkspacePath: string): Promise<string> {
+export async function fetchGitLogInParallel(
+  gitPath: string,
+  currentWorkspacePath: string,
+  workerPath: string
+): Promise<string> {
   const totalCnt = await getLogCount(gitPath, currentWorkspacePath);
-  const workerManager = new GitParallelWorkerManager();
+  const workerManager = new GitParallelWorkerManager(workerPath);
   return workerManager.executeParallelGitLog(gitPath, currentWorkspacePath, totalCnt);
 }
 


### PR DESCRIPTION
## Related issue
#833 

기존에 구현되어 있었으나 사용되지 않던 병렬 처리 함수 fetchGitLogInParallel를 적용했습니다.
Git 로그를 가져오는 전체 실행 시간을 단축하고, 응답 시간의 변동성을 줄여 시스템의 안정성과 예측 가능성을 높이는 것을 목표로 합니다.

## Work list
- 기존 단일 스레드 getGitLog 함수를 병렬 처리 방식의 fetchGitLogInParallel 함수로 교체했습니다.
- fetchGitLogInParallel 함수 빌드를 위해, parallel 함수 경로를 수정했습니다.

## Result
### 🎯 getGitLog, fetchGitLogInParallel 함수 성능 비교
<img width="484" height="146" alt="image" src="https://github.com/user-attachments/assets/18874244-65c2-49a1-8b89-cf0aceebcc83" />

각 함수 자체의 실행 시간을 순수하게 측정한 결과, 병렬 처리로 인한 속도 향상을 확인했습니다.
- getGitLog (기존): 4.346초
- fetchGitLogInParallel (변경): 3.312초
- 결과: 실행시간이 1.024초 23.6% 단축되었습니다.

### 🎰 전체 실행 성능 측정
함수 변경 후, 사용자가 Githru를 실행했을 때의 전체적인 성능을 5회 반복 측정했습니다.
ms | getGitLog | fetchGitLogInParallel
-- | -- | --
1회 | 39.512 | 48.151
2회 | 50.751 | 42.818
3회 | 41.385 | 41.285
4회 | 37.43 | 41.404
5회 | 39.495 | 39.739
<!-- notionvc: ec9e734e-0cb6-408f-9201-ba6da24bdaa2 -->

지표 | getGitLog | fetchGitLogInParallel | 변화율
-- | -- | -- | --
평균 응답 시간 (ms) | 41.715 | 42.679 | +2.31% (증가)
중앙값 (ms) | 39.512 | 41.404 | +4.79% (증가)
최소 응답 시간 (ms) | 37.430 | 39.739 | +6.17% (증가)
최대 응답 시간 (ms) | 50.751 | 48.151 | -5.12% (감소)
표준 편차 (ms) | 5.253 | 3.018 | -42.55% (감소)
변동 계수 (%) | 12.59% | 7.07% | -43.84% (감소)
<!-- notionvc: 1a752b08-614d-4acc-a1b4-1b4b91dcdcf8 -->

전체 테스트에서는 평균 응답 시간이 증가했지만, 병렬 처리의 초기 오버헤드 또는 다른 로직과의 상호작용 때문으로 예상됩니다.

fetchGitLogInParallel 함수는 **속도 향상보다, 안정성을 향상시키는 데에 목적**을 둔 것으로 보입니다.
변동 계수가 43.84% 감소한 부분은 특정 상황에서 급격히 느려지는 스파이크 현상이 줄어들고 일관되고 예측 가능한 응답 시간을 제공할 수 있습니다. `gitParallel.ts`에서 스레드 개수를 최대 3개로 제한하여, 시스템에 과도한 부하를 주지 않기 위해 설계된 것으로 의도적인 설계로 판단됩니다.

## Discussion
성능측정에 사용된 저장소는 [microsoft/vscode](https://github.com/microsoft/vscode) 입니다.
extension.ts 에서 성능측정에 사용된 console.log 는 제거하는 것이 맞을까요?