### PR TITLE
feat : csm pagination view

### DIFF
--- a/packages/analysis-engine/src/csm.spec.ts
+++ b/packages/analysis-engine/src/csm.spec.ts
@@ -438,13 +438,8 @@ describe("csm", () => {
 
   describe("buildPaginatedCSMDict", () => {
     it("should load first page when lastCommitId is not provided", () => {
-      const perPage = 2;
-      const result = buildPaginatedCSMDict(
-        fakeCommitNodeDict,
-        fakeStemDict,
-        "master",
-        perPage
-      );
+      const commitCountPerPage = 2;
+      const result = buildPaginatedCSMDict(fakeCommitNodeDict, fakeStemDict, "master", commitCountPerPage);
 
       expect(result).toBeDefined();
       expect(result.master).toBeDefined();
@@ -456,12 +451,12 @@ describe("csm", () => {
     });
 
     it("should load next page when lastCommitId is provided", () => {
-      const perPage = 2;
+      const commitCountPerPage = 2;
       const result = buildPaginatedCSMDict(
         fakeCommitNodeDict,
         fakeStemDict,
         "master",
-        perPage,
+        commitCountPerPage,
         "4" // Last commit of first page
       );
 
@@ -474,12 +469,12 @@ describe("csm", () => {
     });
 
     it("should return remaining nodes when perPage exceeds remaining nodes", () => {
-      const perPage = 10;
+      const commitCountPerPage = 10;
       const result = buildPaginatedCSMDict(
         fakeCommitNodeDict,
         fakeStemDict,
         "master",
-        perPage,
+        commitCountPerPage,
         "2" // Only [1, 0] remaining
       );
 
@@ -491,12 +486,12 @@ describe("csm", () => {
     });
 
     it("should return empty array when no more nodes available", () => {
-      const perPage = 2;
+      const commitCountPerPage = 2;
       const result = buildPaginatedCSMDict(
         fakeCommitNodeDict,
         fakeStemDict,
         "master",
-        perPage,
+        commitCountPerPage,
         "0" // Last node
       );
 
@@ -507,44 +502,23 @@ describe("csm", () => {
 
     it("should throw error when lastCommitId is invalid", () => {
       expect(() => {
-        buildPaginatedCSMDict(
-          fakeCommitNodeDict,
-          fakeStemDict,
-          "master",
-          2,
-          "invalid-commit-id"
-        );
+        buildPaginatedCSMDict(fakeCommitNodeDict, fakeStemDict, "master", 2, "invalid-commit-id");
       }).toThrow("Invalid lastCommitId");
     });
 
     it("should throw error when perPage is less than or equal to 0", () => {
       expect(() => {
-        buildPaginatedCSMDict(
-          fakeCommitNodeDict,
-          fakeStemDict,
-          "master",
-          0
-        );
+        buildPaginatedCSMDict(fakeCommitNodeDict, fakeStemDict, "master", 0);
       }).toThrow("perPage must be greater than 0");
 
       expect(() => {
-        buildPaginatedCSMDict(
-          fakeCommitNodeDict,
-          fakeStemDict,
-          "master",
-          -1
-        );
+        buildPaginatedCSMDict(fakeCommitNodeDict, fakeStemDict, "master", -1);
       }).toThrow("perPage must be greater than 0");
     });
 
     it("should throw error when base branch does not exist", () => {
       expect(() => {
-        buildPaginatedCSMDict(
-          fakeCommitNodeDict,
-          fakeStemDict,
-          "non-existent-branch",
-          2
-        );
+        buildPaginatedCSMDict(fakeCommitNodeDict, fakeStemDict, "non-existent-branch", 2);
       }).toThrow("no master-stem");
     });
 
@@ -566,14 +540,7 @@ describe("csm", () => {
         },
       } as unknown as PullRequest;
 
-      const result = buildPaginatedCSMDict(
-        fakeCommitNodeDict,
-        fakeStemDict,
-        "master",
-        1,
-        undefined,
-        [fakePR]
-      );
+      const result = buildPaginatedCSMDict(fakeCommitNodeDict, fakeStemDict, "master", 1, undefined, [fakePR]);
 
       expect(result.master[0].base.commit.id).toBe("5");
       // PR integration logic should be applied

--- a/packages/analysis-engine/src/csm.ts
+++ b/packages/analysis-engine/src/csm.ts
@@ -165,13 +165,13 @@ export const buildPaginatedCSMDict = (
   commitDict: CommitDict,
   stemDict: StemDict,
   baseBranchName: string,
-  perPage: number,
+  commitCountPerPage: number,
   lastCommitId?: string,
   pullRequests: Array<PullRequest> = []
 ): CSMDictionary => {
-  // Validate perPage
-  if (perPage <= 0) {
-    throw new Error("perPage must be greater than 0");
+  // Validate commitCountPerPage
+  if (commitCountPerPage <= 0) {
+    throw new Error("commitCountPerPage must be greater than 0");
   }
 
   // Validate stemDict
@@ -196,7 +196,7 @@ export const buildPaginatedCSMDict = (
   }
 
   // Calculate end index and extract page nodes
-  const endIndex = Math.min(startIndex + perPage, baseStem.nodes.length);
+  const endIndex = Math.min(startIndex + commitCountPerPage, baseStem.nodes.length);
   const pageNodes = baseStem.nodes.slice(startIndex, endIndex);
 
   // Build CSM nodes with PR integration

--- a/packages/analysis-engine/src/index.ts
+++ b/packages/analysis-engine/src/index.ts
@@ -93,7 +93,7 @@ export class AnalysisEngine {
       const lastNode: CSMNode | undefined = list.length > 0 ? list[list.length - 1] : undefined;
 
       const isLastPage = list.length < perPage;
-      const nextCommitId = !isLastPage && lastNode ? lastNode.base.commit.id : null;
+      const nextCommitId = !isLastPage && lastNode ? lastNode.base.commit.id : undefined;
 
       return {
         isPRSuccess,
@@ -112,7 +112,7 @@ export class AnalysisEngine {
       return {
         isPRSuccess,
         csmDict,
-        nextCommitId: null,
+        nextCommitId: undefined,
         isLastPage: true,
       };
     }

--- a/packages/analysis-engine/src/index.ts
+++ b/packages/analysis-engine/src/index.ts
@@ -83,28 +83,25 @@ export class AnalysisEngine {
     if (this.isDebugMode) console.log("stemDict: ", this.stemDict);
   };
 
-  public analyzeGit = async (
-    perPage?: number,
-    lastCommitId?: string
-  ): Promise<AnalyzeGitResult> => {
+  public analyzeGit = async (commitCountPerPage?: number, lastCommitId?: string): Promise<AnalyzeGitResult> => {
     if (!this.commitDict || !this.stemDict || !this.pullRequests) {
       throw new Error("AnalysisEngine not initialized. Call init() first.");
     }
 
     // Paginated CSM
-    if (perPage) {
+    if (commitCountPerPage) {
       const csmDict = buildPaginatedCSMDict(
         this.commitDict,
         this.stemDict,
         this.baseBranchName,
-        perPage,
+        commitCountPerPage,
         lastCommitId,
         this.pullRequests
       );
       const list = csmDict[this.baseBranchName] ?? [];
       const lastNode = list.length > 0 ? list[list.length - 1] : undefined;
 
-      const isLastPage = list.length < perPage;
+      const isLastPage = list.length < commitCountPerPage;
       const nextCommitId = !isLastPage && lastNode ? lastNode.base.commit.id : undefined;
 
       return {

--- a/packages/analysis-engine/src/index.ts
+++ b/packages/analysis-engine/src/index.ts
@@ -8,7 +8,7 @@ import getCommitRaws from "./parser";
 import { PluginOctokit } from "./pluginOctokit";
 import { buildStemDict } from "./stem";
 import { getSummary } from "./summary";
-import type { CSMNode } from "./types";
+import type { AnalyzeGitResult } from "./types";
 
 export { buildPaginatedCSMDict } from "./csm";
 
@@ -29,6 +29,12 @@ export class AnalysisEngine {
   private octokit!: PluginOctokit;
 
   private baseBranchName!: string;
+
+  // Cached data
+  private commitDict?: ReturnType<typeof buildCommitDict>;
+  private pullRequests?: Awaited<ReturnType<PluginOctokit["getPullRequests"]>>;
+  private stemDict?: ReturnType<typeof buildStemDict>;
+  private isPRSuccess: boolean = true;
 
   constructor(args: AnalysisEngineArgs) {
     this.insertArgs(args);
@@ -51,66 +57,72 @@ export class AnalysisEngine {
     this.octokit = container.resolve(PluginOctokit);
   };
 
-  public analyzeGit = async (perPage?: number, lastCommitId?: string) => {
-    let isPRSuccess = true;
+  public init = async () => {
     if (this.isDebugMode) console.log("baseBranchName: ", this.baseBranchName);
 
     const commitRaws = getCommitRaws(this.gitLog);
-    if (this.isDebugMode) {
-      console.log("commitRaws: ", commitRaws);
-    }
+    if (this.isDebugMode) console.log("commitRaws: ", commitRaws);
 
-    const commitDict = buildCommitDict(commitRaws);
-    if (this.isDebugMode) console.log("commitDict: ", commitDict);
+    this.commitDict = buildCommitDict(commitRaws);
+    if (this.isDebugMode) console.log("commitDict: ", this.commitDict);
 
-    const pullRequests = await this.octokit
+    this.pullRequests = await this.octokit
       .getPullRequests()
       .catch((err) => {
         console.error(err);
-        isPRSuccess = false;
+        this.isPRSuccess = false;
         return [];
       })
       .then((pullRequests) => {
         console.log("success, pr = ", pullRequests);
         return pullRequests;
       });
-    if (this.isDebugMode) console.log("pullRequests: ", pullRequests);
+    if (this.isDebugMode) console.log("pullRequests: ", this.pullRequests);
 
-    const stemDict = buildStemDict(commitDict, this.baseBranchName);
-    if (this.isDebugMode) console.log("stemDict: ", stemDict);
+    this.stemDict = buildStemDict(this.commitDict, this.baseBranchName);
+    if (this.isDebugMode) console.log("stemDict: ", this.stemDict);
+  };
+
+  public analyzeGit = async (
+    perPage?: number,
+    lastCommitId?: string
+  ): Promise<AnalyzeGitResult> => {
+    if (!this.commitDict || !this.stemDict || !this.pullRequests) {
+      throw new Error("AnalysisEngine not initialized. Call init() first.");
+    }
 
     // Paginated CSM
     if (perPage) {
       const csmDict = buildPaginatedCSMDict(
-        commitDict,
-        stemDict,
+        this.commitDict,
+        this.stemDict,
         this.baseBranchName,
         perPage,
         lastCommitId,
-        pullRequests
+        this.pullRequests
       );
       const list = csmDict[this.baseBranchName] ?? [];
-      const lastNode: CSMNode | undefined = list.length > 0 ? list[list.length - 1] : undefined;
+      const lastNode = list.length > 0 ? list[list.length - 1] : undefined;
 
       const isLastPage = list.length < perPage;
       const nextCommitId = !isLastPage && lastNode ? lastNode.base.commit.id : undefined;
 
       return {
-        isPRSuccess,
+        isPRSuccess: this.isPRSuccess,
         csmDict,
         nextCommitId,
         isLastPage,
       };
     } else {
       // Non-paginated CSM
-      const csmDict = buildCSMDict(commitDict, stemDict, this.baseBranchName, pullRequests);
+      const csmDict = buildCSMDict(this.commitDict, this.stemDict, this.baseBranchName, this.pullRequests);
       if (this.isDebugMode) console.log("csmDict: ", csmDict);
-      const nodes = stemDict.get(this.baseBranchName)?.nodes?.map(({ commit }) => commit);
+      const nodes = this.stemDict.get(this.baseBranchName)?.nodes?.map(({ commit }) => commit);
       const geminiCommitSummary = await getSummary(nodes ? nodes?.slice(-10) : []);
       if (this.isDebugMode) console.log("GeminiCommitSummary: ", geminiCommitSummary);
 
       return {
-        isPRSuccess,
+        isPRSuccess: this.isPRSuccess,
         csmDict,
         nextCommitId: undefined,
         isLastPage: true,
@@ -118,9 +130,18 @@ export class AnalysisEngine {
     }
   };
 
+  public getBaseBranchName = () => {
+    return this.baseBranchName;
+  };
+
   public updateArgs = (args: AnalysisEngineArgs) => {
     if (container.isRegistered("OctokitOptions")) container.clearInstances();
     this.insertArgs(args);
+    // Clear cached data
+    this.commitDict = undefined;
+    this.stemDict = undefined;
+    this.pullRequests = undefined;
+    this.isPRSuccess = true;
   };
 }
 

--- a/packages/analysis-engine/src/types/CSM.ts
+++ b/packages/analysis-engine/src/types/CSM.ts
@@ -8,3 +8,9 @@ export interface CSMNode {
 export interface CSMDictionary {
   [branch: string]: CSMNode[];
 }
+export type AnalyzeGitResult = {
+  isPRSuccess: boolean;
+  csmDict: CSMDictionary;
+  nextCommitId: string | undefined;
+  isLastPage: boolean;
+};

--- a/packages/view/src/App.tsx
+++ b/packages/view/src/App.tsx
@@ -12,8 +12,7 @@ import { RefreshButton } from "components/RefreshButton";
 import type { IDESentEvents } from "types/IDESentEvents";
 import { useBranchStore, useDataStore, useGithubInfo, useLoadingStore, useThemeStore } from "store";
 import { THEME_INFO } from "components/ThemeSelector/ThemeSelector.const";
-
-const PER_PAGE = 10;
+import { PER_PAGE } from "constants/constants";
 
 const App = () => {
   const initRef = useRef<boolean>(false);

--- a/packages/view/src/App.tsx
+++ b/packages/view/src/App.tsx
@@ -12,7 +12,7 @@ import { RefreshButton } from "components/RefreshButton";
 import type { IDESentEvents } from "types/IDESentEvents";
 import { useBranchStore, useDataStore, useGithubInfo, useLoadingStore, useThemeStore } from "store";
 import { THEME_INFO } from "components/ThemeSelector/ThemeSelector.const";
-import { PER_PAGE } from "constants/constants";
+import { COMMIT_COUNT_PER_PAGE } from "constants/constants";
 
 const App = () => {
   const initRef = useRef<boolean>(false);
@@ -38,7 +38,7 @@ const App = () => {
       };
       setLoading(true);
       ideAdapter.addIDESentEventListener(callbacks);
-      ideAdapter.sendFetchAnalyzedDataMessage({ perPage: PER_PAGE });
+      ideAdapter.sendFetchAnalyzedDataMessage({ commitCountPerPage: COMMIT_COUNT_PER_PAGE });
       ideAdapter.sendFetchBranchListMessage();
       ideAdapter.sendFetchGithubInfo();
       initRef.current = true;
@@ -50,7 +50,7 @@ const App = () => {
 
     setLoading(true);
     ideAdapter.sendFetchAnalyzedDataMessage({
-      perPage: PER_PAGE,
+      commitCountPerPage: COMMIT_COUNT_PER_PAGE,
       lastCommitId: nextCommitId,
     });
   };

--- a/packages/view/src/components/@common/Author/Author.tsx
+++ b/packages/view/src/components/@common/Author/Author.tsx
@@ -2,7 +2,7 @@ import { Tooltip, Avatar } from "@mui/material";
 
 import type { AuthorInfo } from "types";
 
-import { GITHUB_URL } from "../../../constants/constants";
+import { GITHUB_URL } from "constants/constants";
 
 import { AVATAR_STYLE, TOOLTIP_STYLE } from "./Author.const";
 

--- a/packages/view/src/components/BranchSelector/BranchSelector.tsx
+++ b/packages/view/src/components/BranchSelector/BranchSelector.tsx
@@ -8,6 +8,7 @@ import "./BranchSelector.scss";
 import { useBranchStore, useLoadingStore } from "store";
 
 import { SLICE_LENGTH } from "./BranchSelector.const";
+import { PER_PAGE } from "constants/constants";
 
 const BranchSelector = () => {
   const { branchList, selectedBranch, setSelectedBranch } = useBranchStore();
@@ -16,7 +17,7 @@ const BranchSelector = () => {
   const handleChangeSelect = (event: SelectChangeEvent) => {
     setSelectedBranch(event.target.value);
     setLoading(true);
-    sendFetchAnalyzedDataCommand(event.target.value);
+    sendFetchAnalyzedDataCommand({ baseBranch: event.target.value, perPage: PER_PAGE });
   };
 
   return (

--- a/packages/view/src/components/BranchSelector/BranchSelector.tsx
+++ b/packages/view/src/components/BranchSelector/BranchSelector.tsx
@@ -8,7 +8,7 @@ import "./BranchSelector.scss";
 import { useBranchStore, useLoadingStore } from "store";
 
 import { SLICE_LENGTH } from "./BranchSelector.const";
-import { PER_PAGE } from "constants/constants";
+import { COMMIT_COUNT_PER_PAGE } from "constants/constants";
 
 const BranchSelector = () => {
   const { branchList, selectedBranch, setSelectedBranch } = useBranchStore();
@@ -17,7 +17,7 @@ const BranchSelector = () => {
   const handleChangeSelect = (event: SelectChangeEvent) => {
     setSelectedBranch(event.target.value);
     setLoading(true);
-    sendFetchAnalyzedDataCommand({ baseBranch: event.target.value, perPage: PER_PAGE });
+    sendFetchAnalyzedDataCommand({ baseBranch: event.target.value, commitCountPerPage: COMMIT_COUNT_PER_PAGE });
   };
 
   return (

--- a/packages/view/src/components/RefreshButton/RefreshButton.tsx
+++ b/packages/view/src/components/RefreshButton/RefreshButton.tsx
@@ -7,6 +7,7 @@ import { throttle } from "utils";
 import "./RefreshButton.scss";
 import { sendRefreshDataCommand } from "services";
 import { useBranchStore, useLoadingStore } from "store";
+import { PER_PAGE } from "constants/constants";
 
 const RefreshButton = () => {
   const { selectedBranch } = useBranchStore();
@@ -14,7 +15,7 @@ const RefreshButton = () => {
 
   const refreshHandler = throttle(() => {
     setLoading(true);
-    sendRefreshDataCommand(selectedBranch);
+    sendRefreshDataCommand({ selectedBranch, perPage: PER_PAGE });
   }, 3000);
 
   return (

--- a/packages/view/src/components/RefreshButton/RefreshButton.tsx
+++ b/packages/view/src/components/RefreshButton/RefreshButton.tsx
@@ -7,7 +7,7 @@ import { throttle } from "utils";
 import "./RefreshButton.scss";
 import { sendRefreshDataCommand } from "services";
 import { useBranchStore, useLoadingStore } from "store";
-import { PER_PAGE } from "constants/constants";
+import { COMMIT_COUNT_PER_PAGE } from "constants/constants";
 
 const RefreshButton = () => {
   const { selectedBranch } = useBranchStore();
@@ -15,7 +15,7 @@ const RefreshButton = () => {
 
   const refreshHandler = throttle(() => {
     setLoading(true);
-    sendRefreshDataCommand({ selectedBranch, perPage: PER_PAGE });
+    sendRefreshDataCommand({ selectedBranch, commitCountPerPage: COMMIT_COUNT_PER_PAGE });
   }, 3000);
 
   return (

--- a/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
+++ b/packages/view/src/components/Statistics/FileIcicleSummary/FileIcicleSummary.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef } from "react";
 
 import { pxToRem } from "utils";
 
-import { PRIMARY_COLOR_VARIABLE_NAME } from "../../../constants/constants";
+import { PRIMARY_COLOR_VARIABLE_NAME } from "constants/constants";
 import { useGetSelectedData } from "../Statistics.hook";
 
 import { getFileChangesTree } from "./FileIcicleSummary.util";

--- a/packages/view/src/components/TemporalFilter/TemporalFilter.util.ts
+++ b/packages/view/src/components/TemporalFilter/TemporalFilter.util.ts
@@ -3,7 +3,7 @@ import { timeFormat } from "d3";
 
 import type { ClusterNode, CommitNode } from "types/Nodes";
 
-import { NODE_TYPES } from "../../constants/constants";
+import { NODE_TYPES } from "constants/constants";
 
 /**
  * Note: Line Chart를 위한 시간순 CommitNode 정렬

--- a/packages/view/src/constants/constants.tsx
+++ b/packages/view/src/constants/constants.tsx
@@ -2,4 +2,4 @@ export const GITHUB_URL = "https://github.com";
 export const GRAVATA_URL = "https://www.gravatar.com/avatar";
 export const PRIMARY_COLOR_VARIABLE_NAME = "--color-primary";
 export const NODE_TYPES = ["COMMIT", "CLUSTER"] as const;
-export const PER_PAGE = 10;
+export const COMMIT_COUNT_PER_PAGE = 10;

--- a/packages/view/src/constants/constants.tsx
+++ b/packages/view/src/constants/constants.tsx
@@ -2,3 +2,4 @@ export const GITHUB_URL = "https://github.com";
 export const GRAVATA_URL = "https://www.gravatar.com/avatar";
 export const PRIMARY_COLOR_VARIABLE_NAME = "--color-primary";
 export const NODE_TYPES = ["COMMIT", "CLUSTER"] as const;
+export const PER_PAGE = 10;

--- a/packages/view/src/hooks/useAnalayzedData.ts
+++ b/packages/view/src/hooks/useAnalayzedData.ts
@@ -3,15 +3,39 @@ import { useShallow } from "zustand/react/shallow";
 import { useDataStore, useLoadingStore } from "store";
 import type { ClusterNode } from "types";
 
+type AnalyzedDataPayload = {
+  clusterNodes: ClusterNode[];
+  nextCommitId?: string;
+  isLastPage: boolean;
+  isLoadMore: boolean;
+};
+
 export const useAnalayzedData = () => {
-  const [setData, setFilteredData, setSelectedData] = useDataStore(
-    useShallow((state) => [state.setData, state.setFilteredData, state.setSelectedData])
+  const { setData, addData, setFilteredData, setSelectedData, setPagination } = useDataStore(
+    useShallow((state) => ({
+      setData: state.setData,
+      addData: state.addData,
+      setFilteredData: state.setFilteredData,
+      setSelectedData: state.setSelectedData,
+      setPagination: state.setPagination,
+    }))
   );
   const { setLoading } = useLoadingStore();
 
-  const handleChangeAnalyzedData = (analyzedData: ClusterNode[]) => {
-    setData(analyzedData);
-    setFilteredData([...analyzedData]);
+  const handleChangeAnalyzedData = (payload: AnalyzedDataPayload) => {
+    if (!payload) {
+      setLoading(false);
+      return;
+    }
+    const { clusterNodes, nextCommitId, isLastPage, isLoadMore } = payload;
+    if (isLoadMore) {
+      addData(clusterNodes);
+    } else {
+      // first load
+      setData(clusterNodes);
+      setFilteredData([...clusterNodes]);
+    }
+    setPagination(isLastPage, nextCommitId);
     setSelectedData([]);
     setLoading(false);
   };

--- a/packages/view/src/hooks/useAnalayzedData.ts
+++ b/packages/view/src/hooks/useAnalayzedData.ts
@@ -8,6 +8,7 @@ type AnalyzedDataPayload = {
   nextCommitId?: string;
   isLastPage: boolean;
   isLoadMore: boolean;
+  isPRSuccess: boolean;
 };
 
 export const useAnalayzedData = () => {

--- a/packages/view/src/ide/FakeIDEAdapter.ts
+++ b/packages/view/src/ide/FakeIDEAdapter.ts
@@ -39,7 +39,12 @@ export default class FakeIDEAdapter implements IDEPort {
     this.sendMessageToMe(message);
   }
 
-  public sendFetchAnalyzedDataMessage(payload?: string) {
+  public sendFetchAnalyzedDataMessage(requestParams?: {
+    baseBranch?: string;
+    perPage?: number;
+    lastCommitId?: string;
+  }) {
+    const payload = requestParams ? JSON.stringify(requestParams) : undefined;
     const message: IDEMessage = {
       command: "fetchAnalyzedData",
       payload,

--- a/packages/view/src/ide/FakeIDEAdapter.ts
+++ b/packages/view/src/ide/FakeIDEAdapter.ts
@@ -1,6 +1,6 @@
 ﻿import { injectable } from "tsyringe";
 
-import type { IDEMessage, IDEMessageEvent } from "types";
+import type { FetchDataRequestPayload, IDEMessage, IDEMessageEvent, RefreshDataRequestPayload } from "types";
 import type { IDESentEvents } from "types/IDESentEvents";
 
 import fakeData from "../fake-assets/cluster-nodes.json";
@@ -31,7 +31,8 @@ export default class FakeIDEAdapter implements IDEPort {
     window.addEventListener("message", onReceiveMessage);
   }
 
-  public sendRefreshDataMessage(payload?: string) {
+  public sendRefreshDataMessage(requestParams?: RefreshDataRequestPayload) {
+    const payload = requestParams ? JSON.stringify(requestParams) : undefined;
     const message: IDEMessage = {
       command: "refresh",
       payload,
@@ -39,11 +40,7 @@ export default class FakeIDEAdapter implements IDEPort {
     this.sendMessageToMe(message);
   }
 
-  public sendFetchAnalyzedDataMessage(requestParams?: {
-    baseBranch?: string;
-    perPage?: number;
-    lastCommitId?: string;
-  }) {
+  public sendFetchAnalyzedDataMessage(requestParams?: FetchDataRequestPayload) {
     const payload = requestParams ? JSON.stringify(requestParams) : undefined;
     const message: IDEMessage = {
       command: "fetchAnalyzedData",

--- a/packages/view/src/ide/IDEPort.ts
+++ b/packages/view/src/ide/IDEPort.ts
@@ -1,4 +1,5 @@
 ﻿import type { IDESentEvents } from "types/IDESentEvents";
+import type { FetchDataRequestPayload, RefreshDataRequestPayload } from "types/IDEMessage";
 
 export type IDEMessage = {
   command: string;
@@ -7,12 +8,8 @@ export type IDEMessage = {
 
 export default interface IDEPort {
   addIDESentEventListener: (apiCallbacks: IDESentEvents) => void;
-  sendRefreshDataMessage: (payload?: string) => void;
-  sendFetchAnalyzedDataMessage: (requestParams?: {
-    baseBranch?: string;
-    perPage?: number;
-    lastCommitId?: string;
-  }) => void;
+  sendRefreshDataMessage: (requestParams?: RefreshDataRequestPayload) => void;
+  sendFetchAnalyzedDataMessage: (requestParams?: FetchDataRequestPayload) => void;
   sendFetchBranchListMessage: () => void;
   sendFetchGithubInfo: () => void;
   sendUpdateThemeMessage: (theme: string) => void;

--- a/packages/view/src/ide/IDEPort.ts
+++ b/packages/view/src/ide/IDEPort.ts
@@ -8,7 +8,11 @@ export type IDEMessage = {
 export default interface IDEPort {
   addIDESentEventListener: (apiCallbacks: IDESentEvents) => void;
   sendRefreshDataMessage: (payload?: string) => void;
-  sendFetchAnalyzedDataMessage: (payload?: string) => void;
+  sendFetchAnalyzedDataMessage: (requestParams?: {
+    baseBranch?: string;
+    perPage?: number;
+    lastCommitId?: string;
+  }) => void;
   sendFetchBranchListMessage: () => void;
   sendFetchGithubInfo: () => void;
   sendUpdateThemeMessage: (theme: string) => void;

--- a/packages/view/src/ide/VSCodeIDEAdapter.ts
+++ b/packages/view/src/ide/VSCodeIDEAdapter.ts
@@ -1,6 +1,6 @@
 ﻿import { injectable } from "tsyringe";
 
-import type { IDEMessage, IDEMessageEvent } from "types";
+import type { FetchDataRequestPayload, IDEMessage, IDEMessageEvent } from "types";
 import type { IDESentEvents } from "types/IDESentEvents";
 
 import type IDEPort from "./IDEPort";
@@ -29,19 +29,15 @@ export default class VSCodeIDEAdapter implements IDEPort {
     window.addEventListener("message", onReceiveMessage);
   }
 
-  public sendRefreshDataMessage(baseBranch?: string) {
+  public sendRefreshDataMessage(requestParams?: FetchDataRequestPayload) {
     const message: IDEMessage = {
       command: "refresh",
-      payload: JSON.stringify(baseBranch),
+      payload: JSON.stringify(requestParams),
     };
     this.sendMessageToIDE(message);
   }
 
-  public sendFetchAnalyzedDataMessage(requestParams?: {
-    baseBranch?: string;
-    perPage?: number;
-    lastCommitId?: string;
-  }) {
+  public sendFetchAnalyzedDataMessage(requestParams?: FetchDataRequestPayload) {
     const message: IDEMessage = {
       command: "fetchAnalyzedData",
       payload: JSON.stringify(requestParams),

--- a/packages/view/src/ide/VSCodeIDEAdapter.ts
+++ b/packages/view/src/ide/VSCodeIDEAdapter.ts
@@ -37,10 +37,14 @@ export default class VSCodeIDEAdapter implements IDEPort {
     this.sendMessageToIDE(message);
   }
 
-  public sendFetchAnalyzedDataMessage(baseBranch?: string) {
+  public sendFetchAnalyzedDataMessage(requestParams?: {
+    baseBranch?: string;
+    perPage?: number;
+    lastCommitId?: string;
+  }) {
     const message: IDEMessage = {
       command: "fetchAnalyzedData",
-      payload: JSON.stringify(baseBranch),
+      payload: JSON.stringify(requestParams),
     };
     this.sendMessageToIDE(message);
   }

--- a/packages/view/src/services/index.ts
+++ b/packages/view/src/services/index.ts
@@ -9,7 +9,7 @@ export const sendUpdateThemeCommand = (theme: string) => {
 
 export const sendFetchAnalyzedDataCommand = (selectedBranch?: string) => {
   const ideAdapter = container.resolve<IDEPort>("IDEAdapter");
-  ideAdapter.sendFetchAnalyzedDataMessage(selectedBranch);
+  ideAdapter.sendFetchAnalyzedDataMessage({ baseBranch: selectedBranch });
 };
 
 export const sendRefreshDataCommand = (selectedBranch?: string) => {

--- a/packages/view/src/services/index.ts
+++ b/packages/view/src/services/index.ts
@@ -1,20 +1,21 @@
 import { container } from "tsyringe";
 
 import type IDEPort from "ide/IDEPort";
+import { FetchDataRequestPayload, RefreshDataRequestPayload } from "types";
 
 export const sendUpdateThemeCommand = (theme: string) => {
   const ideAdapter = container.resolve<IDEPort>("IDEAdapter");
   ideAdapter.sendUpdateThemeMessage(theme);
 };
 
-export const sendFetchAnalyzedDataCommand = (selectedBranch?: string) => {
+export const sendFetchAnalyzedDataCommand = (payload: FetchDataRequestPayload) => {
   const ideAdapter = container.resolve<IDEPort>("IDEAdapter");
-  ideAdapter.sendFetchAnalyzedDataMessage({ baseBranch: selectedBranch });
+  ideAdapter.sendFetchAnalyzedDataMessage(payload);
 };
 
-export const sendRefreshDataCommand = (selectedBranch?: string) => {
+export const sendRefreshDataCommand = (payload: RefreshDataRequestPayload) => {
   const ideAdapter = container.resolve<IDEPort>("IDEAdapter");
-  ideAdapter.sendRefreshDataMessage(selectedBranch);
+  ideAdapter.sendRefreshDataMessage(payload);
   ideAdapter.sendFetchBranchListMessage();
 };
 

--- a/packages/view/src/store/data.ts
+++ b/packages/view/src/store/data.ts
@@ -7,19 +7,31 @@ type DataState = {
   data: ClusterNode[];
   filteredData: ClusterNode[];
   selectedData: ClusterNode[];
+  isLastPage: boolean;
+  nextCommitId?: string;
   setData: (data: ClusterNode[]) => void;
+  addData: (newData: ClusterNode[]) => void;
   setFilteredData: (filteredData: ClusterNode[]) => void;
   setSelectedData: Dispatch<SetStateAction<ClusterNode[]>>;
+  setPagination: (isLastPage: boolean, nextCommitId?: string) => void;
 };
 
 export const useDataStore = create<DataState>((set) => ({
   data: [],
   filteredData: [],
   selectedData: [],
+  isLastPage: false,
+  nextCommitId: undefined,
   setData: (data) => set({ data }),
+  addData: (newData) =>
+    set((state) => ({
+      data: [...state.data, ...newData],
+      filteredData: [...state.filteredData, ...newData],
+    })),
   setFilteredData: (filteredData) => set({ filteredData }),
   setSelectedData: (selectedData) =>
     set((state) => ({
       selectedData: typeof selectedData === "function" ? selectedData(state.selectedData) : selectedData,
     })),
+  setPagination: (isLastPage, nextCommitId) => set({ isLastPage, nextCommitId }),
 }));

--- a/packages/view/src/types/IDEMessage.ts
+++ b/packages/view/src/types/IDEMessage.ts
@@ -14,3 +14,15 @@ export type IDEMessageCommandNames =
   | "fetchCurrentBranch"
   | "fetchGithubInfo"
   | "updateTheme";
+
+export type RefreshDataRequestPayload = {
+  selectedBranch?: string;
+  perPage?: number;
+  lastCommitId?: string;
+};
+
+export type FetchDataRequestPayload = {
+  baseBranch?: string;
+  perPage?: number;
+  lastCommitId?: string;
+};

--- a/packages/view/src/types/IDEMessage.ts
+++ b/packages/view/src/types/IDEMessage.ts
@@ -17,12 +17,12 @@ export type IDEMessageCommandNames =
 
 export type RefreshDataRequestPayload = {
   selectedBranch?: string;
-  perPage?: number;
+  commitCountPerPage?: number;
   lastCommitId?: string;
 };
 
 export type FetchDataRequestPayload = {
   baseBranch?: string;
-  perPage?: number;
+  commitCountPerPage?: number;
   lastCommitId?: string;
 };

--- a/packages/view/src/types/IDESentEvents.ts
+++ b/packages/view/src/types/IDESentEvents.ts
@@ -6,6 +6,7 @@ export type AnalyzedDataPayload = {
   nextCommitId?: string;
   isLastPage: boolean;
   isLoadMore: boolean;
+  isPRSuccess: boolean;
 };
 
 // triggered by ide response

--- a/packages/view/src/types/IDESentEvents.ts
+++ b/packages/view/src/types/IDESentEvents.ts
@@ -1,9 +1,16 @@
 import type { BranchListPayload, githubInfo } from "store";
 import type { ClusterNode } from "types";
 
+export type AnalyzedDataPayload = {
+  clusterNodes: ClusterNode[];
+  nextCommitId?: string;
+  isLastPage: boolean;
+  isLoadMore: boolean;
+};
+
 // triggered by ide response
 export type IDESentEvents = {
-  handleChangeAnalyzedData: (analyzedData: ClusterNode[]) => void;
+  handleChangeAnalyzedData: (payload: AnalyzedDataPayload) => void;
   handleChangeBranchList: (branches: BranchListPayload) => void;
   handleGithubInfo: (repoInfo: githubInfo) => void;
 };

--- a/packages/view/src/types/Nodes.ts
+++ b/packages/view/src/types/Nodes.ts
@@ -18,3 +18,10 @@ export type CommitNode = NodeBase & {
 export type ClusterNode = NodeBase & {
   commitNodeList: CommitNode[];
 };
+
+export type ClusterNodesResult = {
+  clusterNodes: ClusterNode[];
+  isLastPage: boolean;
+  nextCommitId: string | undefined;
+  isPRSuccess: boolean;
+};

--- a/packages/view/src/utils/author.ts
+++ b/packages/view/src/utils/author.ts
@@ -2,7 +2,7 @@ import md5 from "md5";
 
 import type { AuthorInfo } from "types";
 
-import { GITHUB_URL, GRAVATA_URL } from "../constants/constants";
+import { GITHUB_URL, GRAVATA_URL } from "constants/constants";
 
 export function getAuthorProfileImgSrc(authorName: string): Promise<AuthorInfo> {
   return new Promise((resolve) => {

--- a/packages/view/webpack.prod.config.js
+++ b/packages/view/webpack.prod.config.js
@@ -31,6 +31,7 @@ const config = {
       types: path.resolve(__dirname, "src/types/"),
       hooks: path.resolve(__dirname, "src/hooks/"),
       store: path.resolve(__dirname, "src/store/"),
+      constants: path.resolve(__dirname, "src/constants/"),
     },
   },
   module: {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -80,10 +80,11 @@ export async function activate(context: vscode.ExtensionContext) {
       const fetchClusterNodes = async (
         baseBranchName = initialBaseBranchName,
         perPage?: number,
-        lastCommitId?: string
+        lastCommitId?: string,
+        command?: string
       ): Promise<ClusterNodesResult> => {
-        // Cache engine
-        if (!engine || engine.getBaseBranchName() !== baseBranchName) {
+        // Initialize engine if it doesn't exist or if the branch has changed
+        if (command === "refresh" || !engine || engine.getBaseBranchName() !== baseBranchName) {
           const workerPath = vscode.Uri.joinPath(context.extensionUri, "dist", "worker.js").fsPath;
           const gitLog = await fetchGitLogInParallel(gitPath, currentWorkspacePath, workerPath);
           const { owner, repo } = getRepo(gitConfig);

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -79,7 +79,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
       const fetchClusterNodes = async (
         baseBranchName = initialBaseBranchName,
-        perPage?: number,
+        commitCountPerPage?: number,
         lastCommitId?: string,
         command?: string
       ): Promise<ClusterNodesResult> => {
@@ -103,7 +103,7 @@ export async function activate(context: vscode.ExtensionContext) {
           throw new Error("Analysis engine is not initialized.");
         }
 
-        const analysisResult = await engine.analyzeGit(perPage, lastCommitId);
+        const analysisResult = await engine.analyzeGit(commitCountPerPage, lastCommitId);
 
         if (analysisResult.isPRSuccess) console.log("crawling PR Success");
 

--- a/packages/vscode/src/types/Node.ts
+++ b/packages/vscode/src/types/Node.ts
@@ -26,3 +26,10 @@ export type ClusterNode = NodeBase & {
   nodeTypeName: "CLUSTER";
   commitNodeList: CommitNode[];
 };
+
+export type ClusterNodesResult = {
+  clusterNodes: ClusterNode[];
+  isLastPage: boolean;
+  nextCommitId: string | undefined;
+  isPRSuccess: boolean;
+};

--- a/packages/vscode/src/webview-loader.ts
+++ b/packages/vscode/src/webview-loader.ts
@@ -43,7 +43,11 @@ export default class WebviewLoader implements vscode.Disposable {
 
             if (perPage) {
               console.log(`Paging request: perPage=${perPage}, lastCommitId=${lastCommitId}`);
-              analyzedData = await fetchClusterNodes(currentBranch, perPage, lastCommitId);
+              const clusterData = await fetchClusterNodes(currentBranch, perPage, lastCommitId);
+              analyzedData = {
+                ...clusterData,
+                isLoadMore: !!lastCommitId,
+              };
             } else {
               const cacheKey = `${ANALYZE_DATA_KEY}_${currentBranch}`;
               const storedAnalyzedData = context.workspaceState.get<ClusterNode[]>(cacheKey);
@@ -169,8 +173,8 @@ type GithruFetcherMap = {
   fetchClusterNodes: GithruFetcher<
     {
       clusterNodes: ClusterNode[];
-      isLastPage: boolean | undefined;
-      nextCommitId: string | null | undefined;
+      isLastPage: boolean;
+      nextCommitId?: string;
       isPRSuccess: boolean;
     },
     [string?, number?, string?]

--- a/packages/vscode/src/webview-loader.ts
+++ b/packages/vscode/src/webview-loader.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 
 import { getTheme, setTheme } from "./setting-repository";
-import type { ClusterNode, ClusterNodesResult } from "./types/Node";
+import type { ClusterNodesResult } from "./types/Node";
 
 const ANALYZE_DATA_KEY = "memento_analyzed_data";
 
@@ -36,10 +36,10 @@ export default class WebviewLoader implements vscode.Disposable {
 
         if (command === "refresh") {
           const requestPayload = payload ? JSON.parse(payload) : {};
-          const { selectedBranch, perPage, lastCommitId } = requestPayload;
+          const { selectedBranch, commitCountPerPage, lastCommitId } = requestPayload;
           const currentBranch = selectedBranch ?? (await fetchCurrentBranch());
 
-          const clusterData = await fetchClusterNodes(currentBranch, perPage, lastCommitId, "refresh");
+          const clusterData = await fetchClusterNodes(currentBranch, commitCountPerPage, lastCommitId, "refresh");
           analyzedData = {
             ...clusterData,
             isLoadMore: !!lastCommitId,
@@ -53,7 +53,7 @@ export default class WebviewLoader implements vscode.Disposable {
 
         if (command === "fetchAnalyzedData") {
           const requestPayload = payload ? JSON.parse(payload) : {};
-          const { baseBranch, perPage, lastCommitId } = requestPayload;
+          const { baseBranch, commitCountPerPage, lastCommitId } = requestPayload;
           const currentBranch = baseBranch ?? (await fetchCurrentBranch());
 
           const cacheKey = `${ANALYZE_DATA_KEY}_${currentBranch}_${lastCommitId || "firstPage"}`;
@@ -63,7 +63,7 @@ export default class WebviewLoader implements vscode.Disposable {
           if (storedAnalyzedData) {
             analyzedData = storedAnalyzedData;
           } else {
-            const clusterData = await fetchClusterNodes(currentBranch, perPage, lastCommitId);
+            const clusterData = await fetchClusterNodes(currentBranch, commitCountPerPage, lastCommitId);
             analyzedData = {
               ...clusterData,
               isLoadMore: !!lastCommitId,

--- a/packages/vscode/src/webview-loader.ts
+++ b/packages/vscode/src/webview-loader.ts
@@ -17,7 +17,6 @@ export default class WebviewLoader implements vscode.Disposable {
     const { fetchClusterNodes, fetchBranches, fetchCurrentBranch, fetchGithubInfo } = fetcher;
     const viewColumn = vscode.ViewColumn.One;
 
-    console.log("Initialize cache data");
     context.workspaceState.keys().forEach((key) => {
       context.workspaceState.update(key, undefined);
     });
@@ -35,50 +34,47 @@ export default class WebviewLoader implements vscode.Disposable {
       try {
         const { command, payload } = message;
 
-        if (command === "fetchAnalyzedData" || command === "refresh") {
-          try {
-            const requestPayload = payload ? JSON.parse(payload) : {};
-            const { baseBranchName, perPage, lastCommitId } = requestPayload;
-            const currentBranch = baseBranchName ?? (await fetchCurrentBranch());
+        if (command === "refresh") {
+          const requestPayload = payload ? JSON.parse(payload) : {};
+          const { selectedBranch, perPage, lastCommitId } = requestPayload;
+          const currentBranch = selectedBranch ?? (await fetchCurrentBranch());
 
-            if (perPage) {
-              console.log(`Paging request: perPage=${perPage}, lastCommitId=${lastCommitId}`);
-              const clusterData = await fetchClusterNodes(currentBranch, perPage, lastCommitId);
-              analyzedData = {
-                ...clusterData,
-                isLoadMore: !!lastCommitId,
-              };
-            } else {
-              const cacheKey = `${ANALYZE_DATA_KEY}_${currentBranch}`;
-              // "refresh": ignore the cache
-              // "fetchAnalyzedData": use the cache if exists
-              const storedAnalyzedData =
-                command === "fetchAnalyzedData" ? context.workspaceState.get<ClusterNode[]>(cacheKey) : undefined;
+          const clusterData = await fetchClusterNodes(currentBranch, perPage, lastCommitId, "refresh");
+          analyzedData = {
+            ...clusterData,
+            isLoadMore: !!lastCommitId,
+          };
 
-              if (storedAnalyzedData) {
-                console.log("Cache data exists");
-                analyzedData = storedAnalyzedData;
-              } else {
-                console.log(command === "refresh" ? "Forced refresh: fetching new data" : "No cache Data");
-                analyzedData = await fetchClusterNodes(currentBranch);
-                context.workspaceState.update(cacheKey, analyzedData);
-              }
-              console.log("Current Stored data");
-              context.workspaceState.keys().forEach((key) => {
-                console.log(key);
-              });
-            }
+          await this.respondToMessage({
+            command,
+            payload: analyzedData,
+          });
+        }
 
-            const resMessage = {
-              command,
-              payload: analyzedData,
+        if (command === "fetchAnalyzedData") {
+          const requestPayload = payload ? JSON.parse(payload) : {};
+          const { baseBranch, perPage, lastCommitId } = requestPayload;
+          const currentBranch = baseBranch ?? (await fetchCurrentBranch());
+
+          const cacheKey = `${ANALYZE_DATA_KEY}_${currentBranch}_${lastCommitId || "firstPage"}`;
+
+          const storedAnalyzedData = context.workspaceState.get<ClusterNodesResult>(cacheKey);
+
+          if (storedAnalyzedData) {
+            analyzedData = storedAnalyzedData;
+          } else {
+            const clusterData = await fetchClusterNodes(currentBranch, perPage, lastCommitId);
+            analyzedData = {
+              ...clusterData,
+              isLoadMore: !!lastCommitId,
             };
-
-            await this.respondToMessage(resMessage);
-          } catch (e) {
-            console.error("Error fetching analyzed data:", e);
-            throw e;
+            context.workspaceState.update(cacheKey, analyzedData);
           }
+
+          await this.respondToMessage({
+            command,
+            payload: analyzedData,
+          });
         }
 
         if (command === "fetchBranchList") {
@@ -173,7 +169,7 @@ export default class WebviewLoader implements vscode.Disposable {
 
 type GithruFetcher<D = unknown, P extends unknown[] = []> = (...params: P) => Promise<D>;
 type GithruFetcherMap = {
-  fetchClusterNodes: GithruFetcher<ClusterNodesResult, [string?, number?, string?]>;
+  fetchClusterNodes: GithruFetcher<ClusterNodesResult, [string?, number?, string?, string?]>;
   fetchBranches: GithruFetcher<{ branchList: string[]; head: string | null }>;
   fetchCurrentBranch: GithruFetcher<string>;
   fetchGithubInfo: GithruFetcher<{ owner: string; repo: string }>;


### PR DESCRIPTION
## Related issue
#912 

## Result
- 구현된 페이지네이션 API를 view, vscode 프론트에 구현했습니다.
- 페이징마다 매번 새로운 commitRaws, commitDict, stemDict를 재구축하는 로직을 → 캐싱을 사용해서 이미 구축된 stem을 기반으로 buildPaginatedCSMDict 함수를 사용하도록 했습니다.
- 브랜치 변경, 새로고침 버튼은 캐싱을 사용하지 않도록 합니다.

## Work list
1. analyze-engine
- AnalyzeGitResult 반복되는 타입 추출
- commitRaws, commitDict, stemDict 초기 + 캐싱 처리

2. vscode
- ClusterNodesResult 반복되는 타입 추출
- engine 캐싱 로직
- fetchAnalyzedData, refresh 일때의 캐시 사용 처리 분기

3. view
- constant perpage, import 개선
- params payload 의 페이징 적용
- 더보기 버튼 처리 → 추후 무한 스크롤로 개선 예정

✅ 핵심 로직 변경 파일
* 페이징
[packages/analysis-engine/src/index.ts](https://github.com/githru/githru-vscode-ext/pull/937/files#diff-0adef9c60157dbf7f5612d148eff3b674d1b9ef453959fa2cbf30324269aa06f)
[packages/view/src/App.tsx](https://github.com/githru/githru-vscode-ext/pull/937/files#diff-dc3c054400c1c584b044e5dd405335a76a15ace9c924da6b8209740674664ff0)
* 캐싱 상태관리
[packages/view/src/store/data.ts](https://github.com/githru/githru-vscode-ext/pull/937/files#diff-b8b9dbcfd83c64168aaaea3af3625689959fdacac008aeb2742483679988738c)
[packages/view/src/hooks/useAnalayzedData.ts](https://github.com/githru/githru-vscode-ext/pull/937/files#diff-9d8b1583f51cb57e124820518d5c58911703781ca8045cec42eabab3de097a93)
* 캐싱
[packages/vscode/src/extension.ts](https://github.com/githru/githru-vscode-ext/pull/937/files#diff-b07d9e1ce11d8e806c911933f186c2955f9d8e94aaea85cf349cc98a8a088255)
[packages/vscode/src/webview-loader.ts](https://github.com/githru/githru-vscode-ext/pull/937/files#diff-af54979a683081abf3e2559e011da57934542171a8154f1f60642dce0f27ccf0)

## Discussion
![2025-10-077 28 23-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/cb21f8a0-74fb-49d2-ad7d-87118be7d22e)

시나리오
0 : 첫 로드
1 : load more 버튼 
2 : branch select 변경 → 새로운 브랜치리스트 이동은 데이터를 재생성하지만, 방문했던 브랜치를 다시 방문하면(develop) 캐싱 사용
3 : refresh 버튼 → 언제든 캐싱을 사용하지 않고, 데이터 재생성
