### PR TITLE
refactor(view): processMessage 함수 내 GIthubIssueLink 컴포넌트 분리

### DIFF
--- a/packages/view/src/components/@common/GithubIssueLink/GithubIssueLink.scss
+++ b/packages/view/src/components/@common/GithubIssueLink/GithubIssueLink.scss
@@ -1,0 +1,21 @@
+@import "styles/app";
+
+.commit-message__issue-link {
+  color: var(--color-primary);
+  text-decoration: none;
+  font-weight: 500;
+  padding: 0.125rem 0.25rem;
+  border-radius: 0.125rem;
+  background-color: rgba(224, 96, 145, 0.1);
+  transition: all 0.2s ease-in-out;
+
+  &:hover {
+    background-color: rgba(224, 96, 145, 0.2);
+    text-decoration: underline;
+    transform: translateY(-1px);
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+}

--- a/packages/view/src/components/@common/GithubIssueLink/GithubIssueLink.tsx
+++ b/packages/view/src/components/@common/GithubIssueLink/GithubIssueLink.tsx
@@ -1,0 +1,23 @@
+import cn from "classnames";
+
+import type { GithubIssueLinkProps } from "./GithubIssueLink.type";
+import "./GithubIssueLink.scss";
+
+const GithubIssueLink = ({ owner, repo, issueNumber, className, ...rest }: GithubIssueLinkProps) => {
+  const issueLink = `https://github.com/${owner}/${repo}/issues/${issueNumber}`;
+
+  return (
+    <a
+      href={issueLink}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn("commit-message__issue-link", className)}
+      title={`GitHub Issue #${issueNumber}`}
+      {...rest}
+    >
+      #{issueNumber}
+    </a>
+  );
+};
+
+export default GithubIssueLink;

--- a/packages/view/src/components/@common/GithubIssueLink/GithubIssueLink.type.ts
+++ b/packages/view/src/components/@common/GithubIssueLink/GithubIssueLink.type.ts
@@ -1,0 +1,8 @@
+import type { ComponentPropsWithoutRef } from "react";
+
+export interface GithubIssueLinkProps
+  extends Omit<ComponentPropsWithoutRef<"a">, "href" | "target" | "rel" | "children"> {
+  owner: string;
+  repo: string;
+  issueNumber: string;
+}

--- a/packages/view/src/components/@common/GithubIssueLink/index.ts
+++ b/packages/view/src/components/@common/GithubIssueLink/index.ts
@@ -1,0 +1,1 @@
+export { default as GithubIssueLink } from "./GithubIssueLink";

--- a/packages/view/src/components/Detail/Detail.scss
+++ b/packages/view/src/components/Detail/Detail.scss
@@ -76,7 +76,7 @@
         gap: 0.625rem;
         width: 100%;
         flex: 1;
-        margin-left: 0.125rem; // 아주 미세한 여백
+        margin-left: 0.125rem;
         min-width: 0;
         padding-top: 0.3rem;
         padding-right: 3.125rem;
@@ -90,7 +90,6 @@
             gap: 0.75rem;
             margin-bottom: 0.5rem;
 
-            // 아바타를 맨 앞에 배치
             .author {
               width: 1.5rem;
               height: 1.5rem;
@@ -176,7 +175,7 @@
       }
 
       .commit-item__right {
-        display: none; // 오른쪽 레이아웃 숨김
+        display: none;
       }
     }
   }

--- a/packages/view/src/components/Detail/Detail.scss
+++ b/packages/view/src/components/Detail/Detail.scss
@@ -194,23 +194,3 @@
     color: $color-light-gray;
   }
 }
-
-        .commit-message__issue-link {
-          color: var(--color-primary);
-          text-decoration: none;
-          font-weight: 500;
-          padding: 0.125rem 0.25rem;
-          border-radius: 0.125rem;
-          background-color: rgba(224, 96, 145, 0.1);
-          transition: all 0.2s ease-in-out;
-
-          &:hover {
-            background-color: rgba(224, 96, 145, 0.2);
-            text-decoration: underline;
-            transform: translateY(-1px);
-          }
-
-          &:active {
-            transform: translateY(0);
-          }
-        }

--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -11,8 +11,9 @@ import {
 } from "@mui/icons-material";
 import { Tooltip } from "@mui/material";
 
-import { Author } from "components/@common/Author";
 import { useGithubInfo, useDataStore } from "store";
+import { Author } from "components/@common/Author";
+import { GithubIssueLink } from "components/@common/GithubIssueLink";
 
 import { useCommitListHide } from "./Detail.hook";
 import { getCommitListDetail } from "./Detail.util";
@@ -57,21 +58,15 @@ const Detail = ({ clusterId, authSrcMap }: DetailProps) => {
           parts.push(message.slice(lastIndex, match.index));
         }
 
-        // 이슈 번호를 링크로 변환
-        const issueNumber = match[1].substring(1); // # 제거
-        const issueLink = `https://github.com/${owner}/${repo}/issues/${issueNumber}`;
+        const issueNumber = match[1].substring(1);
 
         parts.push(
-          <a
+          <GithubIssueLink
             key={`issue-${issueNumber}-${match.index}`}
-            href={issueLink}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="commit-message__issue-link"
-            title={`GitHub Issue #${issueNumber}`}
-          >
-            {match[1]}
-          </a>
+            owner={owner}
+            repo={repo}
+            issueNumber={issueNumber}
+          />
         );
 
         lastIndex = match.index + match[0].length;

--- a/packages/view/src/components/VerticalClusterList/Summary/Content/Content.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Content/Content.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import ArrowDropDownCircleRoundedIcon from "@mui/icons-material/ArrowDropDownCircleRounded";
 
 import { useGithubInfo } from "store";
+import { GithubIssueLink } from "components/@common/GithubIssueLink";
 
 import type { ContentProps } from "../Summary.type";
 
@@ -32,21 +33,15 @@ const Content = ({ content, clusterId, selectedClusterIds }: ContentProps) => {
           parts.push(message.slice(lastIndex, match.index));
         }
 
-        // 이슈 번호를 링크로 변환
-        const issueNumber = match[1].substring(1); // # 제거
-        const issueLink = `https://github.com/${owner}/${repo}/issues/${issueNumber}`;
+        const issueNumber = match[1].substring(1);
 
         parts.push(
-          <a
+          <GithubIssueLink
             key={`issue-${issueNumber}-${match.index}`}
-            href={issueLink}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="summary__commit-issue-link"
-            title={`GitHub Issue #${issueNumber}`}
-          >
-            {match[1]}
-          </a>
+            owner={owner}
+            repo={repo}
+            issueNumber={issueNumber}
+          />
         );
 
         lastIndex = match.index + match[0].length;

--- a/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
+++ b/packages/view/src/components/VerticalClusterList/Summary/Summary.scss
@@ -143,23 +143,3 @@
   max-height: fit-content;
   padding: 0.625rem 1.075rem;
 }
-
-        .summary__commit-issue-link {
-          color: var(--color-primary);
-          text-decoration: none;
-          font-weight: 500;
-          padding: 0.125rem 0.25rem;
-          border-radius: 0.125rem;
-          background-color: rgba(224, 96, 145, 0.1);
-          transition: all 0.2s ease-in-out;
-
-          &:hover {
-            background-color: rgba(224, 96, 145, 0.2);
-            text-decoration: underline;
-            transform: translateY(-1px);
-          }
-
-          &:active {
-            transform: translateY(0);
-          }
-        }


### PR DESCRIPTION
## Related issue
#900

## Result
Detail과 Content 컴포넌트의 `processMessage` 함수 내 중복으로 존재하던 Github 이슈 링크 JSX 로직을 컴포넌트화하였습니다.

## Work list
- **공통 컴포넌트 생성**: GitHub 이슈 링크 생성 로직 캡슐화
- **기존 컴포넌트 리팩토링**: `Detail.tsx`, `Content.tsx` 내 인라인 JSX를 `GithubIssueLink` 컴포넌트로 교체
- **스타일 중복 제거**: 이슈 링크 관련 CSS 스타일을 `GithubIssueLink.scss`로 통합
- **코드 스타일**: `Detail.scss` 내 불필요한 주석 제거

## Test
- [x] 기존 GitHub 이슈 링크 기능이 정상 동작하는지 확인(`processMessage`)
- [x] GithubIssueLink 컴포넌트가 올바른 URL을 생성하는지 확인
- [x] CSS 스타일이 기존과 동일하게 적용되는지 확인

## 후속 작업
- `processMessage` 함수 내 공통 로직 분리 / 테스트
- 이슈 링크 () 괄호 패턴 매칭 안되는 오류 수정

## Discussion
디버깅 모드에서 아래와 같이 Merge PR와 연관된 커밋들이 각 커밋 메시지가 아닌 동일한 PR 제목/본문으로 표시됩니다.
<img width="1300" height="650" alt="스크린샷 2025-10-01 오후 6 22 08" src="https://github.com/user-attachments/assets/1169de23-251a-40d9-8a5d-c76d9ab604c1" />

1) 만약 의도된 동작이라면, 연관 커밋마다 동일한 PR 본문을 중복 노출할 필요성이 있는가에 대한 의문이 있습니다.
2) 의도된 동작이 아니라면 아래와 같이 Merge 커밋에만 PR 제목/본문을 노출하고, 연관 커밋은 해당 커밋의 제목/본문을 노출하는 것이 적절해 보입니다.
<img width="1290" height="595" alt="스크린샷 2025-10-01 오후 6 11 36" src="https://github.com/user-attachments/assets/938e6d30-2bcd-45a3-8f7b-0b87d3ab5b9d" />
<img width="1290" height="595" alt="스크린샷 2025-10-01 오후 6 11 41" src="https://github.com/user-attachments/assets/967cafc8-c4e4-4c39-ad38-d9dcf2d3c860" />


