### PR TITLE
refactor(view) : 스토리라인 차트 디자인 변경

### DIFF
--- a/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.scss
+++ b/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.scss
@@ -1,6 +1,19 @@
 @import "../../styles/colors";
 
 .folder-activity-flow {
+  // Chart color palette for contributors
+  --chart-color-1: #e06091;  // githru-pri
+  --chart-color-2: #8840bb;  // githru-sec
+  --chart-color-3: #ffd08a;  // githru-ter
+  --chart-color-4: #07bebe;  // githru-suc
+  --chart-color-5: #456cf7;  // hacker-pri
+  --chart-color-6: #0687a3;  // aqua-sec
+  --chart-color-7: #ffcccb;  // cotton-pri
+  --chart-color-8: #feffd1;  // cotton-sec
+  --chart-color-9: #3a4776;  // mono-sec
+  --chart-color-10: #aa4b72; // mono-fai
+
+
   padding: 1rem;
   margin-bottom: 2rem;
   background: $color-background;
@@ -89,7 +102,8 @@
     display: block;
     margin: 0 auto;
     cursor: grab;
-    
+    background: $color-background;
+
     &:active {
       cursor: grabbing;
     }

--- a/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.scss
+++ b/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.scss
@@ -1,7 +1,9 @@
+@import "../../styles/colors";
+
 .folder-activity-flow {
   padding: 1rem;
   margin-bottom: 2rem;
-  background: #ffffff;
+  background: $color-background;
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 
@@ -16,13 +18,13 @@
     margin: 0 0 0.5rem 0;
     font-size: 1.2rem;
     font-weight: 600;
-    color: #212529;
+    color: $color-white;
   }
 
   &__subtitle {
     margin: 0 0 0.5rem 0;
     font-size: 0.875rem;
-    color: #6c757d;
+    color: $color-light-gray;
   }
 
   &__mode-toggle {
@@ -41,7 +43,7 @@
   &__breadcrumb {
     margin: 0 0 1rem 0;
     padding: 0.5rem;
-    background: #f8f9fa;
+    background: $color-dark-gray;
     border-radius: 4px;
     font-size: 0.875rem;
     display: flex;
@@ -49,21 +51,21 @@
     gap: 0.5rem;
 
     .separator {
-      color: #6c757d;
+      color: $color-light-gray;
     }
 
     .clickable {
-      color: #007bff;
+      color: #456cf7;
       cursor: pointer;
       text-decoration: underline;
-      
+
       &:hover {
-        color: #0056b3;
+        color: #e06091;
       }
     }
 
     .current {
-      color: #212529;
+      color: $color-white;
       font-weight: 600;
     }
   }
@@ -71,15 +73,15 @@
   &__back-btn {
     margin-left: auto;
     padding: 0.25rem 0.5rem;
-    background: #007bff;
+    background: #456cf7;
     color: white;
     border: none;
     border-radius: 4px;
     font-size: 0.75rem;
     cursor: pointer;
-    
+
     &:hover {
-      background: #0056b3;
+      background: #e06091;
     }
   }
 
@@ -122,21 +124,21 @@
 
   .lane-background {
     transition: fill 0.2s ease;
-    
+
     &:hover {
-      fill: #e9ecef;
+      fill: #757880;
     }
   }
 
   .folder-label {
     font-weight: 500;
-    
+
     &.clickable {
       cursor: pointer;
       transition: fill 0.2s ease;
-      
+
       &:hover {
-        fill: #007bff !important;
+        fill: #e06091 !important;
       }
     }
   }
@@ -158,11 +160,11 @@
   .x-axis {
     .domain,
     .tick line {
-      stroke: #dee2e6;
+      stroke: $color-medium-gray;
     }
-    
+
     .tick text {
-      fill: #6c757d;
+      fill: $color-light-gray;
       font-size: 11px;
     }
   }

--- a/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.tsx
+++ b/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.tsx
@@ -1,294 +1,139 @@
-import { useRef, useEffect, useState } from "react";
-import { useShallow } from "zustand/react/shallow";
 import * as d3 from "d3";
+import { useEffect, useRef } from "react";
+import { useShallow } from "zustand/react/shallow";
 
 import { useDataStore } from "store";
-import { pxToRem } from "utils/pxToRem";
-import { getTopFolders, type FolderActivity } from "./FolderActivityFlow.analyzer";
-import { getSubFolders } from "./FolderActivityFlow.subfolder";
 
 import { DIMENSIONS } from "./FolderActivityFlow.const";
-import {
-  extractContributorActivities,
-  generateFlowLineData,
-  calculateNodePosition,
-  findFirstContributorNodes,
-  generateFlowLinePath
-} from "./FolderActivityFlow.util";
-import type { ContributorActivity } from "./FolderActivityFlow.type";
 import "./FolderActivityFlow.scss";
+import { extractContributorActivities, extractReleaseBasedContributorActivities } from "./FolderActivityFlow.util";
+import { renderClusterVisualization } from "./ClusterVisualization";
+import { renderReleaseVisualization } from "./ReleaseVisualization";
+import { useFolderNavigation } from "./useFolderNavigation";
 
 const FolderActivityFlow = () => {
-  const [totalData] = useDataStore(
-    useShallow((state) => [state.data])
-  );
+  const [totalData] = useDataStore(useShallow((state) => [state.data]));
 
   const svgRef = useRef<SVGSVGElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
-  const [topFolders, setTopFolders] = useState<FolderActivity[]>([]);
-  const [currentPath, setCurrentPath] = useState<string>("");
-  const [folderDepth, setFolderDepth] = useState<number>(1);
 
-
-  // 폴더 클릭 처리
-  const handleFolderClick = (folderPath: string) => {
-    if (folderPath === '.') return;
-
-    const subFolders = getSubFolders(totalData, folderPath);
-    if (subFolders.length > 0) {
-      setCurrentPath(folderPath);
-      setFolderDepth(folderDepth + 1);
-      setTopFolders(subFolders);
-    }
-  };
-
-  // 상위 폴더로 이동
-  const handleGoUp = () => {
-    if (currentPath === "") return;
-
-    const parentPath = currentPath.includes('/')
-      ? currentPath.substring(0, currentPath.lastIndexOf('/'))
-      : "";
-
-    if (parentPath === "") {
-      setCurrentPath("");
-      setFolderDepth(1);
-      const rootFolders = getTopFolders(totalData.flat(), 8, 1);
-      setTopFolders(rootFolders);
-    } else {
-      setCurrentPath(parentPath);
-      setFolderDepth(Math.max(1, folderDepth - 1));
-      const subFolders = getSubFolders(totalData, parentPath);
-      setTopFolders(subFolders);
-    }
-  };
-
-  const handleBreadcrumbClick = (index: number) => {
-    if (index === 0) {
-      setCurrentPath("");
-      setFolderDepth(1);
-      const folders = getTopFolders(totalData, 8, 1);
-      setTopFolders(folders);
-    } else if (index < getBreadcrumbs().length - 1) {
-      const pathParts = currentPath.split("/");
-      const targetPath = pathParts.slice(0, index).join("/");
-      setCurrentPath(targetPath);
-      setFolderDepth(index + 1);
-      const subFolders = getSubFolders(totalData, targetPath);
-      setTopFolders(subFolders);
-    }
-  };
+  const {
+    topFolders,
+    currentPath,
+    isReleaseMode,
+    releaseGroups,
+    releaseTopFolderPaths,
+    toggleMode,
+    navigateToFolder,
+    navigateUp,
+    navigateToBreadcrumb,
+    initializeRootFolders,
+    getBreadcrumbs,
+  } = useFolderNavigation(totalData);
 
   useEffect(() => {
-    if (!totalData || totalData.length === 0) return;
-
-    // 루트 폴더로 초기화
-    if (currentPath === "") {
-      const folders = getTopFolders(totalData.flat(), 8, 1);
-      setTopFolders(folders);
-    }
-  }, [totalData]);
+    initializeRootFolders();
+  }, [initializeRootFolders]);
 
   useEffect(() => {
-    if (!totalData || totalData.length === 0 || topFolders.length === 0) return;
-
-    const svg = d3.select(svgRef.current)
-      .attr("width", DIMENSIONS.width)
-      .attr("height", DIMENSIONS.height);
-
-    const tooltip = d3.select(tooltipRef.current);
-
-    svg.selectAll("*").remove();
-
-    // 기여자 활동 데이터 추출
-    const contributorActivities = extractContributorActivities(totalData, topFolders, currentPath);
-
-    if (contributorActivities.length === 0) {
-      svg.append("text")
-        .attr("x", DIMENSIONS.width / 2)
-        .attr("y", DIMENSIONS.height / 2)
-        .attr("text-anchor", "middle")
-        .attr("dominant-baseline", "middle")
-        .text("No activity data available for this folder")
-        .style("font-size", "14px")
-        .style("fill", "#757880");
+    if (!totalData || totalData.length === 0) {
       return;
     }
 
-    // 스케일 설정
-    const uniqueContributors = Array.from(new Set(contributorActivities.map(a => a.contributorName)));
-    const uniqueClusters = Array.from(new Set(contributorActivities.map(a => a.clusterIndex))).sort((a, b) => a - b);
-
-    const xScale = d3.scaleBand()
-      .domain(uniqueClusters.map(String))
-      .range([DIMENSIONS.margin.left, DIMENSIONS.width - DIMENSIONS.margin.right])
-      .paddingInner(0.1);
-
-    const yScale = d3.scaleBand()
-      .domain(topFolders.map(f => f.folderPath))
-      .range([DIMENSIONS.margin.top, DIMENSIONS.height - DIMENSIONS.margin.bottom])
-      .paddingInner(0.2);
-
-    const sizeScale = d3.scaleSqrt()
-      .domain([0, d3.max(contributorActivities, d => d.changes) || 1])
-      .range([3, 12]);
-
-    const colorScale = d3.scaleOrdinal()
-      .domain(uniqueContributors)
-      .range(['#e06091', '#8840bb', '#ffd08a', '#07bebe', '#456cf7', '#0687a3', '#ffcccb', '#feffd1', '#3a4776', '#aa4b72']);
-
-    const mainGroup = svg.append("g");
-
-    // 폴더 레이블 그리기
-    mainGroup.selectAll(".folder-label")
-      .data(topFolders)
-      .enter()
-      .append("text")
-      .attr("class", "folder-label clickable")
-      .attr("x", DIMENSIONS.width - DIMENSIONS.margin.right + 10)
-      .attr("y", d => (yScale(d.folderPath) || 0) + yScale.bandwidth() / 2)
-      .attr("text-anchor", "start")
-      .attr("dominant-baseline", "middle")
-      .text(d => {
-        if (d.folderPath === '.') return 'root';
-
-        const fileName = d.folderPath.includes('/')
-          ? d.folderPath.split('/').pop()
-          : d.folderPath;
-
-        return fileName && fileName.length > 15
-          ? fileName.substring(0, 12) + "..."
-          : fileName || 'unknown';
-      })
-      .style("font-size", "12px")
-      .style("fill", "#b4bac6")
-      .style("font-weight", "500")
-      .style("cursor", "pointer")
-      .on("click", (_event, d) => {
-        if (d.folderPath !== '.') {
-          handleFolderClick(d.folderPath);
-        }
-      })
-      .on("mouseover", function() {
-        d3.select(this).style("fill", "#e06091");
-      })
-      .on("mouseout", function() {
-        d3.select(this).style("fill", "#b4bac6");
-      });
-
-    // 클러스터 축
-    const xAxis = d3.axisBottom(xScale)
-      .tickFormat((d: any) => `Cluster ${parseInt(d) + 1}`);
-
-    mainGroup.append("g")
-      .attr("class", "x-axis")
-      .attr("transform", `translate(0, ${DIMENSIONS.height - DIMENSIONS.margin.bottom})`)
-      .call(xAxis as any);
-
-    // 클러스터 내 노드 위치 계산
-    const activitiesByCluster = new Map<number, ContributorActivity[]>();
-    contributorActivities.forEach(activity => {
-      if (!activitiesByCluster.has(activity.clusterIndex)) {
-        activitiesByCluster.set(activity.clusterIndex, []);
+    if (isReleaseMode) {
+      if (releaseGroups.length === 0 || releaseTopFolderPaths.length === 0) {
+        return;
       }
-      activitiesByCluster.get(activity.clusterIndex)!.push(activity);
-    });
+    } else if (topFolders.length === 0) {
+      return;
+    }
 
-    // 활동 노드 그리기
-    const dots = mainGroup.selectAll(".activity-dot")
-      .data(contributorActivities)
-      .enter()
-      .append("circle")
-      .attr("class", "activity-dot")
-      .attr("cx", d => calculateNodePosition(d, xScale, activitiesByCluster))
-      .attr("cy", d => (yScale(d.folderPath) || 0) + yScale.bandwidth() / 2)
-      .attr("r", d => sizeScale(d.changes))
-      .attr("fill", d => colorScale(d.contributorName) as string)
-      .attr("fill-opacity", 1)
-      .attr("stroke", "#fff")
-      .attr("stroke-width", 1);
+    const svg = d3.select(svgRef.current).attr("width", DIMENSIONS.width).attr("height", DIMENSIONS.height);
 
-    // 툴팁 이벤트
-    dots.on("mouseover", (event, d) => {
-        tooltip
-          .style("display", "inline-block")
-          .style("left", pxToRem(event.pageX + 10))
-          .style("top", pxToRem(event.pageY - 10))
-          .html(`
-            <div class="contributor-activity-tooltip">
-              <p><strong>${d.contributorName}</strong></p>
-              <p>Cluster: ${d.clusterIndex + 1}</p>
-              <p>Folder: ${d.folderPath === '.' ? 'root' : d.folderPath}</p>
-              <p>Date: ${d.date.toLocaleDateString()}</p>
-              <p>Changes: ${d.changes}</p>
-              <p style="color: #28a745;">+${d.insertions} insertions</p>
-              <p style="color: #dc3545;">-${d.deletions} deletions</p>
-            </div>
-          `);
-      })
-      .on("mousemove", (event) => {
-        tooltip
-          .style("left", pxToRem(event.pageX + 10))
-          .style("top", pxToRem(event.pageY - 10));
-      })
-      .on("mouseout", () => {
-        tooltip.style("display", "none");
+    svg.selectAll("*").remove();
+
+    if (isReleaseMode) {
+      const currentDepth = currentPath === "" ? 1 : currentPath.split("/").length + 1;
+      const releaseContributorActivities = extractReleaseBasedContributorActivities(
+        totalData,
+        releaseTopFolderPaths,
+        currentDepth
+      );
+
+      if (releaseContributorActivities.length === 0) {
+        svg
+          .append("text")
+          .attr("x", DIMENSIONS.width / 2)
+          .attr("y", DIMENSIONS.height / 2)
+          .attr("text-anchor", "middle")
+          .attr("dominant-baseline", "middle")
+          .text("No release activity data available")
+          .style("font-size", "14px")
+          .style("fill", "#6c757d");
+        return;
+      }
+
+      renderReleaseVisualization({
+        svg,
+        releaseContributorActivities,
+        releaseTopFolderPaths,
+        tooltipRef,
+        onFolderClick: navigateToFolder,
       });
+    } else {
+      const contributorActivities = extractContributorActivities(totalData, topFolders, currentPath);
 
-    // 기여자별 첫 노드에 이름 라벨
-    const firstNodesByContributor = findFirstContributorNodes(contributorActivities);
+      if (contributorActivities.length === 0) {
+        svg
+          .append("text")
+          .attr("x", DIMENSIONS.width / 2)
+          .attr("y", DIMENSIONS.height / 2)
+          .attr("text-anchor", "middle")
+          .attr("dominant-baseline", "middle")
+          .text("No activity data available for this folder")
+          .style("font-size", "14px")
+          .style("fill", "#6c757d");
+        return;
+      }
 
-    mainGroup.selectAll(".contributor-label")
-      .data(Array.from(firstNodesByContributor.values()))
-      .enter()
-      .append("text")
-      .attr("class", "contributor-label")
-      .attr("x", d => calculateNodePosition(d, xScale, activitiesByCluster))
-      .attr("y", d => (yScale(d.folderPath) || 0) + yScale.bandwidth() / 2 - sizeScale(d.changes) - 5)
-      .attr("text-anchor", "middle")
-      .attr("dominant-baseline", "bottom")
-      .text(d => d.contributorName)
-      .style("font-size", "10px")
-      .style("fill", "#b4bac6")
-      .style("font-weight", "500")
-      .style("pointer-events", "none");
-
-    // 플로우 라인 그리기
-    const flowLineData = generateFlowLineData(contributorActivities);
-
-    mainGroup.selectAll(".flow-line")
-      .data(flowLineData)
-      .enter()
-      .append("path")
-      .attr("class", "flow-line")
-      .attr("d", d => generateFlowLinePath(d, xScale, yScale))
-      .attr("fill", "none")
-      .attr("stroke", d => colorScale(d.contributorName) as string)
-      .attr("stroke-width", 2)
-      .attr("stroke-opacity", 0.6);
-
-  }, [totalData, topFolders]);
-
-  // 브레드크럼 생성
-  const getBreadcrumbs = () => {
-    if (currentPath === "") return ["root"];
-    const parts = currentPath.split("/");
-    const breadcrumbs = ["root"];
-    let current = "";
-
-    parts.forEach(part => {
-      current = current ? `${current}/${part}` : part;
-      breadcrumbs.push(part);
-    });
-
-    return breadcrumbs;
-  };
+      renderClusterVisualization({
+        svg,
+        contributorActivities,
+        topFolders,
+        tooltipRef,
+        onFolderClick: navigateToFolder,
+      });
+    }
+  }, [totalData, topFolders, isReleaseMode, releaseGroups, releaseTopFolderPaths, navigateToFolder]);
 
   return (
     <div className="folder-activity-flow">
-      <p className="folder-activity-flow__title">Contributors Folder Activity Flow</p>
-      <div className="folder-activity-flow__subtitle">
-        Contributors moving between top folders over time
+      <div className="folder-activity-flow__header">
+        <div>
+          <p className="folder-activity-flow__title">Contributors Folder Activity Flow</p>
+          <div className="folder-activity-flow__subtitle">
+            {isReleaseMode
+              ? "Contributors moving between folders across releases"
+              : "Contributors moving between top folders over time"}
+          </div>
+        </div>
+        <button
+          type="button"
+          className="folder-activity-flow__mode-toggle"
+          onClick={toggleMode}
+          style={{
+            padding: "8px 16px",
+            backgroundColor: isReleaseMode ? "#28a745" : "#007bff",
+            color: "white",
+            border: "none",
+            borderRadius: "4px",
+            cursor: "pointer",
+            fontSize: "14px",
+            fontWeight: "500",
+          }}
+        >
+          {isReleaseMode ? "📋 Release Mode" : "🔗 Cluster Mode"}
+        </button>
       </div>
 
       <div className="folder-activity-flow__breadcrumb">
@@ -297,7 +142,15 @@ const FolderActivityFlow = () => {
             {index > 0 && <span className="separator"> / </span>}
             <span
               className={index === getBreadcrumbs().length - 1 ? "current" : "clickable"}
-              onClick={() => handleBreadcrumbClick(index)}
+              onClick={() => navigateToBreadcrumb(index, getBreadcrumbs().length)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  navigateToBreadcrumb(index, getBreadcrumbs().length);
+                }
+              }}
+              role="button"
+              tabIndex={index === getBreadcrumbs().length - 1 ? -1 : 0}
             >
               {crumb}
             </span>
@@ -305,8 +158,9 @@ const FolderActivityFlow = () => {
         ))}
         {currentPath !== "" && (
           <button
+            type="button"
             className="folder-activity-flow__back-btn"
-            onClick={handleGoUp}
+            onClick={navigateUp}
           >
             ← Up
           </button>

--- a/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.tsx
+++ b/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.tsx
@@ -1,139 +1,294 @@
-import * as d3 from "d3";
-import { useEffect, useRef } from "react";
+import { useRef, useEffect, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
+import * as d3 from "d3";
 
 import { useDataStore } from "store";
+import { pxToRem } from "utils/pxToRem";
+import { getTopFolders, type FolderActivity } from "./FolderActivityFlow.analyzer";
+import { getSubFolders } from "./FolderActivityFlow.subfolder";
 
 import { DIMENSIONS } from "./FolderActivityFlow.const";
+import {
+  extractContributorActivities,
+  generateFlowLineData,
+  calculateNodePosition,
+  findFirstContributorNodes,
+  generateFlowLinePath
+} from "./FolderActivityFlow.util";
+import type { ContributorActivity } from "./FolderActivityFlow.type";
 import "./FolderActivityFlow.scss";
-import { extractContributorActivities, extractReleaseBasedContributorActivities } from "./FolderActivityFlow.util";
-import { renderClusterVisualization } from "./ClusterVisualization";
-import { renderReleaseVisualization } from "./ReleaseVisualization";
-import { useFolderNavigation } from "./useFolderNavigation";
 
 const FolderActivityFlow = () => {
-  const [totalData] = useDataStore(useShallow((state) => [state.data]));
+  const [totalData] = useDataStore(
+    useShallow((state) => [state.data])
+  );
 
   const svgRef = useRef<SVGSVGElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
+  const [topFolders, setTopFolders] = useState<FolderActivity[]>([]);
+  const [currentPath, setCurrentPath] = useState<string>("");
+  const [folderDepth, setFolderDepth] = useState<number>(1);
 
-  const {
-    topFolders,
-    currentPath,
-    isReleaseMode,
-    releaseGroups,
-    releaseTopFolderPaths,
-    toggleMode,
-    navigateToFolder,
-    navigateUp,
-    navigateToBreadcrumb,
-    initializeRootFolders,
-    getBreadcrumbs,
-  } = useFolderNavigation(totalData);
+
+  // 폴더 클릭 처리
+  const handleFolderClick = (folderPath: string) => {
+    if (folderPath === '.') return;
+
+    const subFolders = getSubFolders(totalData, folderPath);
+    if (subFolders.length > 0) {
+      setCurrentPath(folderPath);
+      setFolderDepth(folderDepth + 1);
+      setTopFolders(subFolders);
+    }
+  };
+
+  // 상위 폴더로 이동
+  const handleGoUp = () => {
+    if (currentPath === "") return;
+
+    const parentPath = currentPath.includes('/')
+      ? currentPath.substring(0, currentPath.lastIndexOf('/'))
+      : "";
+
+    if (parentPath === "") {
+      setCurrentPath("");
+      setFolderDepth(1);
+      const rootFolders = getTopFolders(totalData.flat(), 8, 1);
+      setTopFolders(rootFolders);
+    } else {
+      setCurrentPath(parentPath);
+      setFolderDepth(Math.max(1, folderDepth - 1));
+      const subFolders = getSubFolders(totalData, parentPath);
+      setTopFolders(subFolders);
+    }
+  };
+
+  const handleBreadcrumbClick = (index: number) => {
+    if (index === 0) {
+      setCurrentPath("");
+      setFolderDepth(1);
+      const folders = getTopFolders(totalData, 8, 1);
+      setTopFolders(folders);
+    } else if (index < getBreadcrumbs().length - 1) {
+      const pathParts = currentPath.split("/");
+      const targetPath = pathParts.slice(0, index).join("/");
+      setCurrentPath(targetPath);
+      setFolderDepth(index + 1);
+      const subFolders = getSubFolders(totalData, targetPath);
+      setTopFolders(subFolders);
+    }
+  };
 
   useEffect(() => {
-    initializeRootFolders();
-  }, [initializeRootFolders]);
+    if (!totalData || totalData.length === 0) return;
+
+    // 루트 폴더로 초기화
+    if (currentPath === "") {
+      const folders = getTopFolders(totalData.flat(), 8, 1);
+      setTopFolders(folders);
+    }
+  }, [totalData]);
 
   useEffect(() => {
-    if (!totalData || totalData.length === 0) {
-      return;
-    }
+    if (!totalData || totalData.length === 0 || topFolders.length === 0) return;
 
-    if (isReleaseMode) {
-      if (releaseGroups.length === 0 || releaseTopFolderPaths.length === 0) {
-        return;
-      }
-    } else if (topFolders.length === 0) {
-      return;
-    }
+    const svg = d3.select(svgRef.current)
+      .attr("width", DIMENSIONS.width)
+      .attr("height", DIMENSIONS.height);
 
-    const svg = d3.select(svgRef.current).attr("width", DIMENSIONS.width).attr("height", DIMENSIONS.height);
+    const tooltip = d3.select(tooltipRef.current);
 
     svg.selectAll("*").remove();
 
-    if (isReleaseMode) {
-      const currentDepth = currentPath === "" ? 1 : currentPath.split("/").length + 1;
-      const releaseContributorActivities = extractReleaseBasedContributorActivities(
-        totalData,
-        releaseTopFolderPaths,
-        currentDepth
-      );
+    // 기여자 활동 데이터 추출
+    const contributorActivities = extractContributorActivities(totalData, topFolders, currentPath);
 
-      if (releaseContributorActivities.length === 0) {
-        svg
-          .append("text")
-          .attr("x", DIMENSIONS.width / 2)
-          .attr("y", DIMENSIONS.height / 2)
-          .attr("text-anchor", "middle")
-          .attr("dominant-baseline", "middle")
-          .text("No release activity data available")
-          .style("font-size", "14px")
-          .style("fill", "#6c757d");
-        return;
-      }
-
-      renderReleaseVisualization({
-        svg,
-        releaseContributorActivities,
-        releaseTopFolderPaths,
-        tooltipRef,
-        onFolderClick: navigateToFolder,
-      });
-    } else {
-      const contributorActivities = extractContributorActivities(totalData, topFolders, currentPath);
-
-      if (contributorActivities.length === 0) {
-        svg
-          .append("text")
-          .attr("x", DIMENSIONS.width / 2)
-          .attr("y", DIMENSIONS.height / 2)
-          .attr("text-anchor", "middle")
-          .attr("dominant-baseline", "middle")
-          .text("No activity data available for this folder")
-          .style("font-size", "14px")
-          .style("fill", "#6c757d");
-        return;
-      }
-
-      renderClusterVisualization({
-        svg,
-        contributorActivities,
-        topFolders,
-        tooltipRef,
-        onFolderClick: navigateToFolder,
-      });
+    if (contributorActivities.length === 0) {
+      svg.append("text")
+        .attr("x", DIMENSIONS.width / 2)
+        .attr("y", DIMENSIONS.height / 2)
+        .attr("text-anchor", "middle")
+        .attr("dominant-baseline", "middle")
+        .text("No activity data available for this folder")
+        .style("font-size", "14px")
+        .style("fill", "#757880");
+      return;
     }
-  }, [totalData, topFolders, isReleaseMode, releaseGroups, releaseTopFolderPaths, navigateToFolder]);
+
+    // 스케일 설정
+    const uniqueContributors = Array.from(new Set(contributorActivities.map(a => a.contributorName)));
+    const uniqueClusters = Array.from(new Set(contributorActivities.map(a => a.clusterIndex))).sort((a, b) => a - b);
+
+    const xScale = d3.scaleBand()
+      .domain(uniqueClusters.map(String))
+      .range([DIMENSIONS.margin.left, DIMENSIONS.width - DIMENSIONS.margin.right])
+      .paddingInner(0.1);
+
+    const yScale = d3.scaleBand()
+      .domain(topFolders.map(f => f.folderPath))
+      .range([DIMENSIONS.margin.top, DIMENSIONS.height - DIMENSIONS.margin.bottom])
+      .paddingInner(0.2);
+
+    const sizeScale = d3.scaleSqrt()
+      .domain([0, d3.max(contributorActivities, d => d.changes) || 1])
+      .range([3, 12]);
+
+    const colorScale = d3.scaleOrdinal()
+      .domain(uniqueContributors)
+      .range(['#e06091', '#8840bb', '#ffd08a', '#07bebe', '#456cf7', '#0687a3', '#ffcccb', '#feffd1', '#3a4776', '#aa4b72']);
+
+    const mainGroup = svg.append("g");
+
+    // 폴더 레이블 그리기
+    mainGroup.selectAll(".folder-label")
+      .data(topFolders)
+      .enter()
+      .append("text")
+      .attr("class", "folder-label clickable")
+      .attr("x", DIMENSIONS.width - DIMENSIONS.margin.right + 10)
+      .attr("y", d => (yScale(d.folderPath) || 0) + yScale.bandwidth() / 2)
+      .attr("text-anchor", "start")
+      .attr("dominant-baseline", "middle")
+      .text(d => {
+        if (d.folderPath === '.') return 'root';
+
+        const fileName = d.folderPath.includes('/')
+          ? d.folderPath.split('/').pop()
+          : d.folderPath;
+
+        return fileName && fileName.length > 15
+          ? fileName.substring(0, 12) + "..."
+          : fileName || 'unknown';
+      })
+      .style("font-size", "12px")
+      .style("fill", "#b4bac6")
+      .style("font-weight", "500")
+      .style("cursor", "pointer")
+      .on("click", (_event, d) => {
+        if (d.folderPath !== '.') {
+          handleFolderClick(d.folderPath);
+        }
+      })
+      .on("mouseover", function() {
+        d3.select(this).style("fill", "#e06091");
+      })
+      .on("mouseout", function() {
+        d3.select(this).style("fill", "#b4bac6");
+      });
+
+    // 클러스터 축
+    const xAxis = d3.axisBottom(xScale)
+      .tickFormat((d: any) => `Cluster ${parseInt(d) + 1}`);
+
+    mainGroup.append("g")
+      .attr("class", "x-axis")
+      .attr("transform", `translate(0, ${DIMENSIONS.height - DIMENSIONS.margin.bottom})`)
+      .call(xAxis as any);
+
+    // 클러스터 내 노드 위치 계산
+    const activitiesByCluster = new Map<number, ContributorActivity[]>();
+    contributorActivities.forEach(activity => {
+      if (!activitiesByCluster.has(activity.clusterIndex)) {
+        activitiesByCluster.set(activity.clusterIndex, []);
+      }
+      activitiesByCluster.get(activity.clusterIndex)!.push(activity);
+    });
+
+    // 활동 노드 그리기
+    const dots = mainGroup.selectAll(".activity-dot")
+      .data(contributorActivities)
+      .enter()
+      .append("circle")
+      .attr("class", "activity-dot")
+      .attr("cx", d => calculateNodePosition(d, xScale, activitiesByCluster))
+      .attr("cy", d => (yScale(d.folderPath) || 0) + yScale.bandwidth() / 2)
+      .attr("r", d => sizeScale(d.changes))
+      .attr("fill", d => colorScale(d.contributorName) as string)
+      .attr("fill-opacity", 1)
+      .attr("stroke", "#fff")
+      .attr("stroke-width", 1);
+
+    // 툴팁 이벤트
+    dots.on("mouseover", (event, d) => {
+        tooltip
+          .style("display", "inline-block")
+          .style("left", pxToRem(event.pageX + 10))
+          .style("top", pxToRem(event.pageY - 10))
+          .html(`
+            <div class="contributor-activity-tooltip">
+              <p><strong>${d.contributorName}</strong></p>
+              <p>Cluster: ${d.clusterIndex + 1}</p>
+              <p>Folder: ${d.folderPath === '.' ? 'root' : d.folderPath}</p>
+              <p>Date: ${d.date.toLocaleDateString()}</p>
+              <p>Changes: ${d.changes}</p>
+              <p style="color: #28a745;">+${d.insertions} insertions</p>
+              <p style="color: #dc3545;">-${d.deletions} deletions</p>
+            </div>
+          `);
+      })
+      .on("mousemove", (event) => {
+        tooltip
+          .style("left", pxToRem(event.pageX + 10))
+          .style("top", pxToRem(event.pageY - 10));
+      })
+      .on("mouseout", () => {
+        tooltip.style("display", "none");
+      });
+
+    // 기여자별 첫 노드에 이름 라벨
+    const firstNodesByContributor = findFirstContributorNodes(contributorActivities);
+
+    mainGroup.selectAll(".contributor-label")
+      .data(Array.from(firstNodesByContributor.values()))
+      .enter()
+      .append("text")
+      .attr("class", "contributor-label")
+      .attr("x", d => calculateNodePosition(d, xScale, activitiesByCluster))
+      .attr("y", d => (yScale(d.folderPath) || 0) + yScale.bandwidth() / 2 - sizeScale(d.changes) - 5)
+      .attr("text-anchor", "middle")
+      .attr("dominant-baseline", "bottom")
+      .text(d => d.contributorName)
+      .style("font-size", "10px")
+      .style("fill", "#b4bac6")
+      .style("font-weight", "500")
+      .style("pointer-events", "none");
+
+    // 플로우 라인 그리기
+    const flowLineData = generateFlowLineData(contributorActivities);
+
+    mainGroup.selectAll(".flow-line")
+      .data(flowLineData)
+      .enter()
+      .append("path")
+      .attr("class", "flow-line")
+      .attr("d", d => generateFlowLinePath(d, xScale, yScale))
+      .attr("fill", "none")
+      .attr("stroke", d => colorScale(d.contributorName) as string)
+      .attr("stroke-width", 2)
+      .attr("stroke-opacity", 0.6);
+
+  }, [totalData, topFolders]);
+
+  // 브레드크럼 생성
+  const getBreadcrumbs = () => {
+    if (currentPath === "") return ["root"];
+    const parts = currentPath.split("/");
+    const breadcrumbs = ["root"];
+    let current = "";
+
+    parts.forEach(part => {
+      current = current ? `${current}/${part}` : part;
+      breadcrumbs.push(part);
+    });
+
+    return breadcrumbs;
+  };
 
   return (
     <div className="folder-activity-flow">
-      <div className="folder-activity-flow__header">
-        <div>
-          <p className="folder-activity-flow__title">Contributors Folder Activity Flow</p>
-          <div className="folder-activity-flow__subtitle">
-            {isReleaseMode
-              ? "Contributors moving between folders across releases"
-              : "Contributors moving between top folders over time"}
-          </div>
-        </div>
-        <button
-          type="button"
-          className="folder-activity-flow__mode-toggle"
-          onClick={toggleMode}
-          style={{
-            padding: "8px 16px",
-            backgroundColor: isReleaseMode ? "#28a745" : "#007bff",
-            color: "white",
-            border: "none",
-            borderRadius: "4px",
-            cursor: "pointer",
-            fontSize: "14px",
-            fontWeight: "500",
-          }}
-        >
-          {isReleaseMode ? "📋 Release Mode" : "🔗 Cluster Mode"}
-        </button>
+      <p className="folder-activity-flow__title">Contributors Folder Activity Flow</p>
+      <div className="folder-activity-flow__subtitle">
+        Contributors moving between top folders over time
       </div>
 
       <div className="folder-activity-flow__breadcrumb">
@@ -142,15 +297,7 @@ const FolderActivityFlow = () => {
             {index > 0 && <span className="separator"> / </span>}
             <span
               className={index === getBreadcrumbs().length - 1 ? "current" : "clickable"}
-              onClick={() => navigateToBreadcrumb(index, getBreadcrumbs().length)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  navigateToBreadcrumb(index, getBreadcrumbs().length);
-                }
-              }}
-              role="button"
-              tabIndex={index === getBreadcrumbs().length - 1 ? -1 : 0}
+              onClick={() => handleBreadcrumbClick(index)}
             >
               {crumb}
             </span>
@@ -158,9 +305,8 @@ const FolderActivityFlow = () => {
         ))}
         {currentPath !== "" && (
           <button
-            type="button"
             className="folder-activity-flow__back-btn"
-            onClick={navigateUp}
+            onClick={handleGoUp}
           >
             ← Up
           </button>

--- a/packages/view/src/components/FolderActivityFlow/ReleaseVisualization.tsx
+++ b/packages/view/src/components/FolderActivityFlow/ReleaseVisualization.tsx
@@ -71,58 +71,47 @@ export const renderReleaseVisualization = ({
     .domain([0, d3.max(releaseContributorActivities, (d) => d.changes) || 1])
     .range([3, 12]);
 
-  const colorScale = d3.scaleOrdinal().domain(uniqueContributors).range(d3.schemeCategory10);
+  const svgElement = svg.node();
+  const parentElement = svgElement?.parentElement;
+  const chartColors = Array.from({ length: 10 }, (_, i) =>
+    getComputedStyle(parentElement || document.documentElement)
+      .getPropertyValue(`--chart-color-${i + 1}`)
+      .trim()
+  );
+
+  const colorScale = d3.scaleOrdinal().domain(uniqueContributors).range(chartColors);
 
   const mainGroup = svg.append("g");
 
-  // 폴더 레인 그리기
   mainGroup
-    .selectAll(".folder-lane")
+    .selectAll(".folder-label")
     .data(releaseTopFolderPaths)
     .enter()
-    .append("g")
-    .attr("class", "folder-lane")
-    .each(function (this: SVGGElement, folderPath: string) {
-      const lane = d3.select(this);
-
-      lane
-        .append("rect")
-        .attr("class", "lane-background")
-        .attr("x", DIMENSIONS.margin.left)
-        .attr("y", yScale(folderPath) || 0)
-        .attr("width", DIMENSIONS.width - DIMENSIONS.margin.left - DIMENSIONS.margin.right)
-        .attr("height", yScale.bandwidth())
-        .attr("fill", "#f8f9fa")
-        .attr("stroke", "#dee2e6")
-        .attr("stroke-width", 1);
-
-      lane
-        .append("text")
-        .attr("class", "folder-label clickable")
-        .attr("x", DIMENSIONS.width - DIMENSIONS.margin.right + 10)
-        .attr("y", (yScale(folderPath) || 0) + yScale.bandwidth() / 2)
-        .attr("text-anchor", "start")
-        .attr("dominant-baseline", "middle")
-        .text(() => {
-          if (folderPath === ".") return "root";
-          const fileName = folderPath.includes("/") ? folderPath.split("/").pop() : folderPath;
-          return fileName && fileName.length > 15 ? `${fileName.substring(0, 12)}...` : fileName || "unknown";
-        })
-        .style("font-size", "12px")
-        .style("fill", "#495057")
-        .style("font-weight", "500")
-        .style("cursor", "pointer")
-        .on("click", () => {
-          if (folderPath !== ".") {
-            onFolderClick(folderPath);
-          }
-        })
-        .on("mouseover", function () {
-          d3.select(this).style("fill", "#007bff");
-        })
-        .on("mouseout", function () {
-          d3.select(this).style("fill", "#495057");
-        });
+    .append("text")
+    .attr("class", "folder-label clickable")
+    .attr("x", DIMENSIONS.width - DIMENSIONS.margin.right + 10)
+    .attr("y", (folderPath: string) => (yScale(folderPath) || 0) + yScale.bandwidth() / 2)
+    .attr("text-anchor", "start")
+    .attr("dominant-baseline", "middle")
+    .text((folderPath: string) => {
+      if (folderPath === ".") return "root";
+      const fileName = folderPath.includes("/") ? folderPath.split("/").pop() : folderPath;
+      return fileName && fileName.length > 15 ? `${fileName.substring(0, 12)}...` : fileName || "unknown";
+    })
+    .style("font-size", "12px")
+    .style("fill", "#b4bac6")
+    .style("font-weight", "500")
+    .style("cursor", "pointer")
+    .on("click", (_event: MouseEvent, folderPath: string) => {
+      if (folderPath !== ".") {
+        onFolderClick(folderPath);
+      }
+    })
+    .on("mouseover", function () {
+      d3.select(this).style("fill", "#e06091");
+    })
+    .on("mouseout", function () {
+      d3.select(this).style("fill", "#b4bac6");
     });
 
   // 릴리즈 축
@@ -156,9 +145,7 @@ export const renderReleaseVisualization = ({
     .attr("cy", (d: ReleaseContributorActivity) => (yScale(d.folderPath) || 0) + yScale.bandwidth() / 2)
     .attr("r", (d: ReleaseContributorActivity) => sizeScale(d.changes))
     .attr("fill", (d: ReleaseContributorActivity) => colorScale(d.contributorName) as string)
-    .attr("fill-opacity", 0.8)
-    .attr("stroke", "#fff")
-    .attr("stroke-width", 1);
+    .attr("fill-opacity", 0.8);
 
   // 툴팁 이벤트
   dots
@@ -197,14 +184,13 @@ export const renderReleaseVisualization = ({
     .attr("x", (d: ReleaseContributorActivity) => calculateReleaseNodePosition(d, xScale, activitiesByRelease))
     .attr(
       "y",
-      (d: ReleaseContributorActivity) =>
-        (yScale(d.folderPath) || 0) + yScale.bandwidth() / 2 - sizeScale(d.changes) - 5
+      (d: ReleaseContributorActivity) => (yScale(d.folderPath) || 0) + yScale.bandwidth() / 2 - sizeScale(d.changes) - 5
     )
     .attr("text-anchor", "middle")
     .attr("dominant-baseline", "bottom")
     .text((d: ReleaseContributorActivity) => d.contributorName)
     .style("font-size", "10px")
-    .style("fill", "#495057")
+    .style("fill", "#f7f7f7")
     .style("font-weight", "500")
     .style("pointer-events", "none");
 
@@ -221,5 +207,5 @@ export const renderReleaseVisualization = ({
     .attr("fill", "none")
     .attr("stroke", (d) => colorScale(d.contributorName) as string)
     .attr("stroke-width", 2)
-    .attr("stroke-opacity", 0.4);
+    .attr("stroke-opacity", 1);
 };


### PR DESCRIPTION
## Related issue
#941 

## Result
스토리 라인 차트 디자인 수정했습니다!

## Work list
- [x] 차트 컬러 변경
- [x] 노드 테두리 제거
- [x] 폴더/파일별 가로 레인 삭제
- [x] y축 폴더/파일명 구분(폴더- 호버시 텍스트 컬러변경, 파일- 호버시 변경X 또는 파일명 전부 보여줌)

## Screen Shot


https://github.com/user-attachments/assets/0b65e43e-8090-4463-beb2-f2af07a4ed95


<img width="908" height="379" alt="스크린샷 2025-10-08 오후 1 27 15" src="https://github.com/user-attachments/assets/a34b6ee4-918b-44f0-8c79-925c1b46935e" />
<img width="861" height="362" alt="스크린샷 2025-10-08 오후 1 27 31" src="https://github.com/user-attachments/assets/4ff1924d-2cd4-40f9-b1e1-38a4e61a168f" />



## Discussion
