### PR TITLE
feat: add pathDistribution (histogram/percentiles) and long-tail detection via MAD

### DIFF
--- a/packages/mcp/src/tool/featureImpactAnalyzer.ts
+++ b/packages/mcp/src/tool/featureImpactAnalyzer.ts
@@ -3,7 +3,99 @@ import { GitHubUtils } from "../common/utils.js";
 import { I18n } from "../common/i18n.js";
 import type { FeatureImpactAnalyzerInputs } from "../common/types.js";
 
-const MAX_HEATMAP_ITEMS = 12;
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  const ret: R[] = new Array(items.length);
+  let i = 0;
+  const runners = new Array(Math.min(concurrency, items.length)).fill(0).map(async () => {
+    while (true) {
+      const idx = i++;
+      if (idx >= items.length) break;
+      ret[idx] = await worker(items[idx], idx);
+    }
+  });
+  await Promise.all(runners);
+  return ret;
+}
+
+async function retry<T>(fn: () => Promise<T>, tries = 3, baseMs = 500): Promise<T> {
+  let lastErr: any;
+  for (let i=0; i<tries; i++) {
+    try { return await fn(); }
+    catch (e:any) {
+      lastErr = e;
+      const ms = baseMs * Math.pow(2, i);
+      await new Promise(r => setTimeout(r, ms));
+    }
+  }
+  throw lastErr;
+}
+
+function percentiles(sorted: number[], ps = [0.05,0.25,0.5,0.75,0.95]) {
+  const out: Record<string, number> = {};
+  for (const p of ps) out[`p${Math.round(p*100)}`] = quantile(sorted, p);
+  out.min = sorted[0] ?? NaN;
+  out.max = sorted[sorted.length - 1] ?? NaN;
+  out.mean = sorted.length ? sorted.reduce((a, b) => a + b, 0) / sorted.length : NaN;
+  return out;
+}
+
+function histogram(sorted: number[]) {
+  if (sorted.length < 2) return { bins: [] as number[], counts: [] as number[] };
+  const q25 = quantile(sorted, 0.25);
+  const q75 = quantile(sorted, 0.75);
+  const iqr = q75 - q25 || 1e-9;
+  const binWidth = (2 * iqr) / Math.cbrt(sorted.length);
+  const min = sorted[0], max = sorted[sorted.length - 1];
+  const rawBins = Math.max(1, Math.ceil((max - min) / binWidth));
+  const binCount = Math.max(10, Math.min(rawBins, 80));
+  const bw = (max - min) / binCount || 1;
+  const bins = Array.from({ length: binCount }, (_, i) => min + i * bw);
+  const counts = new Array(binCount).fill(0);
+  for (const v of sorted) {
+    let idx = Math.floor((v - min) / bw);
+    if (idx >= binCount) idx = binCount - 1;
+    if (idx < 0) idx = 0;
+    counts[idx]++;
+  }
+  return { bins, counts };
+}
+
+function robustZScores(values: number[]) {
+  const arr = values.filter(Number.isFinite);
+  if (!arr.length) return [];
+  const sorted = arr.slice().sort((a, b) => a - b);
+  const med = quantile(sorted, 0.5);
+  const absDevs = arr.map(v => Math.abs(v - med)).sort((a, b) => a - b);
+  const mad = quantile(absDevs, 0.5) || 1e-9;
+  return arr.map(v => (v - med) / (1.4826 * mad));
+}
+
+function quantile(sorted: number[], q: number) {
+  if (!sorted.length) return NaN;
+  const pos = (sorted.length - 1) * q;
+  const base = Math.floor(pos);
+  const rest = pos - base;
+  if (sorted[base + 1] !== undefined) {
+    return sorted[base] + rest * (sorted[base + 1] - sorted[base]);
+  }
+  return sorted[base];
+}
+
+function thresholdsP05P95(valuesOrSorted: number[], alreadySorted=false) {
+  const arr = alreadySorted ? valuesOrSorted : valuesOrSorted.filter(Number.isFinite).slice().sort((a,b)=>a-b);
+  return { p05: quantile(arr, 0.05), p95: quantile(arr, 0.95), n: arr.length };
+}
+
+function rateByP05P95(v: number, p05: number, p95: number) {
+  if (!Number.isFinite(v) || !Number.isFinite(p05) || !Number.isFinite(p95)) return "Unknown" as const;
+  if (v >= p95) return "High" as const;
+  if (v <= p05) return "Low" as const;
+  return "Normal" as const;
+}
 
 class McpReportGenerator {
   private repoUrl: string;
@@ -31,15 +123,14 @@ class McpReportGenerator {
   }
 
   private async _getGitDataForPR(owner: string, repo: string, prNumber: number) {
-    const commits = await this.octokit.paginate(
-      this.octokit.pulls.listCommits,
-      { owner, repo, pull_number: prNumber, per_page: 100 }
-    );
-
-    const files = await this.octokit.paginate(
-      this.octokit.pulls.listFiles,
-      { owner, repo, pull_number: prNumber, per_page: 100 }
-    );
+    const [commits, files] = await Promise.all([
+      this.octokit.paginate(this.octokit.pulls.listCommits, {
+        owner, repo, pull_number: prNumber, per_page: 100
+      }),
+      this.octokit.paginate(this.octokit.pulls.listFiles, {
+        owner, repo, pull_number: prNumber, per_page: 100
+      }),
+    ]);
 
     const prFilesAll = files.map(f => f.filename);
 
@@ -69,39 +160,149 @@ class McpReportGenerator {
 
   private _calculateIsolation(commits: any[], prMetadata: any): number {
     if (!commits?.length) return 0;
-    const firstCommitDate = new Date(commits[commits.length - 1]?.authorDate);
-    const prCreationDate = new Date(prMetadata.created_at);
-    const ms = prCreationDate.getTime() - firstCommitDate.getTime();
-    return ms > 0 ? ms / (1000 * 60 * 60 * 24) : 0;
+    const tsList = commits
+      .map(c => new Date(c.authorDate).getTime())
+      .filter(n => Number.isFinite(n));
+    if (!tsList.length) return 0;
+    const firstCommitTs = Math.min(...tsList);
+    const prCreationTs = new Date(prMetadata.created_at).getTime();
+    const d = (prCreationTs - firstCommitTs) / (1000 * 60 * 60 * 24);
+    return d > 0 ? d : 0;
   }
 
   private _calculateLag(prMetadata: any): number {
     if (!prMetadata.merged_at) return 0;
     const createdAt = new Date(prMetadata.created_at).getTime();
     const mergedAt = new Date(prMetadata.merged_at).getTime();
-    return (mergedAt - createdAt) / (1000 * 60 * 60);
+    const d = (mergedAt - createdAt) / (1000 * 60 * 60 * 24);
+    return d > 0 ? d : 0;
   }
 
   private _calculateCoupling(commits: any[]): number {
-    const co = new Map<string, Set<string>>();
-    for (const c of commits) {
-      const files = c.changedFiles ?? [];
-      for (let i = 0; i < files.length; i++) {
-        for (let j = i + 1; j < files.length; j++) {
-          const a = files[i], b = files[j];
-          if (!co.has(a)) co.set(a, new Set());
-          if (!co.has(b)) co.set(b, new Set());
-          co.get(a)!.add(b);
-          co.get(b)!.add(a);
-        }
-      }
+    const allFiles = Array.from(new Set(commits.flatMap(c => c.changedFiles ?? [])));
+    const N = allFiles.length;
+    const MAX_FILES = 400;
+
+    if (N > MAX_FILES) {
+      const step = Math.ceil(N / MAX_FILES);
+      const sampled = allFiles.filter((_, i) => i % step === 0);
+      return this._pairCount(sampled.length);
     }
-    return co.size;
+    return this._pairCount(N);
   }
 
-  async generate() {
+  private _pairCount(n: number) {
+    return (n * (n - 1)) / 2;
+  }
+
+  private _buildPathDistributionAndLongTail(files: string[], topN = 12) {
+    const bucket = new Map<string, number>();
+    for (const f of files) {
+      if (!f) continue;
+      const parts = f.split("/").filter(Boolean);
+      let prefix = "";
+      for (let i = 0; i < parts.length; i++) {
+        prefix = prefix ? `${prefix}/${parts[i]}` : parts[i];
+        const w = i + 1;
+        bucket.set(prefix, (bucket.get(prefix) ?? 0) + w);
+      }
+    }
+
+    const all = Array.from(bucket.entries());
+    const scores = all.map(([, s]) => s);
+
+    const top = all.slice().sort((a, b) => b[1] - a[1]).slice(0, topN);
+    const max = top[0]?.[1] ?? 1;
+    const pathHeatmapTop = top.map(([path, score]) => ({
+      path,
+      impact_score: Math.round((score / max) * 100),
+      raw_score: score,
+    }));
+
+    const sortedScores = scores.slice().sort((a,b)=>a-b);
+    const pathDistribution = {
+      summary: percentiles(sortedScores),
+      histogram: histogram(sortedScores),
+    };
+
+    const { p95 } = thresholdsP05P95(sortedScores, true);
+    const zs = robustZScores(scores);
+
+    const p95List = all
+      .filter(([, s]) => Number.isFinite(p95) && s >= (p95 as number))
+      .map(([path, score]) => ({ path, score, rule: "p95+" as const }));
+
+    const madList = all
+      .map(([path, score], i) => ({ path, score, z: Math.abs(zs[i] ?? 0) }))
+      .filter(x => x.z >= 3)
+      .map(({ path, score }) => ({ path, score, rule: "MAD|z>=3" as const }));
+
+    const seen = new Set<string>();
+    const pathLongTail = [...p95List, ...madList]
+      .filter(x => (seen.has(x.path) ? false : (seen.add(x.path), true)))
+      .sort((a, b) => b.score - a.score);
+
+    return { pathHeatmapTop, pathDistribution, pathLongTail };
+  }
+
+  private async _collectHistoryMetrics(months = 6, limit = 200, concurrency = 8) {
+    const since = new Date();
+    since.setMonth(since.getMonth() - months);
+
+    const picks: any[] = [];
+    for await (const page of this.octokit.paginate.iterator(this.octokit.pulls.list, {
+      owner: this.owner,
+      repo: this.repo,
+      state: "closed",
+      sort: "updated",
+      direction: "desc",
+      per_page: 100,
+    })) {
+      for (const p of page.data) {
+        if (p.merged_at && new Date(p.created_at) >= since) {
+          picks.push(p);
+          if (picks.length >= limit) break;
+        }
+      }
+      if (picks.length >= limit) break;
+    }
+
+    const hist = await mapWithConcurrency(picks, concurrency, async (pr: any) => {
+      const { commits } = await retry(
+        () => this._getGitDataForPR(this.owner, this.repo, pr.number)
+      );
+      return {
+        scale: this._calculateScale(commits),
+        dispersion: this._calculateDispersion(commits),
+        chaos: this._calculateChaos(commits),
+        isolation: this._calculateIsolation(commits, { created_at: pr.created_at }),
+        lag: this._calculateLag({ created_at: pr.created_at, merged_at: pr.merged_at }),
+        coupling: this._calculateCoupling(commits),
+      };
+    });
+
+    return hist;
+  }
+
+  private _rateWithP05P95(current: number, samples: number[]) {
+    const { p05, p95, n } = thresholdsP05P95(samples);
+    if (!Number.isFinite(p05) || !Number.isFinite(p95) || n < 20) {
+      const sorted = samples.slice().sort((a, b) => a - b);
+      const min = sorted[0], max = sorted[sorted.length - 1];
+      if (!Number.isFinite(min) || !Number.isFinite(max)) return "Unknown" as const;
+      if (current <= min) return "Low" as const;
+      if (current >= max) return "High" as const;
+      return "Normal" as const;
+    }
+    return rateByP05P95(current, p05, p95);
+  }
+
+  async generateWithOutlierRatings() {
     const prMetadata = await this._fetchPRMetadata(this.owner, this.repo, this.prNumber);
-    const { commits } = await this._getGitDataForPR(this.owner, this.repo, this.prNumber);
+
+    const { commits, files } = await retry(
+      () => this._getGitDataForPR(this.owner, this.repo, this.prNumber)
+    );
 
     const metrics = {
       scale: this._calculateScale(commits),
@@ -112,71 +313,33 @@ class McpReportGenerator {
       coupling: this._calculateCoupling(commits),
     };
 
+    const hist = await this._collectHistoryMetrics(6, 200, 8);
+
+    const rating = {
+      scale: this._rateWithP05P95(metrics.scale, hist.map(h => h.scale)),
+      dispersion: this._rateWithP05P95(metrics.dispersion, hist.map(h => h.dispersion)),
+      chaos: this._rateWithP05P95(metrics.chaos, hist.map(h => h.chaos)),
+      isolation: this._rateWithP05P95(metrics.isolation, hist.map(h => h.isolation)),
+      lag: this._rateWithP05P95(metrics.lag, hist.map(h => h.lag)),
+      coupling: this._rateWithP05P95(metrics.coupling, hist.map(h => h.coupling)),
+    };
+
+    const { pathHeatmapTop, pathDistribution, pathLongTail } =
+      this._buildPathDistributionAndLongTail(files, 12);
+
     return {
       prInfo: { repoUrl: this.repoUrl, prNumber: this.prNumber },
       metrics,
+      rating,
       prMetadata,
-      commits,    
+      pathHeatmapTop,
+      pathDistribution,
+      pathLongTail,
     };
   }
 }
 
 export async function analyzeFeatureImpact(inputs: FeatureImpactAnalyzerInputs) {
-  const { repoUrl, prNumber } = inputs;
-  const rateScale = (v: number) => (v >= 20 ? "Very Large" : v >= 10 ? "Large" : v >= 5 ? "Medium" : "Small");
-  const rateDispersion = (v: number) => (v >= 6 ? "Very High" : v >= 4 ? "High" : v >= 2 ? "Moderate" : "Low");
-  const rateChaos = (r: number) => (r >= 0.5 ? "High" : r >= 0.25 ? "Moderate" : "Low");
-  const rateIsolationDays = (d: number) => (d >= 14 ? "Long" : d >= 7 ? "Normal" : "Short");
-  const rateReviewLagDays = (d: number) => (d >= 5 ? "Slow" : d >= 2 ? "Normal" : "Fast");
-
-  const reportGenerator = new McpReportGenerator(inputs);
-  const report = await reportGenerator.generate();
-  const { metrics, prMetadata, commits } = report;
-
-  const scale = Number(metrics.scale ?? 0);
-  const dispersion = Number(metrics.dispersion ?? 0);
-  const chaosRatio = Number(((metrics.chaos ?? 0) / 100).toFixed(2));
-  const isolationDays = Number(Number(metrics.isolation ?? 0).toFixed(1));
-  const reviewLagDays = Number(((Number(metrics.lag ?? 0) / 24)).toFixed(1));
-
-  const changedFiles = Array.from(
-    new Set((commits ?? []).flatMap((c: any) => c.changedFiles ?? []))
-  );
-
-  const bucket = new Map<string, number>();
-  for (const f of changedFiles) {
-    const parts = f.split("/").filter(Boolean);
-    for (let i = parts.length; i >= 1; i--) {
-      const key = parts.slice(0, i).join("/");
-      const w = i;
-      bucket.set(key, (bucket.get(key) ?? 0) + w);
-    }
-  }
-
-  const top = Array.from(bucket.entries())
-  .sort((a, b) => b[1] - a[1])
-  .slice(0, MAX_HEATMAP_ITEMS);
-
-  const max = top[0]?.[1] ?? 1;
-  const heatmap = top.map(([path, score]) => ({
-    path,
-    impact_score: Math.round((score / max) * 100),
-  }));
-
-  return {
-    metadata: { analysis_type: "feature_impact_analysis", pull_request_id: prNumber },
-    pull_request_info: {
-      title: prMetadata?.title ?? "",
-      author: prMetadata?.user?.login ?? "",
-      url: prMetadata?.html_url ?? repoUrl,
-    },
-    impact_metrics: {
-      scale: { value: scale, unit: "commits", rating: rateScale(scale) },
-      dispersion: { value: dispersion, unit: "modules", rating: rateDispersion(dispersion) },
-      chaos: { value: chaosRatio, unit: "ratio", rating: rateChaos(chaosRatio) },
-      isolation_period_days: { value: isolationDays, rating: rateIsolationDays(isolationDays) },
-      review_lag_days: { value: reviewLagDays, rating: rateReviewLagDays(reviewLagDays) },
-    },
-    impact_heatmap_data: heatmap
-  };
+  const gen = new McpReportGenerator(inputs);
+  return await gen.generateWithOutlierRatings();
 }


### PR DESCRIPTION
## Related issue
Issue #886 
PR #891, #909 코드 추가 및 리팩토링 작업

## Result
코드 리뷰에서 반영하여
경로 임팩트 스코어(접두사 누적 + 깊이 가중치)에 대해 두 가지 기준을 결합해 롱테일 후보를 선정하도록 수정하였습니다!!

그리고, 메트릭 기준도 상위5%, 하위5% 기준으로 정하여 수정해보았습니다!

고정 임계값 대신, 최근 6개월간 병합된 PR(최대 200건) 에서 수집한 표본 분포의 하위 5%(p05) / 상위 5%(p95) 를 경계로 사용해 현재 PR을 Low / Normal / High 로 분류합니다.

### 롱테일/이상치 탐지 기준

경로 임팩트 스코어(접두사 누적 + 깊이 가중치)에 대해 두 가지 기준을 결합해 롱테일 후보를 선정합니다.

1. 상위 분위 기준: 전체 경로 스코어의 p95 이상
2. 로버스트 z-score 기준: MAD 기반 z-score에서 |z| ≥ 3
3. robustZScores(values) 구현: 중앙값/ MAD 기반 → 극단치에 둔감(안정성↑)
→ 두 기준의 합집합을 pathLongTail 로 반환(중복 제거 후 스코어 내림차순 정렬)

### 분포 요약/히스토그램 산출

pathDistribution은 경로 스코어 전체의 분포를 요약해 시각화/판단 근거를 제공합니다.

1. 분위수 요약: percentiles → p05, p25, p50, p75, p95, min, max, mean
2. 히스토그램: histogram → IQR(사분위범위) 기반 Freedman–Diaconis 변형으로 bin 너비를 결정
3. 최소 10, 최대 80 bins로 캡(노이즈/해상도 균형)

### 예외/폴백 및 파라미터

1. 표본 희소(n < 20): 분위 기반 신뢰 낮음 → min/max 폴백
2. 대형 PR 결합도: 유니크 파일 N > 400 → 균등 샘플링 후 nC2 상한 계산(시간·메모리 안정성)
3. 기본 파라미터(코드 상수):
- 히스토리 기간: months=6
- 샘플 상한: limit=200
- 동시성: concurrency=8
- 롱테일 z 경계: |z| >= 3
- 롱테일 분위 경계: p95+

## Work list
- [ ] 시각화 추가
- [ ] tool description 자세하게 수정
## Discussion
