### PR TITLE
refactor(view): processMessage 함수 공통화 및 리팩토링

### DIFF
--- a/packages/view/src/components/@common/GithubIssueLink/GithubIssueLink.scss
+++ b/packages/view/src/components/@common/GithubIssueLink/GithubIssueLink.scss
@@ -1,6 +1,6 @@
 @import "styles/app";
 
-.commit-message__issue-link {
+.github-issue-link {
   color: var(--color-primary);
   text-decoration: none;
   font-weight: 500;

--- a/packages/view/src/components/@common/GithubIssueLink/GithubIssueLink.tsx
+++ b/packages/view/src/components/@common/GithubIssueLink/GithubIssueLink.tsx
@@ -11,7 +11,7 @@ const GithubIssueLink = ({ owner, repo, issueNumber, className, ...rest }: Githu
       href={issueLink}
       target="_blank"
       rel="noopener noreferrer"
-      className={cn("commit-message__issue-link", className)}
+      className={cn("github-issue-link", className)}
       title={`GitHub Issue #${issueNumber}`}
       {...rest}
     >

--- a/packages/view/src/components/@common/GithubIssueLink/index.ts
+++ b/packages/view/src/components/@common/GithubIssueLink/index.ts
@@ -1,1 +1,3 @@
 export { default as GithubIssueLink } from "./GithubIssueLink";
+export { renderIssueLinkedNodes } from "./renderIssueLinkedNodes";
+export type { IssueLinkedMessage } from "./types";

--- a/packages/view/src/components/@common/GithubIssueLink/renderIssueLinkedNodes.tsx
+++ b/packages/view/src/components/@common/GithubIssueLink/renderIssueLinkedNodes.tsx
@@ -1,0 +1,20 @@
+import { splitMessageByIssueRefs } from "utils/commitMessage";
+
+import GithubIssueLink from "./GithubIssueLink";
+
+export function renderIssueLinkedNodes(message: string, owner: string, repo: string) {
+  return splitMessageByIssueRefs(message).map((part) => {
+    if (part.type === "issue") {
+      const issueNumber = part.value.substring(1);
+      return (
+        <GithubIssueLink
+          key={`issue-${issueNumber}-${part.index}`}
+          owner={owner}
+          repo={repo}
+          issueNumber={issueNumber}
+        />
+      );
+    }
+    return part.value;
+  });
+}

--- a/packages/view/src/components/@common/GithubIssueLink/types.ts
+++ b/packages/view/src/components/@common/GithubIssueLink/types.ts
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+
+export type IssueLinkedMessage = {
+  title: ReactNode[];
+  body?: ReactNode[] | null;
+};

--- a/packages/view/src/components/Detail/Detail.tsx
+++ b/packages/view/src/components/Detail/Detail.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useMemo } from "react";
 import dayjs from "dayjs";
 import {
   AddCircleRounded,
@@ -13,26 +13,25 @@ import { Tooltip } from "@mui/material";
 
 import { useGithubInfo, useDataStore } from "store";
 import { Author } from "components/@common/Author";
-import { GithubIssueLink } from "components/@common/GithubIssueLink";
+import type { IssueLinkedMessage } from "components/@common/GithubIssueLink";
+import { renderIssueLinkedNodes } from "components/@common/GithubIssueLink";
 
 import { useCommitListHide } from "./Detail.hook";
 import { getCommitListDetail } from "./Detail.util";
 import { FIRST_SHOW_NUM } from "./Detail.const";
-import type { DetailProps, DetailSummaryProps, DetailSummaryItem, CommitItemProps, LinkedMessage } from "./Detail.type";
+import type { DetailProps, DetailSummaryProps, DetailSummaryItem, CommitItemProps } from "./Detail.type";
 
 import "./Detail.scss";
 
 const Detail = ({ clusterId, authSrcMap }: DetailProps) => {
   const selectedData = useDataStore((state) => state.selectedData);
-  const [linkedMessage, setLinkedMessage] = useState<LinkedMessage>({
-    title: [],
-    body: null,
-  });
-
   const { owner, repo } = useGithubInfo();
 
-  const commitNodeListInCluster =
-    selectedData?.filter((selected) => selected.commitNodeList[0].clusterId === clusterId)[0].commitNodeList ?? [];
+  const commitNodeListInCluster = useMemo(
+    () =>
+      selectedData?.filter((selected) => selected.commitNodeList[0].clusterId === clusterId)[0].commitNodeList ?? [],
+    [selectedData, clusterId]
+  );
   const { commitNodeList, toggle, handleToggle } = useCommitListHide(commitNodeListInCluster);
 
   const isShow = commitNodeListInCluster.length > FIRST_SHOW_NUM;
@@ -41,63 +40,17 @@ const Detail = ({ clusterId, authSrcMap }: DetailProps) => {
     navigator.clipboard.writeText(id);
   };
 
-  useEffect(() => {
-    const processMessage = (message: string) => {
-      // GitHub 이슈 번호 패턴: #123 또는 (#123)
-      const regex = /(?:^|\s)(#\d+)(?:\s|$)/g;
-      const parts: React.ReactNode[] = [];
-      let lastIndex = 0;
-      let match: RegExpExecArray | null;
+  const issueLinkedMessage: IssueLinkedMessage = useMemo(() => {
+    const message = commitNodeListInCluster?.[0]?.commit?.message;
+    if (!message) return { title: [], body: null };
 
-      while (true) {
-        match = regex.exec(message);
-        if (match === null) break;
+    const [title, ...rest] = message.split("\n");
+    const body = rest.filter((line) => line.trim()).join("\n");
 
-        // 이슈 번호 앞의 텍스트 추가
-        if (match.index > lastIndex) {
-          parts.push(message.slice(lastIndex, match.index));
-        }
-
-        const issueNumber = match[1].substring(1);
-
-        parts.push(
-          <GithubIssueLink
-            key={`issue-${issueNumber}-${match.index}`}
-            owner={owner}
-            repo={repo}
-            issueNumber={issueNumber}
-          />
-        );
-
-        lastIndex = match.index + match[0].length;
-      }
-
-      // 마지막 부분 추가
-      if (lastIndex < message.length) {
-        parts.push(message.slice(lastIndex));
-      }
-
-      return parts.length > 0 ? parts : [message];
+    return {
+      title: renderIssueLinkedNodes(title, owner, repo),
+      body: body ? renderIssueLinkedNodes(body, owner, repo) : null,
     };
-
-    if (commitNodeListInCluster?.[0]?.commit?.message) {
-      const { message } = commitNodeListInCluster[0].commit;
-      const messageLines = message.split("\n");
-      const title = messageLines[0];
-      const body = messageLines
-        .slice(1)
-        .filter((line: string) => line.trim())
-        .join("\n");
-
-      // 제목과 본문을 각각 처리
-      const processedTitle = processMessage(title);
-      const processedBody = body ? processMessage(body) : null;
-
-      setLinkedMessage({
-        title: processedTitle,
-        body: processedBody,
-      });
-    }
   }, [commitNodeListInCluster, owner, repo]);
 
   if (!selectedData || selectedData.length === 0) return null;
@@ -114,7 +67,7 @@ const Detail = ({ clusterId, authSrcMap }: DetailProps) => {
             repo={repo}
             authSrcMap={authSrcMap}
             handleCommitIdCopy={handleCommitIdCopy}
-            linkedMessage={linkedMessage}
+            linkedMessage={issueLinkedMessage}
           />
         ))}
       </ul>

--- a/packages/view/src/components/Detail/Detail.type.ts
+++ b/packages/view/src/components/Detail/Detail.type.ts
@@ -3,11 +3,7 @@ import type { ReactNode } from "react";
 import type { ClusterNode } from "types";
 import type { Commit } from "types/Commit";
 import type { AuthSrcMap } from "components/VerticalClusterList/Summary/Summary.type";
-
-export type LinkedMessage = {
-  title: ReactNode[];
-  body: ReactNode[] | null;
-};
+import type { IssueLinkedMessage } from "components/@common/GithubIssueLink";
 
 export type DetailProps = {
   clusterId: number;
@@ -29,5 +25,5 @@ export interface CommitItemProps {
   repo: string;
   authSrcMap: AuthSrcMap | null;
   handleCommitIdCopy: (id: string) => () => Promise<void>;
-  linkedMessage: LinkedMessage;
+  linkedMessage: IssueLinkedMessage;
 }

--- a/packages/view/src/components/VerticalClusterList/Summary/Content/Content.tsx
+++ b/packages/view/src/components/VerticalClusterList/Summary/Content/Content.tsx
@@ -1,69 +1,17 @@
-import React, { useEffect, useState } from "react";
+import { useMemo } from "react";
 import ArrowDropDownCircleRoundedIcon from "@mui/icons-material/ArrowDropDownCircleRounded";
 
 import { useGithubInfo } from "store";
-import { GithubIssueLink } from "components/@common/GithubIssueLink";
+import type { IssueLinkedMessage } from "components/@common/GithubIssueLink";
+import { renderIssueLinkedNodes } from "components/@common/GithubIssueLink";
 
 import type { ContentProps } from "../Summary.type";
 
-type LinkedMessage = {
-  title: React.ReactNode[];
-};
-
 const Content = ({ content, clusterId, selectedClusterIds }: ContentProps) => {
   const { owner, repo } = useGithubInfo();
-  const [linkedMessage, setLinkedMessage] = useState<LinkedMessage>({
-    title: [],
-  });
 
-  useEffect(() => {
-    const processMessage = (message: string) => {
-      // GitHub 이슈 번호 패턴: #123 또는 (#123)
-      const regex = /(?:^|\s)(#\d+)(?:\s|$)/g;
-      const parts: React.ReactNode[] = [];
-      let lastIndex = 0;
-      let match: RegExpExecArray | null;
-
-      while (true) {
-        match = regex.exec(message);
-        if (match === null) break;
-
-        // 이슈 번호 앞의 텍스트 추가
-        if (match.index > lastIndex) {
-          parts.push(message.slice(lastIndex, match.index));
-        }
-
-        const issueNumber = match[1].substring(1);
-
-        parts.push(
-          <GithubIssueLink
-            key={`issue-${issueNumber}-${match.index}`}
-            owner={owner}
-            repo={repo}
-            issueNumber={issueNumber}
-          />
-        );
-
-        lastIndex = match.index + match[0].length;
-      }
-
-      // 마지막 부분 추가
-      if (lastIndex < message.length) {
-        parts.push(message.slice(lastIndex));
-      }
-
-      return parts.length > 0 ? parts : [message];
-    };
-
-    const messageLines = content.message.split("\n");
-    const title = messageLines[0];
-
-    // 제목만 처리
-    const processedTitle = processMessage(title);
-
-    setLinkedMessage({
-      title: processedTitle,
-    });
+  const issueLinkedMessage: IssueLinkedMessage = useMemo(() => {
+    return { title: renderIssueLinkedNodes(content.message.split("\n")[0], owner, repo) };
   }, [content.message, owner, repo]);
 
   const messageLines = content.message.split("\n");
@@ -73,7 +21,9 @@ const Content = ({ content, clusterId, selectedClusterIds }: ContentProps) => {
     <>
       <div className="summary__content">
         <div className="summary__commit-message">
-          <div className="summary__commit-title">{linkedMessage.title.length > 0 ? linkedMessage.title : title}</div>
+          <div className="summary__commit-title">
+            {issueLinkedMessage.title.length > 0 ? issueLinkedMessage.title : title}
+          </div>
         </div>
         {content.count > 0 && <span className="summary__more-commit">+ {content.count} more</span>}
       </div>

--- a/packages/view/src/types/CommitMessageParts.ts
+++ b/packages/view/src/types/CommitMessageParts.ts
@@ -1,0 +1,4 @@
+type TextPart = { type: "text"; value: string };
+type IssueRefPart = { type: "issue"; value: string; index: number };
+
+export type CommitMessagePart = TextPart | IssueRefPart;

--- a/packages/view/src/types/index.ts
+++ b/packages/view/src/types/index.ts
@@ -3,3 +3,4 @@ export * from "./Nodes";
 export * from "./IDESentEvents";
 export * from "./IDEMessage";
 export * from "./Author";
+export * from "./CommitMessageParts";

--- a/packages/view/src/utils/commitMessage.test.ts
+++ b/packages/view/src/utils/commitMessage.test.ts
@@ -1,0 +1,110 @@
+import type { CommitMessagePart } from "types";
+
+import { splitMessageByIssueRefs } from "./commitMessage";
+
+describe("splitMessageByIssueRefs", () => {
+  type IssueRefSplitCase = readonly [
+    label: string,
+    message: string,
+    expectedParts: readonly string[],
+    expectedIssueRefs?: readonly string[],
+  ];
+
+  const values = (parts: CommitMessagePart[]) => parts.map((p) => p.value);
+  const issueRefs = (parts: CommitMessagePart[]) => parts.filter((p) => p.type === "issue").map((p) => p.value);
+
+  describe("when parsing GitHub issue refs", () => {
+    const issueRefParsingCases = [
+      [
+        "parses plain hash",
+        "feat(engine): add contributing.md #10",
+        ["feat(engine): add contributing.md ", "#10"],
+        ["#10"],
+      ],
+      [
+        "parses hash in parentheses",
+        "feat(engine): add contributing.md (#10)",
+        ["feat(engine): add contributing.md (", "#10", ")"],
+        ["#10"],
+      ],
+      [
+        "parses hash in square brackets",
+        "feat(engine): add contributing.md [#10]",
+        ["feat(engine): add contributing.md [", "#10", "]"],
+        ["#10"],
+      ],
+      [
+        "parses multiple hashes with mixed wrappers",
+        "fix: 500 on null (#10) and [#20], also #30",
+        ["fix: 500 on null (", "#10", ") and [", "#20", "], also ", "#30"],
+        ["#10", "#20", "#30"],
+      ],
+    ] as const satisfies readonly IssueRefSplitCase[];
+
+    it.each(issueRefParsingCases)("%s", (_, message, expectedParts, expectedIssueRefs) => {
+      const parts = splitMessageByIssueRefs(message);
+      expect(values(parts)).toEqual(expectedParts);
+      expect(issueRefs(parts)).toEqual(expectedIssueRefs);
+    });
+  });
+
+  describe("when refs appear at different positions", () => {
+    const refPositionCases = [
+      [
+        "parses ref at the start",
+        "#10 feat(engine): add contributing.md",
+        ["#10", " feat(engine): add contributing.md"],
+      ],
+      [
+        "parses ref in the middle",
+        "Merge pull request #10 from user/main",
+        ["Merge pull request ", "#10", " from user/main"],
+      ],
+      ["parses ref at the end", "feat(engine): add contributing.md #10", ["feat(engine): add contributing.md ", "#10"]],
+    ] as const satisfies readonly IssueRefSplitCase[];
+
+    it.each(refPositionCases)("%s", (_, message, expectedParts) => {
+      const parts = splitMessageByIssueRefs(message);
+      expect(values(parts)).toEqual(expectedParts);
+    });
+  });
+
+  describe("on invalid or edge cases", () => {
+    const edgeAndInvalidCases = [
+      [
+        "ignores word-internal refs",
+        "keep #9 but ignore #10abc and issue#11",
+        ["keep ", "#9", " but ignore #10abc and issue#11"],
+        ["#9"],
+      ],
+      [
+        "returns single text part when no refs are present",
+        "feat(engine): add contributing.md",
+        ["feat(engine): add contributing.md"],
+        [],
+      ],
+    ] as const satisfies readonly IssueRefSplitCase[];
+
+    it.each(edgeAndInvalidCases)("%s", (_, message, expectedParts, expectedIssueRefs) => {
+      const parts = splitMessageByIssueRefs(message);
+      expect(values(parts)).toEqual(expectedParts);
+      expect(issueRefs(parts)).toEqual(expectedIssueRefs);
+    });
+
+    it("computes correct index for each ref", () => {
+      const message = "A (#10) B [#20] C #30";
+      const parts = splitMessageByIssueRefs(message);
+      const issueParts = parts.filter((p): p is Extract<CommitMessagePart, { type: "issue" }> => p.type === "issue");
+      issueParts.forEach((part) => expect(message.slice(part.index, part.index + part.value.length)).toBe(part.value));
+    });
+
+    it("remains stateless across calls", () => {
+      const msg = "A (#10) B [#20] C #30";
+      const a = splitMessageByIssueRefs(msg);
+      const b = splitMessageByIssueRefs(msg);
+      expect(values(a)).toEqual(values(b));
+      expect(issueRefs(a)).toEqual(["#10", "#20", "#30"]);
+      expect(issueRefs(b)).toEqual(["#10", "#20", "#30"]);
+    });
+  });
+});

--- a/packages/view/src/utils/commitMessage.ts
+++ b/packages/view/src/utils/commitMessage.ts
@@ -1,0 +1,34 @@
+import type { CommitMessagePart } from "types";
+
+export function splitMessageByIssueRefs(message: string): CommitMessagePart[] {
+  const GITHUB_ISSUE_REGEX = /\(\s*(#[0-9]+)\s*\)|\[\s*(#[0-9]+)\s*\]|(?:^|\s)(#[0-9]+)(?=\s|$)/g;
+  const parts: CommitMessagePart[] = [];
+  let cursor = 0;
+
+  for (;;) {
+    const match = GITHUB_ISSUE_REGEX.exec(message);
+    if (!match) break;
+
+    const issueRef = match[1] ?? match[2] ?? match[3];
+    const issueRefStart = match.index + match[0].indexOf("#");
+    const issueRefEnd = issueRefStart + issueRef.length;
+
+    if (issueRefStart > cursor) {
+      parts.push({ type: "text", value: message.slice(cursor, issueRefStart) });
+    }
+
+    parts.push({
+      type: "issue",
+      value: issueRef,
+      index: issueRefStart,
+    });
+
+    cursor = issueRefEnd;
+  }
+
+  if (cursor < message.length) {
+    parts.push({ type: "text", value: message.slice(cursor) });
+  }
+
+  return parts;
+}


### PR DESCRIPTION
## Related issue
#900

## Result
`Detail.tsx`, `Content.tsx`에 중복되어 있던 커밋 메시지 파싱/이슈 링크 렌더링 로직을 공통 유틸과 헬퍼로 분리하는 리팩토링 작업을 진행했습니다.

## Work list
### 1. 커밋 메시지 분리 유틸 함수 추가
**splitMessageByIssueRefs** (`src/utils/commitMessage.ts`)

- 기존 `processMessage` 함수 로직을 공통 유틸로 분리
  - 이슈 링크 컴포넌트 생성 로직 제외, 문자열 파싱(텍스트/이슈 참조 분리)만 추출
  - 이슈 #900에 작성된 내용과 다르게 "이슈 번호 앞 텍스트 추출 / 마지막 텍스트 추가"와 같은 세부 단계를 별도 헬퍼로 쪼개지 않은 이유
    -> 한 번의 스캔으로 메시지를 분리하기 위함. 세부 단계로 나누면 각 단계에서 문자열을 분리/탐색하고 재조립하는 과정에서 중복 탐색이나 불필요한 메모리 할당이 발생할 수 있음. 단일 함수에서 커서 기반으로 처리

### 2. 파싱 오류 수정 / 기능 보강
- 괄호 패턴 지원
  - 기존 코드상 주석 처리된 부분에 괄호가 포함된 이슈 참조도 지원한다고 되어있으나 실제로는 처리되지 않음
  ```
  const processMessage = (message: string) => {
      // GitHub 이슈 번호 패턴: #123 또는 (#123)
      const regex = /(?:^|\s)(#\d+)(?:\s|$)/g;
      ....
  }
  ```
  -> `(#123)`, `[#123]`과 같은 패턴도 정확히 매칭하여 링크로 치환할 수 있도록 수정
- 커밋 메시지 원문 보존
  - 문제) 기존 메시지 분리 시 공백 누락. 재조립 시 원문 보존 X
  e.g. "Merge pull request #&#8203;921 from user/main" -> ["Merge pull request", "#&#8203;921" "from user/main"] -> "Merge pull request#&#8203;921from user/main"
  - 개선) 공백까지 포함하여 추출
    e.g. "Merge pull request #&#8203;921 from user/main" -> ["Merge pull request ", "#&#8203;921" " from user/main"] -> "Merge pull request #&#8203;921 from user/main"

(전)
<img width="1075" height="530" alt="스크린샷 2025-10-07 오전 1 24 52" src="https://github.com/user-attachments/assets/6e4ce3b5-3397-4d65-95e5-37a68ab34bbd" width="45%" />

(후)
<img width="1075" height="530" alt="스크린샷 2025-10-07 오전 1 16 24" src="https://github.com/user-attachments/assets/8f05042f-f816-4a3b-ac71-5938834c9b49" width="45%" />

### 3. splitMessageByIssueRefs 단위 테스트 추가
- [x] #&#8203;123, (#&#8203;123), [#&#8203;123], 다중 참조 패턴 매칭 확인
- [x] 이슈 참조가 문장 첫 번째, 중간, 마지막에 위치하는 경우 정확히 파싱되는지 확인
- [x] edge case 확인
  - [x] #&#8203;123abc와 같이 문자와 붙어있는 경우 파싱 X
  - [x] 커밋 메시지 내 이슈 참조가 존재하지 않는 경우 원문 텍스트 반환

### 4. Detail, Content 컴포넌트 리팩토링
- `renderIssueLinkedNodes` 공용 렌더 헬퍼 추출
  - 메시지 내 이슈 참조를 `GithubIssueLink`로 렌더하는 로직 분리
- 기존 useEffect, setState로 관리하던 제목/본문 파싱+렌더링 로직을 `useMemo`로 전환
  - 순수 파생값이므로 불필요한 추가 렌더링 제거 및 의존성 관리 단순화
- useState로 관리하던 `linkedMessge` -> `issueLinkedMessage`로 이름 변경
- Detail, Content에 중복으로 정의되어 있던 LinkedMessage 타입을 단일 타입으로 통합

### 5. 이전 PR 피드백 반영
Related issue: #921
- `GithubIssueLink` 컴포넌트 내 css 클래스명 변경 `commit-message__issue-link` -> `github-issue-link`
