### PR TITLE
feat(view): 스토리라인 차트 UI 구현

### DIFF
--- a/packages/view/src/App.tsx
+++ b/packages/view/src/App.tsx
@@ -1,10 +1,11 @@
 import "reflect-metadata";
 import { container } from "tsyringe";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import BounceLoader from "react-spinners/BounceLoader";
 
 import MonoLogo from "assets/monoLogo.svg";
 import { BranchSelector, Statistics, TemporalFilter, ThemeSelector, VerticalClusterList } from "components";
+import { FolderActivityFlow } from "components/FolderActivityFlow";
 import "./App.scss";
 import type IDEPort from "ide/IDEPort";
 import { useAnalayzedData } from "hooks";
@@ -15,6 +16,7 @@ import { THEME_INFO } from "components/ThemeSelector/ThemeSelector.const";
 
 const App = () => {
   const initRef = useRef<boolean>(false);
+  const [showExperimentModal, setShowExperimentModal] = useState(false);
   const { handleChangeAnalyzedData } = useAnalayzedData();
   const filteredData = useDataStore((state) => state.filteredData);
   const { handleChangeBranchList } = useBranchStore();
@@ -60,6 +62,20 @@ const App = () => {
         <ThemeSelector />
         <BranchSelector />
         <RefreshButton />
+        <button
+          onClick={() => setShowExperimentModal(true)}
+          style={{
+            padding: "8px 16px",
+            background: "#007bff",
+            color: "white",
+            border: "none",
+            borderRadius: "4px",
+            cursor: "pointer",
+            fontSize: "14px",
+          }}
+        >
+          Experiment
+        </button>
       </div>
       <div className="top-container">
         <TemporalFilter />
@@ -78,6 +94,54 @@ const App = () => {
           </div>
         )}
       </div>
+
+      {/* Experiment Modal */}
+      {showExperimentModal && (
+        <div
+          style={{
+            position: "fixed",
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: "100%",
+            backgroundColor: "rgba(0, 0, 0, 0.5)",
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            zIndex: 1000,
+          }}
+          onClick={() => setShowExperimentModal(false)}
+        >
+          <div
+            style={{
+              backgroundColor: "white",
+              padding: "20px",
+              borderRadius: "8px",
+              width: "90%",
+              height: "80%",
+              overflow: "auto",
+              position: "relative",
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              onClick={() => setShowExperimentModal(false)}
+              style={{
+                position: "absolute",
+                top: "10px",
+                right: "10px",
+                background: "none",
+                border: "none",
+                fontSize: "20px",
+                cursor: "pointer",
+              }}
+            >
+              ×
+            </button>
+            <FolderActivityFlow />
+          </div>
+        </div>
+      )}
     </>
   );
 };

--- a/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.analyzer.ts
+++ b/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.analyzer.ts
@@ -1,0 +1,92 @@
+export interface FolderActivity {
+  folderPath: string;
+  totalChanges: number;
+  insertions: number;
+  deletions: number;
+  commitCount: number;
+}
+
+export interface CommitData {
+  id: string;
+  authorDate: string;
+  commitDate: string;
+  diffStatistics: {
+    insertions: number;
+    deletions: number;
+    files: Record<string, { insertions: number; deletions: number }>;
+  };
+}
+
+export function extractFolderFromPath(filePath: string, depth: number = 1): string {
+  const parts = filePath.split('/');
+  if (parts.length === 1) return '.'; // 루트 레벨 파일
+
+  const folderParts = parts.slice(0, Math.min(depth, parts.length - 1));
+  return folderParts.length > 0 ? folderParts.join('/') : '.';
+}
+
+export function analyzeFolderActivity(clusterNodeList: any[], folderDepth: number = 1): FolderActivity[] {
+  const folderStats = new Map<string, FolderActivity>();
+
+  // 클러스터에서 모든 커밋 추출
+  const allCommits: CommitData[] = [];
+  clusterNodeList.forEach(cluster => {
+    if (cluster.commitNodeList) {
+      cluster.commitNodeList.forEach((commitNode: any) => {
+        if (commitNode.commit) {
+          allCommits.push(commitNode.commit);
+        }
+      });
+    }
+  });
+
+  // 각 커밋의 파일 변경사항 분석
+  allCommits.forEach(commit => {
+    if (commit.diffStatistics?.files) {
+      Object.entries(commit.diffStatistics.files).forEach(([filePath, stats]) => {
+        const folderPath = extractFolderFromPath(filePath, folderDepth);
+
+        if (!folderStats.has(folderPath)) {
+          folderStats.set(folderPath, {
+            folderPath,
+            totalChanges: 0,
+            insertions: 0,
+            deletions: 0,
+            commitCount: 0
+          });
+        }
+
+        const folderActivity = folderStats.get(folderPath)!;
+        folderActivity.insertions += stats.insertions;
+        folderActivity.deletions += stats.deletions;
+        folderActivity.totalChanges += stats.insertions + stats.deletions;
+      });
+    }
+  });
+
+  // 폴더별 고유 커밋 수 계산
+  allCommits.forEach(commit => {
+    if (commit.diffStatistics?.files) {
+      const foldersInCommit = new Set<string>();
+      Object.keys(commit.diffStatistics.files).forEach(filePath => {
+        const folderPath = extractFolderFromPath(filePath, folderDepth);
+        foldersInCommit.add(folderPath);
+      });
+
+      foldersInCommit.forEach(folderPath => {
+        if (folderStats.has(folderPath)) {
+          folderStats.get(folderPath)!.commitCount++;
+        }
+      });
+    }
+  });
+
+  // 배열로 변환하고 총 활동량 기준 정렬
+  return Array.from(folderStats.values())
+    .sort((a, b) => b.totalChanges - a.totalChanges);
+}
+
+export function getTopFolders(clusterNodeList: any[], count: number = 5, folderDepth: number = 1): FolderActivity[] {
+  const allActivities = analyzeFolderActivity(clusterNodeList, folderDepth);
+  return allActivities.slice(0, count);
+}

--- a/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.const.ts
+++ b/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.const.ts
@@ -1,0 +1,5 @@
+export const DIMENSIONS = {
+  width: 800,
+  height: 400,
+  margin: { top: 40, right: 120, bottom: 60, left: 20 }
+};

--- a/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.scss
+++ b/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.scss
@@ -1,0 +1,149 @@
+.folder-activity-flow {
+  padding: 1rem;
+  margin-bottom: 2rem;
+  background: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+
+  &__title {
+    margin: 0 0 0.5rem 0;
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: #212529;
+  }
+
+  &__subtitle {
+    margin: 0 0 0.5rem 0;
+    font-size: 0.875rem;
+    color: #6c757d;
+  }
+
+  &__breadcrumb {
+    margin: 0 0 1rem 0;
+    padding: 0.5rem;
+    background: #f8f9fa;
+    border-radius: 4px;
+    font-size: 0.875rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    .separator {
+      color: #6c757d;
+    }
+
+    .clickable {
+      color: #007bff;
+      cursor: pointer;
+      text-decoration: underline;
+      
+      &:hover {
+        color: #0056b3;
+      }
+    }
+
+    .current {
+      color: #212529;
+      font-weight: 600;
+    }
+  }
+
+  &__back-btn {
+    margin-left: auto;
+    padding: 0.25rem 0.5rem;
+    background: #007bff;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    cursor: pointer;
+    
+    &:hover {
+      background: #0056b3;
+    }
+  }
+
+  &__chart {
+    display: block;
+    margin: 0 auto;
+    cursor: grab;
+    
+    &:active {
+      cursor: grabbing;
+    }
+  }
+
+  &__tooltip {
+    position: absolute;
+    display: none;
+    padding: 0.5rem;
+    background: rgba(0, 0, 0, 0.9);
+    color: white;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    pointer-events: none;
+    z-index: 1000;
+
+    .contributor-activity-tooltip {
+      p {
+        margin: 0.25rem 0;
+        
+        &:first-child {
+          margin-top: 0;
+          font-weight: 600;
+        }
+        
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
+
+  .lane-background {
+    transition: fill 0.2s ease;
+    
+    &:hover {
+      fill: #e9ecef;
+    }
+  }
+
+  .folder-label {
+    font-weight: 500;
+    
+    &.clickable {
+      cursor: pointer;
+      transition: fill 0.2s ease;
+      
+      &:hover {
+        fill: #007bff !important;
+      }
+    }
+  }
+
+  .activity-dot {
+    cursor: pointer;
+    transition: all 0.2s ease;
+    
+    &:hover {
+      stroke-width: 2;
+      r: 8;
+    }
+  }
+
+  .flow-line {
+    pointer-events: none;
+  }
+
+  .x-axis {
+    .domain,
+    .tick line {
+      stroke: #dee2e6;
+    }
+    
+    .tick text {
+      fill: #6c757d;
+      font-size: 11px;
+    }
+  }
+}

--- a/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.tsx
+++ b/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.tsx
@@ -1,0 +1,387 @@
+import { useRef, useEffect, useState } from "react";
+import { useShallow } from "zustand/react/shallow";
+import * as d3 from "d3";
+
+import { useDataStore } from "store";
+import { pxToRem } from "utils/pxToRem";
+import { getTopFolders, type FolderActivity } from "./FolderActivityFlow.analyzer";
+
+import { DIMENSIONS } from "./FolderActivityFlow.const";
+import {
+  extractContributorActivities,
+  generateFlowLineData,
+  calculateNodePosition,
+  findFirstContributorNodes,
+  generateFlowLinePath
+} from "./FolderActivityFlow.util";
+import type { ContributorActivity } from "./FolderActivityFlow.type";
+import "./FolderActivityFlow.scss";
+
+const FolderActivityFlow = () => {
+  const [totalData] = useDataStore(
+    useShallow((state) => [state.data])
+  );
+
+  const svgRef = useRef<SVGSVGElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const [topFolders, setTopFolders] = useState<FolderActivity[]>([]);
+  const [currentPath, setCurrentPath] = useState<string>("");
+  const [folderDepth, setFolderDepth] = useState<number>(1);
+
+  // 하위 폴더 데이터 추출
+  const getSubFolders = (parentPath: string) => {
+    if (!totalData || totalData.length === 0) return [];
+
+    const subFolderStats = new Map<string, FolderActivity>();
+
+    totalData.flat().forEach(cluster => {
+      if (cluster.commitNodeList) {
+        cluster.commitNodeList.forEach((commitNode: any) => {
+          if (commitNode.commit?.diffStatistics?.files) {
+            const commit = commitNode.commit;
+
+            Object.entries(commit.diffStatistics.files).forEach(([filePath, stats]: [string, any]) => {
+              if (parentPath === "" || filePath.startsWith(parentPath + "/")) {
+                const relativePath = parentPath === "" ? filePath : filePath.substring(parentPath.length + 1);
+                const pathParts = relativePath.split('/');
+                const subPath = pathParts[0];
+
+                if (subPath && subPath !== '.' && subPath !== '') {
+                  const fullPath = parentPath === "" ? subPath : `${parentPath}/${subPath}`;
+
+                  if (!subFolderStats.has(fullPath)) {
+                    subFolderStats.set(fullPath, {
+                      folderPath: fullPath,
+                      totalChanges: 0,
+                      insertions: 0,
+                      deletions: 0,
+                      commitCount: 0
+                    });
+                  }
+
+                  const folderActivity = subFolderStats.get(fullPath)!;
+                  folderActivity.insertions += stats.insertions;
+                  folderActivity.deletions += stats.deletions;
+                  folderActivity.totalChanges += stats.insertions + stats.deletions;
+                }
+              }
+            });
+          }
+        });
+      }
+    });
+
+    return Array.from(subFolderStats.values())
+      .sort((a, b) => b.totalChanges - a.totalChanges)
+      .slice(0, 8);
+  };
+
+  // 폴더 클릭 처리
+  const handleFolderClick = (folderPath: string) => {
+    if (folderPath === '.') return;
+
+    const subFolders = getSubFolders(folderPath);
+    if (subFolders.length > 0) {
+      setCurrentPath(folderPath);
+      setFolderDepth(folderDepth + 1);
+      setTopFolders(subFolders);
+    }
+  };
+
+  // 상위 폴더로 이동
+  const handleGoBack = () => {
+    if (currentPath === "") return;
+
+    const parentPath = currentPath.includes('/')
+      ? currentPath.substring(0, currentPath.lastIndexOf('/'))
+      : "";
+
+    if (parentPath === "") {
+      setCurrentPath("");
+      setFolderDepth(1);
+      const rootFolders = getTopFolders(totalData.flat(), 8, 1);
+      setTopFolders(rootFolders);
+    } else {
+      setCurrentPath(parentPath);
+      setFolderDepth(Math.max(1, folderDepth - 1));
+      const subFolders = getSubFolders(parentPath);
+      setTopFolders(subFolders);
+    }
+  };
+
+  useEffect(() => {
+    if (!totalData || totalData.length === 0) return;
+
+    // 루트 폴더로 초기화
+    if (currentPath === "") {
+      const folders = getTopFolders(totalData.flat(), 8, 1);
+      setTopFolders(folders);
+    }
+  }, [totalData]);
+
+  useEffect(() => {
+    if (!totalData || totalData.length === 0 || topFolders.length === 0) return;
+
+    const svg = d3.select(svgRef.current)
+      .attr("width", DIMENSIONS.width)
+      .attr("height", DIMENSIONS.height);
+
+    const tooltip = d3.select(tooltipRef.current);
+
+    svg.selectAll("*").remove();
+
+    // 기여자 활동 데이터 추출
+    const contributorActivities = extractContributorActivities(totalData, topFolders, currentPath);
+
+    if (contributorActivities.length === 0) {
+      svg.append("text")
+        .attr("x", DIMENSIONS.width / 2)
+        .attr("y", DIMENSIONS.height / 2)
+        .attr("text-anchor", "middle")
+        .attr("dominant-baseline", "middle")
+        .text("No activity data available for this folder")
+        .style("font-size", "14px")
+        .style("fill", "#6c757d");
+      return;
+    }
+
+    // 스케일 설정
+    const uniqueContributors = Array.from(new Set(contributorActivities.map(a => a.contributorName)));
+    const uniqueClusters = Array.from(new Set(contributorActivities.map(a => a.clusterIndex))).sort((a, b) => a - b);
+
+    const xScale = d3.scaleBand()
+      .domain(uniqueClusters.map(String))
+      .range([DIMENSIONS.margin.left, DIMENSIONS.width - DIMENSIONS.margin.right])
+      .paddingInner(0.1);
+
+    const yScale = d3.scaleBand()
+      .domain(topFolders.map(f => f.folderPath))
+      .range([DIMENSIONS.margin.top, DIMENSIONS.height - DIMENSIONS.margin.bottom])
+      .paddingInner(0.2);
+
+    const sizeScale = d3.scaleSqrt()
+      .domain([0, d3.max(contributorActivities, d => d.changes) || 1])
+      .range([3, 12]);
+
+    const colorScale = d3.scaleOrdinal()
+      .domain(uniqueContributors)
+      .range(d3.schemeCategory10);
+
+    const mainGroup = svg.append("g");
+
+    // 폴더 레인 그리기
+    mainGroup.selectAll(".folder-lane")
+      .data(topFolders)
+      .enter()
+      .append("g")
+      .attr("class", "folder-lane")
+      .each(function(d) {
+        const lane = d3.select(this);
+
+        lane.append("rect")
+          .attr("class", "lane-background")
+          .attr("x", DIMENSIONS.margin.left)
+          .attr("y", yScale(d.folderPath) || 0)
+          .attr("width", DIMENSIONS.width - DIMENSIONS.margin.left - DIMENSIONS.margin.right)
+          .attr("height", yScale.bandwidth())
+          .attr("fill", "#f8f9fa")
+          .attr("stroke", "#dee2e6")
+          .attr("stroke-width", 1);
+
+        lane.append("text")
+          .attr("class", "folder-label clickable")
+          .attr("x", DIMENSIONS.width - DIMENSIONS.margin.right + 10)
+          .attr("y", (yScale(d.folderPath) || 0) + yScale.bandwidth() / 2)
+          .attr("text-anchor", "start")
+          .attr("dominant-baseline", "middle")
+          .text(() => {
+            if (d.folderPath === '.') return 'root';
+
+            const fileName = d.folderPath.includes('/')
+              ? d.folderPath.split('/').pop()
+              : d.folderPath;
+
+            return fileName && fileName.length > 15
+              ? fileName.substring(0, 12) + "..."
+              : fileName || 'unknown';
+          })
+          .style("font-size", "12px")
+          .style("fill", "#495057")
+          .style("font-weight", "500")
+          .style("cursor", "pointer")
+          .on("click", () => {
+            if (d.folderPath !== '.') {
+              handleFolderClick(d.folderPath);
+            }
+          })
+          .on("mouseover", function() {
+            d3.select(this).style("fill", "#007bff");
+          })
+          .on("mouseout", function() {
+            d3.select(this).style("fill", "#495057");
+          });
+      });
+
+    // 클러스터 축
+    const xAxis = d3.axisBottom(xScale)
+      .tickFormat((d: any) => `Cluster ${parseInt(d) + 1}`);
+
+    mainGroup.append("g")
+      .attr("class", "x-axis")
+      .attr("transform", `translate(0, ${DIMENSIONS.height - DIMENSIONS.margin.bottom})`)
+      .call(xAxis as any);
+
+    // 클러스터 내 노드 위치 계산
+    const activitiesByCluster = new Map<number, ContributorActivity[]>();
+    contributorActivities.forEach(activity => {
+      if (!activitiesByCluster.has(activity.clusterIndex)) {
+        activitiesByCluster.set(activity.clusterIndex, []);
+      }
+      activitiesByCluster.get(activity.clusterIndex)!.push(activity);
+    });
+
+    // 활동 노드 그리기
+    const dots = mainGroup.selectAll(".activity-dot")
+      .data(contributorActivities)
+      .enter()
+      .append("circle")
+      .attr("class", "activity-dot")
+      .attr("cx", d => calculateNodePosition(d, xScale, activitiesByCluster))
+      .attr("cy", d => (yScale(d.folderPath) || 0) + yScale.bandwidth() / 2)
+      .attr("r", d => sizeScale(d.changes))
+      .attr("fill", d => colorScale(d.contributorName) as string)
+      .attr("fill-opacity", 0.8)
+      .attr("stroke", "#fff")
+      .attr("stroke-width", 1);
+
+    // 툴팁 이벤트
+    dots.on("mouseover", (event, d) => {
+        tooltip
+          .style("display", "inline-block")
+          .style("left", pxToRem(event.pageX + 10))
+          .style("top", pxToRem(event.pageY - 10))
+          .html(`
+            <div class="contributor-activity-tooltip">
+              <p><strong>${d.contributorName}</strong></p>
+              <p>Cluster: ${d.clusterIndex + 1}</p>
+              <p>Folder: ${d.folderPath === '.' ? 'root' : d.folderPath}</p>
+              <p>Date: ${d.date.toLocaleDateString()}</p>
+              <p>Changes: ${d.changes}</p>
+              <p style="color: #28a745;">+${d.insertions} insertions</p>
+              <p style="color: #dc3545;">-${d.deletions} deletions</p>
+            </div>
+          `);
+      })
+      .on("mousemove", (event) => {
+        tooltip
+          .style("left", pxToRem(event.pageX + 10))
+          .style("top", pxToRem(event.pageY - 10));
+      })
+      .on("mouseout", () => {
+        tooltip.style("display", "none");
+      });
+
+    // 기여자별 첫 노드에 이름 라벨
+    const firstNodesByContributor = findFirstContributorNodes(contributorActivities);
+
+    mainGroup.selectAll(".contributor-label")
+      .data(Array.from(firstNodesByContributor.values()))
+      .enter()
+      .append("text")
+      .attr("class", "contributor-label")
+      .attr("x", d => calculateNodePosition(d, xScale, activitiesByCluster))
+      .attr("y", d => (yScale(d.folderPath) || 0) + yScale.bandwidth() / 2 - sizeScale(d.changes) - 5)
+      .attr("text-anchor", "middle")
+      .attr("dominant-baseline", "bottom")
+      .text(d => d.contributorName)
+      .style("font-size", "10px")
+      .style("fill", "#495057")
+      .style("font-weight", "500")
+      .style("pointer-events", "none");
+
+    // 플로우 라인 그리기
+    const flowLineData = generateFlowLineData(contributorActivities);
+
+    mainGroup.selectAll(".flow-line")
+      .data(flowLineData)
+      .enter()
+      .append("path")
+      .attr("class", "flow-line")
+      .attr("d", d => generateFlowLinePath(d, xScale, yScale))
+      .attr("fill", "none")
+      .attr("stroke", d => colorScale(d.contributorName) as string)
+      .attr("stroke-width", 2)
+      .attr("stroke-opacity", 0.4);
+
+  }, [totalData, topFolders]);
+
+  // 브레드크럼 생성
+  const getBreadcrumbs = () => {
+    if (currentPath === "") return ["root"];
+    const parts = currentPath.split("/");
+    const breadcrumbs = ["root"];
+    let current = "";
+
+    parts.forEach(part => {
+      current = current ? `${current}/${part}` : part;
+      breadcrumbs.push(part);
+    });
+
+    return breadcrumbs;
+  };
+
+  return (
+    <div className="folder-activity-flow">
+      <p className="folder-activity-flow__title">Contributors Folder Activity Flow</p>
+      <div className="folder-activity-flow__subtitle">
+        Contributors moving between top folders over time
+      </div>
+
+      <div className="folder-activity-flow__breadcrumb">
+        {getBreadcrumbs().map((crumb, index) => (
+          <span key={index}>
+            {index > 0 && <span className="separator"> / </span>}
+            <span
+              className={index === getBreadcrumbs().length - 1 ? "current" : "clickable"}
+              onClick={() => {
+                if (index === 0) {
+                  setCurrentPath("");
+                  setFolderDepth(1);
+                  const folders = getTopFolders(totalData.flat(), 8, 1);
+                  setTopFolders(folders);
+                } else if (index < getBreadcrumbs().length - 1) {
+                  const pathParts = currentPath.split("/");
+                  const targetPath = pathParts.slice(0, index).join("/");
+                  setCurrentPath(targetPath);
+                  setFolderDepth(index + 1);
+                  const subFolders = getSubFolders(targetPath);
+                  setTopFolders(subFolders);
+                }
+              }}
+            >
+              {crumb}
+            </span>
+          </span>
+        ))}
+        {currentPath !== "" && (
+          <button
+            className="folder-activity-flow__back-btn"
+            onClick={handleGoBack}
+          >
+            ← Back
+          </button>
+        )}
+      </div>
+      <svg
+        className="folder-activity-flow__chart"
+        ref={svgRef}
+      />
+      <div
+        className="folder-activity-flow__tooltip"
+        ref={tooltipRef}
+      />
+    </div>
+  );
+};
+
+export default FolderActivityFlow;

--- a/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.type.ts
+++ b/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.type.ts
@@ -1,0 +1,19 @@
+export interface ContributorActivity {
+  contributorId: string;
+  contributorName: string;
+  date: Date;
+  folderPath: string;
+  changes: number;
+  insertions: number;
+  deletions: number;
+  clusterId: string;
+  clusterIndex: number;
+}
+
+export interface FlowLineData {
+  startClusterIndex: number;
+  startFolder: string;
+  endClusterIndex: number;
+  endFolder: string;
+  contributorName: string;
+}

--- a/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.util.ts
+++ b/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.util.ts
@@ -1,0 +1,154 @@
+import * as d3 from "d3";
+import { extractFolderFromPath } from "./FolderActivityFlow.analyzer";
+import type { ContributorActivity, FlowLineData } from "./FolderActivityFlow.type";
+
+// 기여자 활동 데이터 추출
+export function extractContributorActivities(
+  totalData: any[],
+  topFolders: any[],
+  currentPath: string
+): ContributorActivity[] {
+  const contributorActivities: ContributorActivity[] = [];
+
+  totalData.flat().forEach((cluster, clusterIndex) => {
+    const clusterId = `cluster-${clusterIndex}`;
+
+    if (cluster.commitNodeList) {
+      cluster.commitNodeList.forEach((commitNode: any) => {
+        if (commitNode.commit && commitNode.commit.commitDate) {
+          const commit = commitNode.commit;
+          const date = new Date(commit.commitDate);
+
+          if (commit.author?.names?.[0] && commit.author?.emails?.[0] && commit.diffStatistics?.files) {
+            const contributorName = commit.author.names[0].trim();
+            const contributorId = `${contributorName}-${commit.author.emails[0]}`;
+
+            const folderChanges = new Map<string, {insertions: number; deletions: number}>();
+
+            Object.entries(commit.diffStatistics.files).forEach(([filePath, stats]: [string, any]) => {
+              let folderPath: string;
+
+              if (currentPath === "") {
+                folderPath = extractFolderFromPath(filePath, 1);
+              } else {
+                if (filePath.startsWith(currentPath + "/")) {
+                  const relativePath = filePath.substring(currentPath.length + 1);
+                  const pathParts = relativePath.split('/');
+                  folderPath = currentPath + "/" + pathParts[0];
+                } else {
+                  return;
+                }
+              }
+
+              if (topFolders.some(f => f.folderPath === folderPath)) {
+                if (!folderChanges.has(folderPath)) {
+                  folderChanges.set(folderPath, { insertions: 0, deletions: 0 });
+                }
+                const folder = folderChanges.get(folderPath)!;
+                folder.insertions += stats.insertions;
+                folder.deletions += stats.deletions;
+              }
+            });
+
+            folderChanges.forEach((stats, folderPath) => {
+              contributorActivities.push({
+                contributorId,
+                contributorName,
+                date,
+                folderPath,
+                changes: stats.insertions + stats.deletions,
+                insertions: stats.insertions,
+                deletions: stats.deletions,
+                clusterId,
+                clusterIndex
+              });
+            });
+          }
+        }
+      });
+    }
+  });
+
+  return contributorActivities.sort((a, b) => a.date.getTime() - b.date.getTime());
+}
+
+// 플로우 라인 데이터 생성
+export function generateFlowLineData(contributorActivities: ContributorActivity[]): FlowLineData[] {
+  const activitiesByContributor = new Map<string, ContributorActivity[]>();
+  contributorActivities.forEach(activity => {
+    if (!activitiesByContributor.has(activity.contributorId)) {
+      activitiesByContributor.set(activity.contributorId, []);
+    }
+    activitiesByContributor.get(activity.contributorId)!.push(activity);
+  });
+
+  const flowLineData: FlowLineData[] = [];
+
+  activitiesByContributor.forEach((contributorActivities) => {
+    contributorActivities.sort((a, b) => a.clusterIndex - b.clusterIndex || a.date.getTime() - b.date.getTime());
+
+    for (let i = 0; i < contributorActivities.length - 1; i++) {
+      const current = contributorActivities[i];
+      const next = contributorActivities[i + 1];
+
+      if (current.clusterIndex !== next.clusterIndex) {
+        flowLineData.push({
+          startClusterIndex: current.clusterIndex,
+          startFolder: current.folderPath,
+          endClusterIndex: next.clusterIndex,
+          endFolder: next.folderPath,
+          contributorName: current.contributorName
+        });
+      }
+    }
+  });
+
+  return flowLineData;
+}
+
+// 클러스터 내 노드 위치 계산
+export function calculateNodePosition(
+  activity: ContributorActivity,
+  xScale: d3.ScaleBand<string>,
+  activitiesByCluster: Map<number, ContributorActivity[]>
+): number {
+  const clusterX = (xScale(String(activity.clusterIndex)) || 0) + xScale.bandwidth() / 2;
+  const clusterActivities = activitiesByCluster.get(activity.clusterIndex) || [];
+  const activityIndex = clusterActivities.findIndex(a =>
+    a.contributorId === activity.contributorId &&
+    a.folderPath === activity.folderPath &&
+    a.date.getTime() === activity.date.getTime()
+  );
+  const offsetRange = xScale.bandwidth() * 0.8;
+  const offset = (activityIndex - (clusterActivities.length - 1) / 2) * (offsetRange / Math.max(clusterActivities.length, 1));
+  return clusterX + offset;
+}
+
+// 첫 번째 기여자 노드 찾기
+export function findFirstContributorNodes(contributorActivities: ContributorActivity[]): Map<string, ContributorActivity> {
+  const firstNodesByContributor = new Map<string, ContributorActivity>();
+  const sortedActivities = [...contributorActivities].sort((a, b) => a.clusterIndex - b.clusterIndex || a.date.getTime() - b.date.getTime());
+
+  sortedActivities.forEach(activity => {
+    const key = activity.contributorId;
+    if (!firstNodesByContributor.has(key)) {
+      firstNodesByContributor.set(key, activity);
+    }
+  });
+
+  return firstNodesByContributor;
+}
+
+// 플로우 라인 경로 생성
+export function generateFlowLinePath(
+  d: FlowLineData,
+  xScale: d3.ScaleBand<string>,
+  yScale: d3.ScaleBand<string>
+): string {
+  const x1 = (xScale(String(d.startClusterIndex)) || 0) + xScale.bandwidth() / 2;
+  const y1 = (yScale(d.startFolder) || 0) + yScale.bandwidth() / 2;
+  const x2 = (xScale(String(d.endClusterIndex)) || 0) + xScale.bandwidth() / 2;
+  const y2 = (yScale(d.endFolder) || 0) + yScale.bandwidth() / 2;
+  const midX = (x1 + x2) / 2;
+  return `M ${x1},${y1} Q ${midX},${y1} ${midX},${(y1 + y2) / 2} Q ${midX},${y2} ${x2},${y2}`;
+}

--- a/packages/view/src/components/FolderActivityFlow/index.ts
+++ b/packages/view/src/components/FolderActivityFlow/index.ts
@@ -1,0 +1,1 @@
+export { default as FolderActivityFlow } from "./FolderActivityFlow";


### PR DESCRIPTION
## Related issue
closes #887 

## Result

<img width="1440" height="900" alt="스크린샷 2025-09-17 오후 6 07 55" src="https://github.com/user-attachments/assets/00f473d6-721c-486d-96e6-870f89338883" />

## Work list
- [ ] 해당 경로 내 기여자 첫 등장(?) 노드에 이름 라벨링
- [ ] folderActivityAnalyzer 유틸 함수로 초기 데이터 가공
- [ ] 클러스터 기반 X(시간)축 구현
- [ ] 기여자별 색상 구분 및 노드 크기 스케일링
- [ ] 폴더 드릴다운 (클릭으로 하위 폴더 탐색)
- [ ] 마우스 호버 효과 및 상세 툴팁 표시
- [ ] 헤더 Experiment 버튼 및 모달 인터페이스

## Discussion
- 현재 클러스터가 많아지는 상위 폴더일때, x축에 클러스터 이름 겹침, 이름 라벨링 겹침 문제가 있습니다.
- 스토리라인 차트 위치를 어디 잡을 지 결정되지 않아서 임의로 헤더에 Experiment 버튼을 추가하여 모달로 배치해두었습니다.
- 파일명 오른쪽으로 옮겨두었습니다.
---
## Task
- x축 기준 정리 -> 릴리즈 단위 분리
- 작업량 기준 (CLOC, 커밋수)수, 작업량 시각화(노드 크기)
- 같은 시점 여러 파일/폴더 작업시 노드 연결유무(엣지 번들링)
- 원하는 기여자 필터링, 드래그앤드롭 효과 추가
- 시각화 위치
- 노드 중첩 시 시각 처리



