### PR TITLE
feat(engine): CSM Squash Merge 로직 개선

### DIFF
--- a/packages/analysis-engine/src/csm.spec.ts
+++ b/packages/analysis-engine/src/csm.spec.ts
@@ -63,12 +63,12 @@ describe("csm", () => {
   // Set mergedIntoStem flags based on merge structure
   // Node 8 (parents=[7, 13]) is merged into master at node 2
   // Node 11 (parents=[10, 16]) is merged into master at node 3
-  fakeCommitNodeDict.get("8")!.mergedIntoStem = "master";
-  fakeCommitNodeDict.get("11")!.mergedIntoStem = "master";
+  fakeCommitNodeDict.get("8")!.mergedIntoBaseStem = "master";
+  fakeCommitNodeDict.get("11")!.mergedIntoBaseStem = "master";
   // Node 13 is merged into sub1 at node 8
-  fakeCommitNodeDict.get("13")!.mergedIntoStem = "sub1";
+  fakeCommitNodeDict.get("13")!.mergedIntoBaseStem = "sub1";
   // Node 16 is merged into sub1 at node 11
-  fakeCommitNodeDict.get("16")!.mergedIntoStem = "sub1";
+  fakeCommitNodeDict.get("16")!.mergedIntoBaseStem = "sub1";
 
   describe("buildCSM", () => {
     let csmDict: CSMDictionary;
@@ -150,12 +150,12 @@ describe("csm", () => {
     // Set mergedIntoStem flags for sub1 as base branch
     // Node 8 (parents=[7, 13]) is merged into sub1 at itself
     // Node 11 (parents=[10, 16]) is merged into sub1 at itself
-    fakeCommitNodeDictWithSub1.get("8")!.mergedIntoStem = "sub1";
-    fakeCommitNodeDictWithSub1.get("11")!.mergedIntoStem = "sub1";
+    fakeCommitNodeDictWithSub1.get("8")!.mergedIntoBaseStem = "sub1";
+    fakeCommitNodeDictWithSub1.get("11")!.mergedIntoBaseStem = "sub1";
     // Node 13 is merged into sub1 at node 8
-    fakeCommitNodeDictWithSub1.get("13")!.mergedIntoStem = "sub1";
+    fakeCommitNodeDictWithSub1.get("13")!.mergedIntoBaseStem = "sub1";
     // Node 16 is merged into sub1 at node 11
-    fakeCommitNodeDictWithSub1.get("16")!.mergedIntoStem = "sub1";
+    fakeCommitNodeDictWithSub1.get("16")!.mergedIntoBaseStem = "sub1";
 
     beforeAll(() => {
       csmDict = buildCSMDict(fakeCommitNodeDictWithSub1, fakeStemDictWithSub1, "sub1");
@@ -253,9 +253,9 @@ describe("csm", () => {
     );
 
     // Set mergedIntoStem flags
-    octopusCommitNodeDict.get("3")!.mergedIntoStem = "master";
-    octopusCommitNodeDict.get("5")!.mergedIntoStem = "master";
-    octopusCommitNodeDict.get("7")!.mergedIntoStem = "master";
+    octopusCommitNodeDict.get("3")!.mergedIntoBaseStem = "master";
+    octopusCommitNodeDict.get("5")!.mergedIntoBaseStem = "master";
+    octopusCommitNodeDict.get("7")!.mergedIntoBaseStem = "master";
 
     it("should handle octopus merge with 4 parents", () => {
       const csmDict = buildCSMDict(octopusCommitNodeDict, octopusStemDict, "master");
@@ -379,7 +379,7 @@ describe("csm", () => {
       new Map<string, CommitNode>()
     );
 
-    edgeCaseCommitNodeDict.get("2")!.mergedIntoStem = "master";
+    edgeCaseCommitNodeDict.get("2")!.mergedIntoBaseStem = "master";
 
     it("should filter out non-existent parent commits", () => {
       const csmDict = buildCSMDict(edgeCaseCommitNodeDict, edgeCaseStemDict, "master");

--- a/packages/analysis-engine/src/csm.spec.ts
+++ b/packages/analysis-engine/src/csm.spec.ts
@@ -60,6 +60,16 @@ describe("csm", () => {
     return dict;
   }, new Map<string, CommitNode>());
 
+  // Set mergedIntoStem flags based on merge structure
+  // Node 8 (parents=[7, 13]) is merged into master at node 2
+  // Node 11 (parents=[10, 16]) is merged into master at node 3
+  fakeCommitNodeDict.get("8")!.mergedIntoStem = "master";
+  fakeCommitNodeDict.get("11")!.mergedIntoStem = "master";
+  // Node 13 is merged into sub1 at node 8
+  fakeCommitNodeDict.get("13")!.mergedIntoStem = "sub1";
+  // Node 16 is merged into sub1 at node 11
+  fakeCommitNodeDict.get("16")!.mergedIntoStem = "sub1";
+
   describe("buildCSM", () => {
     let csmDict: CSMDictionary;
 
@@ -127,8 +137,28 @@ describe("csm", () => {
       makeFakeStemTuple("sub2", [12, 13, 14, 15, 16].reverse().map(String)),
     ]);
 
+    const fakeCommitNodeDictWithSub1: Map<string, CommitNode> = Array.from(fakeStemDictWithSub1.entries()).reduce(
+      (dict, [, stem]) => {
+        stem.nodes.forEach((commitNode) => {
+          dict.set(commitNode.commit.id, commitNode);
+        });
+        return dict;
+      },
+      new Map<string, CommitNode>()
+    );
+
+    // Set mergedIntoStem flags for sub1 as base branch
+    // Node 8 (parents=[7, 13]) is merged into sub1 at itself
+    // Node 11 (parents=[10, 16]) is merged into sub1 at itself
+    fakeCommitNodeDictWithSub1.get("8")!.mergedIntoStem = "sub1";
+    fakeCommitNodeDictWithSub1.get("11")!.mergedIntoStem = "sub1";
+    // Node 13 is merged into sub1 at node 8
+    fakeCommitNodeDictWithSub1.get("13")!.mergedIntoStem = "sub1";
+    // Node 16 is merged into sub1 at node 11
+    fakeCommitNodeDictWithSub1.get("16")!.mergedIntoStem = "sub1";
+
     beforeAll(() => {
-      csmDict = buildCSMDict(fakeCommitNodeDict, fakeStemDictWithSub1, "sub1");
+      csmDict = buildCSMDict(fakeCommitNodeDictWithSub1, fakeStemDictWithSub1, "sub1");
     });
 
     it("has squash-commits", () => {

--- a/packages/analysis-engine/src/csm.ts
+++ b/packages/analysis-engine/src/csm.ts
@@ -50,7 +50,7 @@ const buildCSMNode = (baseCommitNode: CommitNode, commitDict: CommitDict, stemDi
     // First, find the end index (before next mergedIntoStem or end of stem)
     let endIndex = squashStem.nodes.length - 1;
     for (let i = squashStartNodeIndex + 1; i < squashStem.nodes.length; i++) {
-      if (squashStem.nodes[i].mergedIntoStem) {
+      if (squashStem.nodes[i].mergedIntoBaseStem) {
         endIndex = i - 1;
         break;
       }

--- a/packages/analysis-engine/src/stem.ts
+++ b/packages/analysis-engine/src/stem.ts
@@ -19,6 +19,7 @@ export function getStemNodes(
         if (idx === 0) return;
         const parentNode = commitDict.get(parent);
         if (parentNode) {
+          parentNode.mergedIntoStem = stemId;
           q.push(parentNode);
         }
       }, q);

--- a/packages/analysis-engine/src/stem.ts
+++ b/packages/analysis-engine/src/stem.ts
@@ -19,7 +19,7 @@ export function getStemNodes(
         if (idx === 0) return;
         const parentNode = commitDict.get(parent);
         if (parentNode) {
-          parentNode.mergedIntoStem = stemId;
+          parentNode.mergedIntoBaseStem = stemId;
           q.push(parentNode);
         }
       }, q);

--- a/packages/analysis-engine/src/types/CommitNode.ts
+++ b/packages/analysis-engine/src/types/CommitNode.ts
@@ -1,8 +1,10 @@
 import type { CommitRaw } from "./CommitRaw";
 
 export interface CommitNode {
-  // 순회 이전에는 stemId가 존재하지 않음.
+  // stemId does not exist before traversal.
   stemId?: string;
+  // ID of the stem this node was merged into (for merge parents)
+  mergedIntoStem?: string;
   commit: CommitRaw;
 }
 

--- a/packages/analysis-engine/src/types/CommitNode.ts
+++ b/packages/analysis-engine/src/types/CommitNode.ts
@@ -4,7 +4,7 @@ export interface CommitNode {
   // stemId does not exist before traversal.
   stemId?: string;
   // ID of the stem this node was merged into (for merge parents)
-  mergedIntoStem?: string;
+  mergedIntoBaseStem?: string;
   commit: CommitRaw;
 }
 


### PR DESCRIPTION
## 🎯 목적

최신순으로 CSM(Commit Summary Model) 빌드 시 squash merge 로직을 개선하여 over-squashing 문제를 해결합니다. 머지 부모 노드를 정확하게 추적하고, 적절한 범위까지만 squash가 이루어지도록 로직을 수정했습니다.

## 📋 주요 변경사항

### 1. CommitNode에 mergedIntoStem 플래그 추가
- 머지 부모 노드가 어느 stem으로 병합되었는지 추적하는 `mergedIntoStem` 필드 추가
- 이를 통해 향후 머지 포인트를 정확하게 식별 가능

### 2. Squash 범위 제한 로직 구현
- 기존: stem의 끝까지 모든 노드를 squash (over-squashing 발생)
- 개선: 다음 `mergedIntoStem` 노드 직전까지만 squash
- 이후 머지를 위해 남겨둬야 할 커밋을 보호

### 3. 커밋 정렬 순서 수정
- 시간순 정렬: 오래된 커밋 → 최신 커밋 (올바른 순서)
- `commit.sequence` 기준 오름차순 정렬 적용

### 4. 테스트 케이스 업데이트
- 모든 테스트 데이터에 `mergedIntoStem` 플래그 명시
- master 브랜치와 sub1 브랜치 케이스 모두 업데이트
- 머지 구조를 명확하게 표현하여 테스트 신뢰성 향상

## 📊 영향 범위

### 변경된 파일 (4개)
- `packages/analysis-engine/src/csm.ts` - CSM 빌드 로직 개선
- `packages/analysis-engine/src/csm.spec.ts` - 테스트 케이스 업데이트
- `packages/analysis-engine/src/stem.ts` - mergedIntoStem 플래그 설정
- `packages/analysis-engine/src/types/CommitNode.ts` - 타입 정의 추가

## 🧪 테스트

### 추가된 테스트
- `mergedIntoStem` 플래그 검증 테스트
- 머지 구조 정확성 테스트
- master 및 sub1 브랜치 기반 CSM 빌드 테스트

### 테스트 커버리지
- 기존 테스트 모두 통과
- 새로운 플래그 로직 테스트 추가

## 🔗 관련 이슈

- Closes #913 

## 📝 추가 노트

### Before
```
Stem A: [C1, C2, C3, C4, C5]  <- 모두 squash (over-squashing)
             ↓
          C3가 다음 머지의 부모
```

### After
```
Stem A: [C1, C2, C3] [C4, C5]
             ↓         ↓
          squash    보호됨 (다음 머지용)
```

이 변경으로 CSM 생성 시 올바른 커밋 범위만 squash되어, 시각화의 정확성이 향상됩니다.