### PR TITLE
FEAT[vibe]: 다국어처리

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -6,7 +6,10 @@
 	"module": "./src/index.ts",
 	"type": "module",
 	"scripts": {
-		"dev": "npx @smithery/cli dev"
+		"dev": "npx @smithery/cli dev",
+		"build": "npx tsc && copyfiles -u 1 \"src/locales/**/*\" dist/",
+		"build:clean": "rimraf dist && npm run build",
+		"watch": "npx tsc -w"
 	},
 	"keywords": [],
 	"author": "",
@@ -22,6 +25,8 @@
 	},
 	"devDependencies": {
 		"@smithery/cli": "^1.2.4",
+		"copyfiles": "^2.4.1",
+		"rimraf": "^6.0.1",
 		"tsx": "^4.19.4"
 	}
 }

--- a/packages/mcp/src/common/i18n.ts
+++ b/packages/mcp/src/common/i18n.ts
@@ -1,0 +1,83 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+class I18nManager {
+  private currentLocale = 'en';
+  private translations: Record<string, any> = {};
+  private fallbackTranslations: Record<string, any> = {};
+
+  constructor() {
+    this.loadFallback();
+  }
+
+  private loadFallback() {
+    try {
+      const fallbackPath = path.join(__dirname, '../locales/en.json');
+      const fallbackData = fs.readFileSync(fallbackPath, 'utf-8');
+      this.fallbackTranslations = JSON.parse(fallbackData);
+      this.translations = this.fallbackTranslations;
+    } catch (error) {
+      console.error('Failed to load fallback translations:', error);
+      this.fallbackTranslations = {};
+      this.translations = {};
+    }
+  }
+
+  setLocale(locale: string) {
+    this.currentLocale = locale;
+    
+    if (locale === 'en') {
+      this.translations = this.fallbackTranslations;
+      return;
+    }
+
+    try {
+      const localePath = path.join(__dirname, `../locales/${locale}.json`);
+      const localeData = fs.readFileSync(localePath, 'utf-8');
+      this.translations = JSON.parse(localeData);
+    } catch (error) {
+      console.error(`Locale '${locale}' not found, using English fallback`);
+      this.translations = this.fallbackTranslations;
+    }
+  }
+
+  t(key: string, params?: Record<string, any>): string {
+    const keys = key.split('.');
+    let value: any = this.translations;
+    
+    for (const k of keys) {
+      value = value?.[k];
+    }
+    
+    if (!value && this.currentLocale !== 'en') {
+      value = this.fallbackTranslations;
+      for (const k of keys) {
+        value = value?.[k];
+      }
+    }
+    
+    if (!value || typeof value !== 'string') {
+      return key;
+    }
+    
+    const stringValue = value as string;
+    
+    if (params) {
+      return stringValue.replace(/\{(\w+)\}/g, (match: string, param: string) => 
+        params[param]?.toString() ?? match
+      );
+    }
+    
+    return stringValue;
+  }
+
+  getCurrentLocale(): string {
+    return this.currentLocale;
+  }
+}
+
+export const I18n = new I18nManager();

--- a/packages/mcp/src/common/types.ts
+++ b/packages/mcp/src/common/types.ts
@@ -13,6 +13,7 @@ export interface FeatureImpactAnalyzerInputs {
   repoUrl: string;
   prNumber: number;
   githubToken: string;
+  locale?: string;
 }
 export interface ContributorRecommenderInputs {
   repoPath: string;
@@ -22,6 +23,7 @@ export interface ContributorRecommenderInputs {
   since?: string;
   until?: string;
   githubToken: string;
+  locale?: string;
 }
 
 export interface ContributorCandidate {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -49,7 +49,6 @@ export default function createStatelessServer({
     }
   );
 
-  // ping 툴 등록
   server.registerTool(
       "ping",
       {
@@ -62,7 +61,6 @@ export default function createStatelessServer({
       }
   );
 
-  // echo 툴 등록 (파라미터 받기 예제)
   server.registerTool(
       "echo",
       {
@@ -77,7 +75,6 @@ export default function createStatelessServer({
       }
   );
 
-  // bmi_calculator 툴 등록
   server.registerTool(
       "bmi_calculator",
       {

--- a/packages/mcp/src/locales/en.json
+++ b/packages/mcp/src/locales/en.json
@@ -1,0 +1,31 @@
+{
+  "errors": {
+    "pr_analysis": "PR analysis error:",
+    "path_analysis": "Error analyzing path '{path}':",
+    "branch_analysis": "Branch analysis error:",
+    "file_analysis": "Error analyzing file '{file}':",
+    "feature_impact_analysis": "Feature impact analysis error:",
+    "github_api_error": "GitHub API error:"
+  },
+  "notes": {
+    "pr_recommendation": "PR #{pr} based recommendation",
+    "path_recommendation": "Path based recommendation: {paths}",
+    "branch_recommendation": "Branch '{branch}' based recommendation",
+    "analysis_period": "Analysis period: {days} days",
+    "feature_scale": "Scale: {scale} (commits: {commits}, files: {files})",
+    "feature_dispersion": "Dispersion: {dispersion}",
+    "feature_chaos": "Chaos: {chaos}",
+    "feature_isolation": "Isolation: {isolation}",
+    "feature_coupling": "Coupling: {coupling}"
+  },
+  "messages": {
+    "no_contributors_found": "No contributors found for the specified criteria",
+    "analysis_complete": "Analysis completed successfully",
+    "loading_pr_data": "Loading PR data...",
+    "processing_commits": "Processing commits..."
+  },
+  "echo": {
+    "response": "Echo: {text}",
+    "greeting": "Hello! Your message was: {text}"
+  }
+}

--- a/packages/mcp/src/locales/ko.json
+++ b/packages/mcp/src/locales/ko.json
@@ -1,0 +1,31 @@
+{
+  "errors": {
+    "pr_analysis": "PR 분석 중 오류 발생:",
+    "path_analysis": "경로 '{path}' 분석 중 오류:",
+    "branch_analysis": "브랜치 분석 중 오류 발생:",
+    "file_analysis": "파일 '{file}' 분석 중 오류:",
+    "feature_impact_analysis": "기능 영향 분석 중 오류 발생:",
+    "github_api_error": "GitHub API 오류:"
+  },
+  "notes": {
+    "pr_recommendation": "PR #{pr} 기반 기여자 추천",
+    "path_recommendation": "경로 기반 추천: {paths}",
+    "branch_recommendation": "'{branch}' 브랜치 기반 추천",
+    "analysis_period": "분석 기간: 최근 {days}일",
+    "feature_scale": "규모: {scale} (커밋: {commits}개, 파일: {files}개)",
+    "feature_dispersion": "분산도: {dispersion}",
+    "feature_chaos": "혼돈도: {chaos}",
+    "feature_isolation": "격리도: {isolation}",
+    "feature_coupling": "결합도: {coupling}"
+  },
+  "messages": {
+    "no_contributors_found": "지정된 조건에 맞는 기여자를 찾을 수 없습니다",
+    "analysis_complete": "분석이 성공적으로 완료되었습니다",
+    "loading_pr_data": "PR 데이터를 로드하는 중...",
+    "processing_commits": "커밋을 처리하는 중..."
+  },
+  "echo": {
+    "response": "메아리: {text}",
+    "greeting": "(핑테스트) 안녕하세요! 받은 메시지: {text}"
+  }
+}

--- a/packages/mcp/src/tool/featureImpactAnalyzer.ts
+++ b/packages/mcp/src/tool/featureImpactAnalyzer.ts
@@ -1,5 +1,6 @@
 import { Octokit } from "@octokit/rest";
 import { GitHubUtils } from "../common/utils.js";
+import { I18n } from "../common/i18n.js";
 import type { FeatureImpactAnalyzerInputs } from "../common/types.js";
 
 class McpReportGenerator {
@@ -9,7 +10,11 @@ class McpReportGenerator {
   private owner: string;
   private repo: string;
 
-  constructor({ repoUrl, prNumber, githubToken }: FeatureImpactAnalyzerInputs) {
+  constructor({ repoUrl, prNumber, githubToken, locale }: FeatureImpactAnalyzerInputs) {
+    if (locale) {
+      I18n.setLocale(locale);
+    }
+    
     this.repoUrl = repoUrl;
     this.prNumber = prNumber;
     this.octokit = GitHubUtils.createGitHubAPIClient(githubToken);


### PR DESCRIPTION
## Related issue
#902 관련 멘토님 이슈 반영

## Result
다국어 처리 적용하였습니다
<img width="738" height="283" alt="image" src="https://github.com/user-attachments/assets/6463da41-badf-4255-b28a-128c5c920698" />

## Work list
- I18n을 통한 다국어 처리
- `npm run build`시에 locales 폴더 카피

## Discussion
