### PR TITLE
fix(view): ClusterNode 선택 시 FileIcicleSummary 중복 렌더링 수정

### DIFF
--- a/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
+++ b/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
@@ -116,7 +116,7 @@ const drawIcicleTree = async ($target: RefObject<SVGSVGElement>, data: FileChang
 };
 
 const destroyIcicleTree = ($target: RefObject<SVGSVGElement>) => {
-  d3.select($target.current).selectAll("svg").remove();
+  d3.select($target.current).selectAll("g").remove();
 };
 
 const FileIcicleSummary = () => {


### PR DESCRIPTION
## 🎯 목적

Statistics 패널에서 사용자가 ClusterNode를 선택/해제할 때 File Summary (Icicle Tree) 시각화가 중복되어 표시되는 버그를 수정합니다.

## 🐛 문제

사용자가 ClusterNode를 클릭하여 선택하거나 해제할 때, File Summary 차트가 여러 번 겹쳐서 렌더링되어 혼란스러운 화면을 보여주는 문제가 발생했습니다.

## 📋 주요 변경사항

### 근본 원인
- `destroyIcicleTree` cleanup 함수가 잘못된 D3 셀렉터(`'svg'`)를 사용
- `drawIcicleTree`는 SVG 내부에 `<g>` 요소들을 생성하지만, cleanup 함수는 존재하지 않는 `<svg>` 자식 요소를 선택하려고 시도
- 이전 `<g>` 요소들이 제거되지 않아 새로운 요소들이 위에 추가되면서 중복 렌더링 발생

### 해결 방법
- `destroyIcicleTree` 함수의 D3 셀렉터를 `'svg'`에서 `'g'`로 변경
- DOM 요소들이 재렌더링 전에 올바르게 제거되도록 수정

## 📊 영향 범위

**수정된 파일:**
- `packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx` (1줄 변경)

**영향받는 컴포넌트:**
- FileIcicleSummary 컴포넌트
- Statistics 패널 시각화

**사용자 영향:**
- File Summary 차트의 시각적 버그 수정
- ClusterNode 인터랙션 시 사용자 경험 개선

## 🧪 테스트

- [x] 기존 테스트 통과 (`FileIcicleSummary.util.test.ts` - 6/6 통과)
- [ ] 수동 테스트: ClusterNode 선택/해제
- [ ] 시각적 회귀 테스트 권장

## ✅ 체크리스트

- [x] 코드가 프로젝트 컨벤션을 따름
- [x] 셀프 리뷰 완료
- [x] 기존 테스트 통과
- [ ] 수동 테스트 완료
- [ ] Breaking changes 없음
- [ ] 문서 업데이트 (필요시)

## 🔗 관련 이슈

Closes #919 

## 📝 추가 정보

단일 라인 변경으로 근본 원인을 해결하는 최소한의 수정입니다. React의 cleanup 함수가 재렌더링 전에 D3로 생성된 모든 DOM 요소를 올바르게 제거하도록 보장합니다.
