### PR TITLE
feat: (vibe) NewViz Storyline UI 와 MCP 서버 연동

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -19,12 +19,20 @@
 		"@modelcontextprotocol/sdk": "^1.12.1",
 		"@octokit/rest": "^22.0.0",
 		"cors": "^2.8.5",
+		"d3": "^7.8.5",
 		"dayjs": "^1.11.18",
 		"express": "^5.1.0",
+		"puppeteer": "^21.0.0",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"sharp": "^0.34.4",
 		"zod": "^3.25.76"
 	},
 	"devDependencies": {
 		"@smithery/cli": "^1.2.4",
+		"@types/d3": "^7.4.3",
+		"@types/react": "^18.2.0",
+		"@types/react-dom": "^18.2.0",
 		"copyfiles": "^2.4.1",
 		"rimraf": "^6.0.1",
 		"tsx": "^4.19.4"

--- a/packages/mcp/src/common/types.ts
+++ b/packages/mcp/src/common/types.ts
@@ -42,20 +42,6 @@ export interface ContributorRecommendation {
   notes: string[];
 }
 
-export interface CommitInfo {
-  sha: string;
-  message: string;
-  authorDate: string;
-  changedFiles: string[];
-}
-
-export interface FileChangeInfo {
-  filename: string;
-  additions?: number;
-  deletions?: number;
-  changes?: number;
-}
-
 export interface CSMDictGeneratorInputs {
   repo: string;
   githubToken: string;
@@ -64,9 +50,49 @@ export interface CSMDictGeneratorInputs {
   debug?: boolean;
 }
 
+export interface GitUser {
+  name: string;
+  email: string;
+}
+
+export interface DifferenceStatistic {
+  totalInsertionCount: number;
+  totalDeletionCount: number;
+  fileDictionary: { [filePath: string]: { insertionCount: number; deletionCount: number } };
+}
+
+export interface CommitRaw {
+  sequence: number;
+  id: string;
+  parents: string[];
+  branches: string[];
+  tags: string[];
+  author: GitUser;
+  authorDate: Date;
+  committer: GitUser;
+  committerDate: Date;
+  message: string;
+  differenceStatistic: DifferenceStatistic;
+  commitMessageType: string;
+}
+
+export interface CommitNode {
+  stemId?: string;
+  commit: CommitRaw;
+}
+
+export interface CSMNode {
+  base: CommitNode;
+  source: CommitNode[];
+}
+
+export interface CSMDictionary {
+  [branch: string]: CSMNode[];
+}
+
 export interface AnalysisResult {
   isPRSuccess: boolean;
-  csmDict: Record<string, unknown[]>;
+  csmDict: CSMDictionary;
 }
 
 export interface CSMDictResult {
@@ -78,7 +104,7 @@ export interface CSMDictResult {
       isPRDataAvailable: boolean;
       branches: string[];
       totalClusters: number;
-      csmDict: Record<string, unknown[]>;
+      csmDict: CSMDictionary;
     };
   };
   metadata: {
@@ -89,7 +115,6 @@ export interface CSMDictResult {
   };
 }
 
-// React Component Test Types
 export interface ReactComponentTestInputs {
   complexity?: "simple" | "medium" | "complex" | "all";
   componentType?: "basic" | "chart" | "form" | "data-display" | "interactive";
@@ -107,7 +132,6 @@ export interface ReactComponentTestResult {
   testQuestions: string[];
 }
 
-// Data-driven React Component Types
 export interface DataDrivenComponentInputs {
   dataType?: "chart" | "table" | "list" | "card" | "all";
   sampleData?: boolean;

--- a/packages/mcp/src/component/FolderActivityFlow/FolderActivityFlow.releaseAnalyzer.ts
+++ b/packages/mcp/src/component/FolderActivityFlow/FolderActivityFlow.releaseAnalyzer.ts
@@ -1,0 +1,330 @@
+import { ClusterNode } from "../../dataProcessors/storylineProcessor";
+
+export interface ReleaseGroup {
+  releaseTag: string;
+  commitCount: number;
+  dateRange: {
+    start: Date;
+    end: Date;
+  };
+  commits: CommitData[];
+}
+
+export interface ReleaseFolderActivity {
+  folderPath: string;
+  releaseTag: string;
+  totalChanges: number;
+  insertions: number;
+  deletions: number;
+  commitCount: number;
+  contributors: string[];
+}
+
+export interface CommitData {
+  id: string;
+  authorDate: string;
+  commitDate: string;
+  author: {
+    id: string;
+    names: string[];
+    emails: string[];
+  };
+  diffStatistics: {
+    insertions: number;
+    deletions: number;
+    files: { [filePath: string]: { insertions: number; deletions: number } };
+  };
+  releaseTags: string[];
+}
+
+/**
+ * 폴더 경로에서 지정된 깊이의 폴더를 추출
+ */
+export function extractFolderFromPath(filePath: string, depth = 1): string {
+  const parts = filePath.split("/");
+  if (parts.length === 1) return "."; // 루트 레벨 파일
+
+  const folderParts = parts.slice(0, Math.min(depth, parts.length - 1));
+  return folderParts.length > 0 ? folderParts.join("/") : ".";
+}
+
+/**
+ * 커밋들을 releaseTags 기준으로 그룹화
+ * releaseTags가 없는 커밋은 이전 releaseTags와 합침
+ */
+export function groupCommitsByReleaseTags(clusterNodeList: ClusterNode[]): ReleaseGroup[] {
+  // 모든 커밋을 시간순으로 정렬
+  const allCommits: CommitData[] = [];
+  clusterNodeList.forEach((cluster) => {
+    cluster.commitNodeList.forEach((commitNode) => {
+      // CommitRaw를 CommitData로 변환
+      const commitRaw = commitNode.commit;
+      const commitData: CommitData = {
+        id: commitRaw.id,
+        authorDate: commitRaw.authorDate.toISOString(),
+        commitDate: commitRaw.committerDate.toISOString(),
+        author: {
+          id: commitRaw.author.name,
+          names: [commitRaw.author.name],
+          emails: [commitRaw.author.email]
+        },
+        diffStatistics: {
+          insertions: commitRaw.differenceStatistic.totalInsertionCount,
+          deletions: commitRaw.differenceStatistic.totalDeletionCount,
+          files: Object.fromEntries(
+            Object.entries(commitRaw.differenceStatistic.fileDictionary).map(([path, stats]) => [
+              path,
+              {
+                insertions: stats.insertionCount,
+                deletions: stats.deletionCount
+              }
+            ])
+          )
+        },
+        releaseTags: commitRaw.tags || []
+      };
+      allCommits.push(commitData);
+    });
+  });
+
+  // 커밋 날짜 기준으로 정렬
+  allCommits.sort((a, b) => new Date(a.commitDate).getTime() - new Date(b.commitDate).getTime());
+
+  const releaseGroups: ReleaseGroup[] = [];
+  let currentGroup: ReleaseGroup | null = null;
+
+  allCommits.forEach((commit) => {
+    if (commit.releaseTags && commit.releaseTags.length > 0) {
+      // 새로운 릴리즈 태그가 있는 경우, 새 그룹 시작
+      commit.releaseTags.forEach((releaseTag) => {
+        currentGroup = {
+          releaseTag,
+          commitCount: 1,
+          dateRange: {
+            start: new Date(commit.commitDate),
+            end: new Date(commit.commitDate),
+          },
+          commits: [commit],
+        };
+        releaseGroups.push(currentGroup);
+      });
+    } else if (currentGroup) {
+      // 기존 그룹에 추가
+      currentGroup.commits.push(commit);
+      currentGroup.commitCount += 1;
+      currentGroup.dateRange.end = new Date(commit.commitDate);
+    } else {
+      // 첫 번째 릴리즈 태그 이전의 커밋들을 위한 그룹 생성
+      currentGroup = {
+        releaseTag: "Pre-release",
+        commitCount: 1,
+        dateRange: {
+          start: new Date(commit.commitDate),
+          end: new Date(commit.commitDate),
+        },
+        commits: [commit],
+      };
+      releaseGroups.unshift(currentGroup); // 맨 앞에 추가
+    }
+  });
+
+  return releaseGroups;
+}
+
+/**
+ * 릴리즈 그룹별 폴더 활동 분석
+ */
+export function analyzeReleaseFolderActivity(releaseGroups: ReleaseGroup[], folderDepth = 1): ReleaseFolderActivity[] {
+  const activities: ReleaseFolderActivity[] = [];
+
+  releaseGroups.forEach((group) => {
+    const folderStats = new Map<
+      string,
+      {
+        totalChanges: number;
+        insertions: number;
+        deletions: number;
+        commitCount: number;
+        contributors: Set<string>;
+      }
+    >();
+
+    // 각 커밋의 파일 변경사항 분석
+    group.commits.forEach((commit) => {
+      const authorName = commit.author.names[0] || "Unknown";
+
+      Object.entries(commit.diffStatistics.files).forEach(([filePath, stats]) => {
+        const folderPath = extractFolderFromPath(filePath, folderDepth);
+
+        if (!folderStats.has(folderPath)) {
+          folderStats.set(folderPath, {
+            totalChanges: 0,
+            insertions: 0,
+            deletions: 0,
+            commitCount: 0,
+            contributors: new Set(),
+          });
+        }
+
+        const folderActivity = folderStats.get(folderPath);
+        if (!folderActivity) return;
+        folderActivity.insertions += stats.insertions;
+        folderActivity.deletions += stats.deletions;
+        folderActivity.totalChanges += stats.insertions + stats.deletions;
+        folderActivity.contributors.add(authorName);
+      });
+    });
+
+    // 폴더별 고유 커밋 수 계산
+    group.commits.forEach((commit) => {
+      const foldersInCommit = new Set<string>();
+      Object.keys(commit.diffStatistics.files).forEach((filePath) => {
+        const folderPath = extractFolderFromPath(filePath, folderDepth);
+        foldersInCommit.add(folderPath);
+      });
+
+      foldersInCommit.forEach((folderPath) => {
+        const stats = folderStats.get(folderPath);
+        if (stats) {
+          stats.commitCount += 1;
+        }
+      });
+    });
+
+    // ReleaseFolderActivity 객체로 변환
+    folderStats.forEach((stats, folderPath) => {
+      activities.push({
+        folderPath,
+        releaseTag: group.releaseTag,
+        totalChanges: stats.totalChanges,
+        insertions: stats.insertions,
+        deletions: stats.deletions,
+        commitCount: stats.commitCount,
+        contributors: Array.from(stats.contributors),
+      });
+    });
+  });
+
+  return activities;
+}
+
+/**
+ * 릴리즈별 상위 폴더 추출
+ */
+export function getTopFoldersByRelease(
+  clusterNodeList: ClusterNode[],
+  count = 8,
+  folderDepth = 1
+): {
+  releaseGroups: ReleaseGroup[];
+  folderActivities: ReleaseFolderActivity[];
+  topFolders: string[];
+} {
+  const releaseGroups = groupCommitsByReleaseTags(clusterNodeList);
+  const folderActivities = analyzeReleaseFolderActivity(releaseGroups, folderDepth);
+
+  // 전체 기간 동안 가장 활발한 폴더들 추출
+  const globalFolderStats = new Map<string, number>();
+  folderActivities.forEach((activity) => {
+    const current = globalFolderStats.get(activity.folderPath) || 0;
+    globalFolderStats.set(activity.folderPath, current + activity.totalChanges);
+  });
+
+  const topFolders = Array.from(globalFolderStats.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, count)
+    .map(([folderPath]) => folderPath);
+
+  return {
+    releaseGroups,
+    folderActivities: folderActivities.filter((activity) => topFolders.includes(activity.folderPath)),
+    topFolders,
+  };
+}
+
+/**
+ * 특정 릴리즈 그룹의 기여자 활동 추출
+ */
+export function extractReleaseContributorActivities(
+  releaseGroups: ReleaseGroup[],
+  topFolders: string[],
+  folderDepth = 1
+) {
+  const activities: Array<{
+    contributorName: string;
+    folderPath: string;
+    releaseTag: string;
+    releaseIndex: number;
+    changes: number;
+    insertions: number;
+    deletions: number;
+    date: Date;
+  }> = [];
+
+  releaseGroups.forEach((group, releaseIndex) => {
+    const contributorFolderStats = new Map<
+      string,
+      Map<
+        string,
+        {
+          changes: number;
+          insertions: number;
+          deletions: number;
+          lastDate: Date;
+        }
+      >
+    >();
+
+    group.commits.forEach((commit) => {
+      const authorName = commit.author.names[0] || "Unknown";
+      const commitDate = new Date(commit.commitDate);
+
+      if (!contributorFolderStats.has(authorName)) {
+        contributorFolderStats.set(authorName, new Map());
+      }
+
+      const contributorStats = contributorFolderStats.get(authorName);
+      if (!contributorStats) return;
+
+      Object.entries(commit.diffStatistics.files).forEach(([filePath, stats]) => {
+        const folderPath = extractFolderFromPath(filePath, folderDepth);
+
+        if (!topFolders.includes(folderPath)) return;
+
+        if (!contributorStats.has(folderPath)) {
+          contributorStats.set(folderPath, {
+            changes: 0,
+            insertions: 0,
+            deletions: 0,
+            lastDate: commitDate,
+          });
+        }
+
+        const folderStats = contributorStats.get(folderPath);
+        if (!folderStats) return;
+        folderStats.changes += stats.insertions + stats.deletions;
+        folderStats.insertions += stats.insertions;
+        folderStats.deletions += stats.deletions;
+        folderStats.lastDate = commitDate;
+      });
+    });
+
+    // 활동 데이터로 변환
+    contributorFolderStats.forEach((folderStatsMap, contributorName) => {
+      folderStatsMap.forEach((stats, folderPath) => {
+        activities.push({
+          contributorName,
+          folderPath,
+          releaseTag: group.releaseTag,
+          releaseIndex,
+          changes: stats.changes,
+          insertions: stats.insertions,
+          deletions: stats.deletions,
+          date: stats.lastDate,
+        });
+      });
+    });
+  });
+
+  return activities;
+}

--- a/packages/mcp/src/component/FolderActivityFlow/FolderActivityFlow.scss
+++ b/packages/mcp/src/component/FolderActivityFlow/FolderActivityFlow.scss
@@ -1,0 +1,169 @@
+.folder-activity-flow {
+  padding: 1rem;
+  margin-bottom: 2rem;
+  background: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 1rem;
+  }
+
+  &__title {
+    margin: 0 0 0.5rem 0;
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: #212529;
+  }
+
+  &__subtitle {
+    margin: 0 0 0.5rem 0;
+    font-size: 0.875rem;
+    color: #6c757d;
+  }
+
+  &__mode-toggle {
+    transition: all 0.2s ease;
+
+    &:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    }
+
+    &:active {
+      transform: translateY(0);
+    }
+  }
+
+  &__breadcrumb {
+    margin: 0 0 1rem 0;
+    padding: 0.5rem;
+    background: #f8f9fa;
+    border-radius: 4px;
+    font-size: 0.875rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    .separator {
+      color: #6c757d;
+    }
+
+    .clickable {
+      color: #007bff;
+      cursor: pointer;
+      text-decoration: underline;
+      
+      &:hover {
+        color: #0056b3;
+      }
+    }
+
+    .current {
+      color: #212529;
+      font-weight: 600;
+    }
+  }
+
+  &__back-btn {
+    margin-left: auto;
+    padding: 0.25rem 0.5rem;
+    background: #007bff;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    cursor: pointer;
+    
+    &:hover {
+      background: #0056b3;
+    }
+  }
+
+  &__chart {
+    display: block;
+    margin: 0 auto;
+    cursor: grab;
+    
+    &:active {
+      cursor: grabbing;
+    }
+  }
+
+  &__tooltip {
+    position: absolute;
+    display: none;
+    padding: 0.5rem;
+    background: rgba(0, 0, 0, 0.9);
+    color: white;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    pointer-events: none;
+    z-index: 1000;
+
+    .contributor-activity-tooltip {
+      p {
+        margin: 0.25rem 0;
+        
+        &:first-child {
+          margin-top: 0;
+          font-weight: 600;
+        }
+        
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
+
+  .lane-background {
+    transition: fill 0.2s ease;
+    
+    &:hover {
+      fill: #e9ecef;
+    }
+  }
+
+  .folder-label {
+    font-weight: 500;
+    
+    &.clickable {
+      cursor: pointer;
+      transition: fill 0.2s ease;
+      
+      &:hover {
+        fill: #007bff !important;
+      }
+    }
+  }
+
+  .activity-dot {
+    cursor: pointer;
+    transition: all 0.2s ease;
+    
+    &:hover {
+      stroke-width: 2;
+      r: 8;
+    }
+  }
+
+  .flow-line {
+    pointer-events: none;
+  }
+
+  .x-axis {
+    .domain,
+    .tick line {
+      stroke: #dee2e6;
+    }
+    
+    .tick text {
+      fill: #6c757d;
+      font-size: 11px;
+    }
+  }
+}

--- a/packages/mcp/src/component/FolderActivityFlow/FolderActivityFlow.tsx
+++ b/packages/mcp/src/component/FolderActivityFlow/FolderActivityFlow.tsx
@@ -1,0 +1,320 @@
+import * as d3 from "d3";
+import { useCallback, useEffect, useRef } from "react";
+
+import "./FolderActivityFlow.scss";
+import type { ReleaseContributorActivity, ReleaseFlowLineData } from "./FolderActivityFlow.type";
+
+const DIMENSIONS = {
+  width: 800,
+  height: 400,
+  margin: { top: 40, right: 120, bottom: 60, left: 20 },
+};
+
+export interface ReleaseGroup {
+  releaseTag: string;
+  commitCount: number;
+  dateRange: {
+    start: Date;
+    end: Date;
+  };
+  commits: CommitData[];
+}
+
+interface CommitData {
+  id: string;
+  authorDate: string;
+  commitDate: string;
+  author: {
+    id: string;
+    names: string[];
+    emails: string[];
+  };
+  diffStatistics: {
+    insertions: number;
+    deletions: number;
+    files: { [filePath: string]: { insertions: number; deletions: number } };
+  };
+  releaseTags: string[];
+}
+
+const FolderActivityFlow = ({
+                              releaseGroups,
+                              releaseTopFolderPaths,
+                              flowLineData,
+                              releaseContributorActivities,
+                              firstNodesByContributor,
+                            }: {
+  releaseGroups: ReleaseGroup[];
+  releaseTopFolderPaths: string[];
+  flowLineData: ReleaseFlowLineData[];
+  releaseContributorActivities: ReleaseContributorActivity[];
+  firstNodesByContributor: Map<string, ReleaseContributorActivity>;
+}) => {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+
+  const pxToRem = (px: number) => `${px / 16}rem`;
+
+  // 릴리즈 기반 노드 위치 계산
+  const calculateReleaseNodePosition = (
+    activity: ReleaseContributorActivity,
+    xScale: d3.ScaleBand<string>,
+    activitiesByRelease: Map<number, ReleaseContributorActivity[]>
+  ): number => {
+    const releaseX = (xScale(String(activity.releaseIndex)) || 0) + xScale.bandwidth() / 2;
+    const releaseActivities = activitiesByRelease.get(activity.releaseIndex) || [];
+    const activityIndex = releaseActivities.findIndex(
+      (a) =>
+        a.contributorName === activity.contributorName &&
+        a.folderPath === activity.folderPath &&
+        a.date.getTime() === activity.date.getTime()
+    );
+    const offsetRange = xScale.bandwidth() * 0.8;
+    const offset =
+      (activityIndex - (releaseActivities.length - 1) / 2) * (offsetRange / Math.max(releaseActivities.length, 1));
+    return releaseX + offset;
+  };
+
+  // 릴리즈 기반 플로우 라인 경로 생성
+  const generateReleaseFlowLinePath = (
+    d: ReleaseFlowLineData,
+    xScale: d3.ScaleBand<string>,
+    yScale: d3.ScaleBand<string>
+  ): string => {
+    const x1 = (xScale(String(d.startReleaseIndex)) || 0) + xScale.bandwidth() / 2;
+    const y1 = (yScale(d.startFolder) || 0) + yScale.bandwidth() / 2;
+    const x2 = (xScale(String(d.endReleaseIndex)) || 0) + xScale.bandwidth() / 2;
+    const y2 = (yScale(d.endFolder) || 0) + yScale.bandwidth() / 2;
+    const midX = (x1 + x2) / 2;
+    return `M ${x1},${y1} Q ${midX},${y1} ${midX},${(y1 + y2) / 2} Q ${midX},${y2} ${x2},${y2}`;
+  };
+
+  const renderReleaseVisualization = useCallback(
+    (
+      svg: d3.Selection<SVGSVGElement, unknown, null, undefined>,
+      // eslint-disable-next-line no-shadow
+      releaseContributorActivities: ReleaseContributorActivity[]
+    ) => {
+      const tooltip = d3.select(tooltipRef.current);
+
+      // scale
+      const uniqueContributors = Array.from(new Set(releaseContributorActivities.map((a) => a.contributorName)));
+      const uniqueReleases = Array.from(new Set(releaseContributorActivities.map((a) => a.releaseIndex))).sort(
+        (a, b) => a - b
+      );
+      const releaseTagsByIndex = new Map<number, string>();
+      releaseContributorActivities.forEach((a) => {
+        releaseTagsByIndex.set(a.releaseIndex, a.releaseTag);
+      });
+
+      const xScale = d3
+        .scaleBand()
+        .domain(uniqueReleases.map(String))
+        .range([DIMENSIONS.margin.left, DIMENSIONS.width - DIMENSIONS.margin.right])
+        .paddingInner(0.1);
+
+      const yScale = d3
+        .scaleBand()
+        .domain(releaseTopFolderPaths)
+        .range([DIMENSIONS.margin.top, DIMENSIONS.height - DIMENSIONS.margin.bottom])
+        .paddingInner(0.2);
+
+      const sizeScale = d3
+        .scaleSqrt()
+        .domain([0, d3.max(releaseContributorActivities, (d) => d.changes) || 1])
+        .range([3, 12]);
+
+      const colorScale = d3.scaleOrdinal().domain(uniqueContributors).range(d3.schemeCategory10);
+
+      const mainGroup = svg.append("g");
+
+      // 폴더 레인 그리기
+      mainGroup
+        .selectAll(".folder-lane")
+        .data(releaseTopFolderPaths)
+        .enter()
+        .append("g")
+        .attr("class", "folder-lane")
+        .each(function (this: SVGGElement, folderPath: string) {
+          const lane = d3.select(this);
+
+          lane
+            .append("rect")
+            .attr("class", "lane-background")
+            .attr("x", DIMENSIONS.margin.left)
+            .attr("y", yScale(folderPath) || 0)
+            .attr("width", DIMENSIONS.width - DIMENSIONS.margin.left - DIMENSIONS.margin.right)
+            .attr("height", yScale.bandwidth())
+            .attr("fill", "#f8f9fa")
+            .attr("stroke", "#dee2e6")
+            .attr("stroke-width", 1);
+
+          lane
+            .append("text")
+            .attr("class", "folder-label")
+            .attr("x", DIMENSIONS.width - DIMENSIONS.margin.right + 10)
+            .attr("y", (yScale(folderPath) || 0) + yScale.bandwidth() / 2)
+            .attr("text-anchor", "start")
+            .attr("dominant-baseline", "middle")
+            .text(() => {
+              if (folderPath === ".") return "root";
+              const fileName = folderPath.includes("/") ? folderPath.split("/").pop() : folderPath;
+              return fileName && fileName.length > 15 ? `${fileName.substring(0, 12)}...` : fileName || "unknown";
+            })
+            .style("font-size", "12px")
+            .style("fill", "#495057")
+            .style("font-weight", "500");
+        });
+
+      // 릴리즈 축
+      const xAxis = d3
+        .axisBottom(xScale)
+        .tickFormat((d: string) => releaseTagsByIndex.get(parseInt(d, 10)) || `Release ${parseInt(d, 10)}`);
+
+      mainGroup
+        .append("g")
+        .attr("class", "x-axis")
+        .attr("transform", `translate(0, ${DIMENSIONS.height - DIMENSIONS.margin.bottom})`)
+        .call(xAxis as any);
+
+      // 릴리즈별 노드 위치 계산
+      const activitiesByRelease = new Map<number, ReleaseContributorActivity[]>();
+      releaseContributorActivities.forEach((activity) => {
+        if (!activitiesByRelease.has(activity.releaseIndex)) {
+          activitiesByRelease.set(activity.releaseIndex, []);
+        }
+        const activities = activitiesByRelease.get(activity.releaseIndex);
+        if (activities) {
+          activities.push(activity);
+        }
+      });
+
+      // 활동 노드 그리기
+      const dots = mainGroup
+        .selectAll(".activity-dot")
+        .data(releaseContributorActivities)
+        .enter()
+        .append("circle")
+        .attr("class", "activity-dot")
+        .attr("cx", (d: ReleaseContributorActivity) => calculateReleaseNodePosition(d, xScale, activitiesByRelease))
+        .attr("cy", (d: ReleaseContributorActivity) => (yScale(d.folderPath) || 0) + yScale.bandwidth() / 2)
+        .attr("r", (d: ReleaseContributorActivity) => sizeScale(d.changes))
+        .attr("fill", (d: ReleaseContributorActivity) => colorScale(d.contributorName) as string)
+        .attr("fill-opacity", 0.8)
+        .attr("stroke", "#fff")
+        .attr("stroke-width", 1);
+
+      // 툴팁 이벤트
+      dots
+        .on("mouseover", (event: MouseEvent, d: ReleaseContributorActivity) => {
+          tooltip
+            .style("display", "inline-block")
+            .style("left", pxToRem(event.pageX + 10))
+            .style("top", pxToRem(event.pageY - 10)).html(`
+            <div class="contributor-activity-tooltip">
+              <p><strong>${d.contributorName}</strong></p>
+              <p>Release: ${d.releaseTag}</p>
+              <p>Folder: ${d.folderPath === "." ? "root" : d.folderPath}</p>
+              <p>Date: ${d.date.toLocaleDateString()}</p>
+              <p>Changes: ${d.changes}</p>
+              <p style="color: #28a745;">+${d.insertions} insertions</p>
+              <p style="color: #dc3545;">-${d.deletions} deletions</p>
+            </div>
+          `);
+        })
+        .on("mousemove", (event: MouseEvent) => {
+          tooltip.style("left", pxToRem(event.pageX + 10)).style("top", pxToRem(event.pageY - 10));
+        })
+        .on("mouseout", () => {
+          tooltip.style("display", "none");
+        });
+
+      // 기여자별 첫 노드에 이름 라벨
+      // const firstNodesByContributor = findFirstReleaseContributorNodes(releaseContributorActivities);
+
+      mainGroup
+        .selectAll(".contributor-label")
+        .data(Array.from(firstNodesByContributor.values()))
+        .enter()
+        .append("text")
+        .attr("class", "contributor-label")
+        .attr("x", (d: any) => calculateReleaseNodePosition(d, xScale, activitiesByRelease))
+        .attr("y", (d: any) => (yScale(d.folderPath) || 0) + yScale.bandwidth() / 2 - sizeScale(d.changes) - 5)
+        .attr("text-anchor", "middle")
+        .attr("dominant-baseline", "bottom")
+        .text((d: any) => d.contributorName)
+        .style("font-size", "10px")
+        .style("fill", "#495057")
+        .style("font-weight", "500")
+        .style("pointer-events", "none");
+
+      // 플로우 라인 그리기
+      // const flowLineData = generateReleaseFlowLineData(releaseContributorActivities);
+
+      mainGroup
+        .selectAll(".flow-line")
+        .data(flowLineData)
+        .enter()
+        .append("path")
+        .attr("class", "flow-line")
+        .attr("d", (d: any) => generateReleaseFlowLinePath(d, xScale, yScale))
+        .attr("fill", "none")
+        .attr("stroke", (d: any) => colorScale(d.contributorName) as string)
+        .attr("stroke-width", 2)
+        .attr("stroke-opacity", 0.4);
+    },
+    [releaseTopFolderPaths]
+  );
+
+  useEffect(() => {
+    // 릴리즈 모드 데이터 체크
+    if (releaseGroups.length === 0 || releaseTopFolderPaths.length === 0) {
+      return;
+    }
+    const svg = d3
+      .select(svgRef.current)
+      .attr("width", DIMENSIONS.width)
+      .attr("height", DIMENSIONS.height) as d3.Selection<SVGSVGElement, unknown, null, undefined>;
+
+    svg.selectAll("*").remove();
+
+    // // 릴리즈 모드: releaseTopFolderPaths 기반
+    // const releaseContributorActivities = extractReleaseBasedContributorActivities(totalData, releaseTopFolderPaths, 1);
+
+    if (releaseContributorActivities.length === 0) {
+      svg
+        .append("text")
+        .attr("x", DIMENSIONS.width / 2)
+        .attr("y", DIMENSIONS.height / 2)
+        .attr("text-anchor", "middle")
+        .attr("dominant-baseline", "middle")
+        .text("No release activity data available")
+        .style("font-size", "14px")
+        .style("fill", "#6c757d");
+      return;
+    }
+
+    renderReleaseVisualization(svg, releaseContributorActivities);
+  }, [releaseGroups, releaseTopFolderPaths, renderReleaseVisualization]);
+
+  return (
+    <div className="folder-activity-flow">
+      <div className="folder-activity-flow__header">
+        <div>
+          <p className="folder-activity-flow__title">Contributors Folder Activity Flow</p>
+          <div className="folder-activity-flow__subtitle">Contributors moving between folders across releases</div>
+        </div>
+      </div>
+      <svg
+        className="folder-activity-flow__chart"
+        ref={svgRef}
+      />
+      <div
+        className="folder-activity-flow__tooltip"
+        ref={tooltipRef}
+      />
+    </div>
+  );
+};
+
+export default FolderActivityFlow;

--- a/packages/mcp/src/component/FolderActivityFlow/FolderActivityFlow.type.ts
+++ b/packages/mcp/src/component/FolderActivityFlow/FolderActivityFlow.type.ts
@@ -1,0 +1,38 @@
+export interface ContributorActivity {
+  contributorId: string;
+  contributorName: string;
+  date: Date;
+  folderPath: string;
+  changes: number;
+  insertions: number;
+  deletions: number;
+  clusterId: string;
+  clusterIndex: number;
+}
+
+export interface FlowLineData {
+  startClusterIndex: number;
+  startFolder: string;
+  endClusterIndex: number;
+  endFolder: string;
+  contributorName: string;
+}
+
+export interface ReleaseContributorActivity {
+  contributorName: string;
+  folderPath: string;
+  releaseTag: string;
+  releaseIndex: number;
+  changes: number;
+  insertions: number;
+  deletions: number;
+  date: Date;
+}
+
+export interface ReleaseFlowLineData {
+  startReleaseIndex: number;
+  startFolder: string;
+  endReleaseIndex: number;
+  endFolder: string;
+  contributorName: string;
+}

--- a/packages/mcp/src/component/FolderActivityFlow/FolderActivityFlow.util.ts
+++ b/packages/mcp/src/component/FolderActivityFlow/FolderActivityFlow.util.ts
@@ -1,0 +1,225 @@
+import type * as d3 from "d3";
+
+import {
+  getTopFoldersByRelease,
+  extractReleaseContributorActivities,
+  type ReleaseGroup,
+  type ReleaseFolderActivity,
+} from "./FolderActivityFlow.releaseAnalyzer.js";
+import type {
+  ContributorActivity,
+  FlowLineData,
+  ReleaseContributorActivity,
+  ReleaseFlowLineData,
+} from "./FolderActivityFlow.type.js";
+import { ClusterNode } from "../../dataProcessors/storylineProcessor.js";
+
+// 플로우 라인 데이터 생성
+export function generateFlowLineData(contributorActivities: ContributorActivity[]): FlowLineData[] {
+  const activitiesByContributor = new Map<string, ContributorActivity[]>();
+  contributorActivities.forEach((activity) => {
+    if (!activitiesByContributor.has(activity.contributorId)) {
+      activitiesByContributor.set(activity.contributorId, []);
+    }
+    const contributorActivitiesList = activitiesByContributor.get(activity.contributorId);
+    if (contributorActivitiesList) {
+      contributorActivitiesList.push(activity);
+    }
+  });
+
+  const flowLineData: FlowLineData[] = [];
+
+  activitiesByContributor.forEach((contributorActivitiesList) => {
+    contributorActivitiesList.sort((a, b) => a.clusterIndex - b.clusterIndex || a.date.getTime() - b.date.getTime());
+
+    for (let i = 0; i < contributorActivitiesList.length - 1; i += 1) {
+      const current = contributorActivitiesList[i];
+      const next = contributorActivitiesList[i + 1];
+
+      if (current.clusterIndex !== next.clusterIndex) {
+        flowLineData.push({
+          startClusterIndex: current.clusterIndex,
+          startFolder: current.folderPath,
+          endClusterIndex: next.clusterIndex,
+          endFolder: next.folderPath,
+          contributorName: current.contributorName,
+        });
+      }
+    }
+  });
+
+  return flowLineData;
+}
+
+// 클러스터 내 노드 위치 계산
+export function calculateNodePosition(
+  activity: ContributorActivity,
+  xScale: d3.ScaleBand<string>,
+  activitiesByCluster: Map<number, ContributorActivity[]>
+): number {
+  const clusterX = (xScale(String(activity.clusterIndex)) || 0) + xScale.bandwidth() / 2;
+  const clusterActivities = activitiesByCluster.get(activity.clusterIndex) || [];
+  const activityIndex = clusterActivities.findIndex(
+    (a) =>
+      a.contributorId === activity.contributorId &&
+      a.folderPath === activity.folderPath &&
+      a.date.getTime() === activity.date.getTime()
+  );
+  const offsetRange = xScale.bandwidth() * 0.8;
+  const offset =
+    (activityIndex - (clusterActivities.length - 1) / 2) * (offsetRange / Math.max(clusterActivities.length, 1));
+  return clusterX + offset;
+}
+
+// 첫 번째 기여자 노드 찾기
+export function findFirstContributorNodes(
+  contributorActivities: ContributorActivity[]
+): Map<string, ContributorActivity> {
+  const firstNodesByContributor = new Map<string, ContributorActivity>();
+  const sortedActivities = [...contributorActivities].sort(
+    (a, b) => a.clusterIndex - b.clusterIndex || a.date.getTime() - b.date.getTime()
+  );
+
+  sortedActivities.forEach((activity) => {
+    const key = activity.contributorId;
+    if (!firstNodesByContributor.has(key)) {
+      firstNodesByContributor.set(key, activity);
+    }
+  });
+
+  return firstNodesByContributor;
+}
+
+// 플로우 라인 경로 생성
+export function generateFlowLinePath(
+  d: FlowLineData,
+  xScale: d3.ScaleBand<string>,
+  yScale: d3.ScaleBand<string>
+): string {
+  const x1 = (xScale(String(d.startClusterIndex)) || 0) + xScale.bandwidth() / 2;
+  const y1 = (yScale(d.startFolder) || 0) + yScale.bandwidth() / 2;
+  const x2 = (xScale(String(d.endClusterIndex)) || 0) + xScale.bandwidth() / 2;
+  const y2 = (yScale(d.endFolder) || 0) + yScale.bandwidth() / 2;
+  const midX = (x1 + x2) / 2;
+  return `M ${x1},${y1} Q ${midX},${y1} ${midX},${(y1 + y2) / 2} Q ${midX},${y2} ${x2},${y2}`;
+}
+
+// === ReleaseTags 기반 유틸리티 함수들 ===
+
+// 릴리즈 기반 상위 폴더 분석
+export function analyzeReleaseBasedFolders(
+  totalData: ClusterNode[],
+  count = 8,
+  folderDepth = 1
+): {
+  releaseGroups: ReleaseGroup[];
+  topFolders: ReleaseFolderActivity[];
+  topFolderPaths: string[];
+} {
+  const result = getTopFoldersByRelease(totalData, count, folderDepth);
+
+  return {
+    releaseGroups: result.releaseGroups,
+    topFolders: result.folderActivities,
+    topFolderPaths: result.topFolders,
+  };
+}
+
+// 릴리즈 기반 기여자 활동 추출
+export function extractReleaseBasedContributorActivities(
+  totalData: ClusterNode[],
+  topFolderPaths: string[],
+  folderDepth = 1
+): ReleaseContributorActivity[] {
+  const result = getTopFoldersByRelease(totalData, topFolderPaths.length, folderDepth);
+  return extractReleaseContributorActivities(result.releaseGroups, topFolderPaths, folderDepth);
+}
+
+// 릴리즈 기반 플로우 라인 데이터 생성
+export function generateReleaseFlowLineData(
+  contributorActivities: ReleaseContributorActivity[]
+): ReleaseFlowLineData[] {
+  const activitiesByContributor = new Map<string, ReleaseContributorActivity[]>();
+  contributorActivities.forEach((activity) => {
+    if (!activitiesByContributor.has(activity.contributorName)) {
+      activitiesByContributor.set(activity.contributorName, []);
+    }
+    activitiesByContributor.get(activity.contributorName)?.push(activity);
+  });
+
+  const flowLineData: ReleaseFlowLineData[] = [];
+
+  activitiesByContributor.forEach((contributorActivitiesList) => {
+    contributorActivitiesList.sort((a, b) => a.releaseIndex - b.releaseIndex || a.date.getTime() - b.date.getTime());
+
+    for (let i = 0; i < contributorActivitiesList.length - 1; i += 1) {
+      const current = contributorActivitiesList[i];
+      const next = contributorActivitiesList[i + 1];
+
+      if (current.releaseIndex !== next.releaseIndex) {
+        flowLineData.push({
+          startReleaseIndex: current.releaseIndex,
+          startFolder: current.folderPath,
+          endReleaseIndex: next.releaseIndex,
+          endFolder: next.folderPath,
+          contributorName: current.contributorName,
+        });
+      }
+    }
+  });
+
+  return flowLineData;
+}
+
+// 릴리즈 기반 노드 위치 계산
+export function calculateReleaseNodePosition(
+  activity: ReleaseContributorActivity,
+  xScale: d3.ScaleBand<string>,
+  activitiesByRelease: Map<number, ReleaseContributorActivity[]>
+): number {
+  const releaseX = (xScale(String(activity.releaseIndex)) || 0) + xScale.bandwidth() / 2;
+  const releaseActivities = activitiesByRelease.get(activity.releaseIndex) || [];
+  const activityIndex = releaseActivities.findIndex(
+    (a) =>
+      a.contributorName === activity.contributorName &&
+      a.folderPath === activity.folderPath &&
+      a.date.getTime() === activity.date.getTime()
+  );
+  const offsetRange = xScale.bandwidth() * 0.8;
+  const offset =
+    (activityIndex - (releaseActivities.length - 1) / 2) * (offsetRange / Math.max(releaseActivities.length, 1));
+  return releaseX + offset;
+}
+
+// 릴리즈 기반 첫 번째 기여자 노드 찾기
+export function findFirstReleaseContributorNodes(
+  contributorActivities: ReleaseContributorActivity[]
+): Map<string, ReleaseContributorActivity> {
+  const firstNodesByContributor = new Map<string, ReleaseContributorActivity>();
+  const sortedActivities = [...contributorActivities].sort(
+    (a, b) => a.releaseIndex - b.releaseIndex || a.date.getTime() - b.date.getTime()
+  );
+
+  sortedActivities.forEach((activity) => {
+    const key = activity.contributorName;
+    if (!firstNodesByContributor.has(key)) {
+      firstNodesByContributor.set(key, activity);
+    }
+  });
+
+  return firstNodesByContributor;
+}
+
+// 릴리즈 기반 플로우 라인 경로 생성
+export function generateReleaseFlowLinePath(
+  d: ReleaseFlowLineData,
+  xScale: d3.ScaleBand<string>,
+  yScale: d3.ScaleBand<string>
+): string {
+  const x1 = (xScale(String(d.startReleaseIndex)) || 0) + xScale.bandwidth() / 2;
+  const y1 = (yScale(d.startFolder) || 0) + yScale.bandwidth() / 2;
+  const x2 = (xScale(String(d.endReleaseIndex)) || 0) + xScale.bandwidth() / 2;
+  const y2 = (yScale(d.endFolder) || 0) + yScale.bandwidth() / 2;
+  const midX = (x1 + x2) / 2;
+  return `M ${x1},${y1} Q ${midX},${y1} ${midX},${(y1 + y2) / 2} Q ${midX},${y2} ${x2},${y2}`;
+}

--- a/packages/mcp/src/component/FolderActivityFlow/ServerSideFolderActivityFlow.tsx
+++ b/packages/mcp/src/component/FolderActivityFlow/ServerSideFolderActivityFlow.tsx
@@ -1,0 +1,233 @@
+import React from 'react';
+import type { ReleaseContributorActivity, ReleaseFlowLineData } from "./FolderActivityFlow.type";
+
+const DIMENSIONS = {
+  width: 800,
+  height: 400,
+  margin: { top: 40, right: 120, bottom: 60, left: 20 },
+};
+
+export interface ReleaseGroup {
+  releaseTag: string;
+  commitCount: number;
+  dateRange: {
+    start: Date;
+    end: Date;
+  };
+  commits: any[];
+}
+
+const ServerSideFolderActivityFlow = ({
+  releaseGroups,
+  releaseTopFolderPaths,
+  flowLineData,
+  releaseContributorActivities,
+  firstNodesByContributor,
+}: {
+  releaseGroups: ReleaseGroup[];
+  releaseTopFolderPaths: string[];
+  flowLineData: ReleaseFlowLineData[];
+  releaseContributorActivities: ReleaseContributorActivity[];
+  firstNodesByContributor: Map<string, any>;
+}) => {
+  
+  const createPureSVG = (): string => {
+    // 데이터 준비
+    const uniqueReleases = Array.from(new Set(releaseContributorActivities.map(a => a.releaseIndex))).sort((a, b) => a - b);
+    const releaseTagsByIndex = new Map<number, string>();
+    releaseContributorActivities.forEach(a => {
+      releaseTagsByIndex.set(a.releaseIndex, a.releaseTag);
+    });
+
+    // 스케일 계산
+    const xRange = DIMENSIONS.width - DIMENSIONS.margin.left - DIMENSIONS.margin.right;
+    const yRange = DIMENSIONS.height - DIMENSIONS.margin.top - DIMENSIONS.margin.bottom;
+    
+    const xBandwidth = xRange / uniqueReleases.length;
+    const yBandwidth = yRange / releaseTopFolderPaths.length;
+
+    // 색상 팔레트
+    const colors = ['#3498db', '#e74c3c', '#2ecc71', '#f39c12', '#9b59b6', '#1abc9c', '#34495e', '#e67e22'];
+    const contributorNames = Array.from(new Set(releaseContributorActivities.map(a => a.contributorName)));
+    const colorMap = new Map<string, string>();
+    contributorNames.forEach((name, index) => {
+      colorMap.set(name, colors[index % colors.length]);
+    });
+
+    // 최대 변경량 계산
+    const maxChanges = Math.max(...releaseContributorActivities.map(d => d.changes));
+
+    // SVG 요소 생성
+    let svgElements = '';
+
+    // 폴더 레인 그리기
+    releaseTopFolderPaths.forEach((folderPath, index) => {
+      const y = DIMENSIONS.margin.top + index * yBandwidth;
+      const folderName = folderPath === "." ? "📁 root" : `📁 ${folderPath.split('/').pop() || folderPath}`;
+      
+      svgElements += `
+        <rect x="${DIMENSIONS.margin.left}" y="${y}" width="${xRange}" height="${yBandwidth}" 
+              fill="#ffffff" stroke="#dee2e6" stroke-width="1" rx="4"/>
+        <text x="${DIMENSIONS.width - DIMENSIONS.margin.right + 10}" y="${y + yBandwidth/2}" 
+              text-anchor="start" dominant-baseline="middle" 
+              style="font-size: 12px; fill: #495057; font-weight: 500;">${folderName}</text>
+      `;
+    });
+
+    // 릴리즈 축 그리기
+    uniqueReleases.forEach((releaseIndex, index) => {
+      const x = DIMENSIONS.margin.left + index * xBandwidth + xBandwidth / 2;
+      const releaseTag = releaseTagsByIndex.get(releaseIndex) || `Release ${releaseIndex}`;
+      
+      svgElements += `
+        <line x1="${x}" y1="${DIMENSIONS.height - DIMENSIONS.margin.bottom}" 
+              x2="${x}" y2="${DIMENSIONS.height - DIMENSIONS.margin.bottom + 10}" 
+              stroke="#6c757d" stroke-width="1"/>
+        <text x="${x}" y="${DIMENSIONS.height - DIMENSIONS.margin.bottom + 25}" 
+              text-anchor="middle" style="font-size: 11px; fill: #6c757d;">${releaseTag}</text>
+      `;
+    });
+
+    // 활동 노드 그리기
+    releaseContributorActivities.forEach(activity => {
+      const folderIndex = releaseTopFolderPaths.indexOf(activity.folderPath);
+      const releaseIndex = uniqueReleases.indexOf(activity.releaseIndex);
+      
+      if (folderIndex === -1 || releaseIndex === -1) return;
+
+      const x = DIMENSIONS.margin.left + releaseIndex * xBandwidth + xBandwidth / 2;
+      const y = DIMENSIONS.margin.top + folderIndex * yBandwidth + yBandwidth / 2;
+      
+      // 노드 크기 계산 (4-16px 범위)
+      const radius = 4 + (activity.changes / maxChanges) * 12;
+      const color = colorMap.get(activity.contributorName) || '#3498db';
+      
+      svgElements += `
+        <circle cx="${x}" cy="${y}" r="${radius}" 
+                fill="${color}" fill-opacity="0.8" stroke="#fff" stroke-width="2"/>
+      `;
+    });
+
+    // 첫 번째 노드에 기여자 이름 표시
+    Array.from(firstNodesByContributor.values()).forEach(activity => {
+      const folderIndex = releaseTopFolderPaths.indexOf(activity.folderPath);
+      const releaseIndex = uniqueReleases.indexOf(activity.releaseIndex);
+      
+      if (folderIndex === -1 || releaseIndex === -1) return;
+
+      const x = DIMENSIONS.margin.left + releaseIndex * xBandwidth + xBandwidth / 2;
+      const y = DIMENSIONS.margin.top + folderIndex * yBandwidth + yBandwidth / 2;
+      const radius = 4 + (activity.changes / maxChanges) * 12;
+      
+      svgElements += `
+        <text x="${x}" y="${y - radius - 8}" text-anchor="middle" dominant-baseline="bottom" 
+              style="font-size: 10px; fill: #495057; font-weight: 500;">${activity.contributorName}</text>
+      `;
+    });
+
+    // 플로우 라인 그리기
+    flowLineData.forEach(flow => {
+      const startFolderIndex = releaseTopFolderPaths.indexOf(flow.startFolder);
+      const endFolderIndex = releaseTopFolderPaths.indexOf(flow.endFolder);
+      const startReleaseIndex = uniqueReleases.indexOf(flow.startReleaseIndex);
+      const endReleaseIndex = uniqueReleases.indexOf(flow.endReleaseIndex);
+      
+      if (startFolderIndex === -1 || endFolderIndex === -1 || startReleaseIndex === -1 || endReleaseIndex === -1) return;
+
+      const x1 = DIMENSIONS.margin.left + startReleaseIndex * xBandwidth + xBandwidth / 2;
+      const y1 = DIMENSIONS.margin.top + startFolderIndex * yBandwidth + yBandwidth / 2;
+      const x2 = DIMENSIONS.margin.left + endReleaseIndex * xBandwidth + xBandwidth / 2;
+      const y2 = DIMENSIONS.margin.top + endFolderIndex * yBandwidth + yBandwidth / 2;
+      
+      const midX = (x1 + x2) / 2;
+      const midY = (y1 + y2) / 2;
+      
+      const color = colorMap.get(flow.contributorName) || '#3498db';
+      
+      svgElements += `
+        <path d="M ${x1},${y1} Q ${midX},${y1} ${midX},${midY} Q ${midX},${y2} ${x2},${y2}" 
+              fill="none" stroke="${color}" stroke-width="2" stroke-opacity="0.4"/>
+      `;
+    });
+
+    return `
+      <svg width="${DIMENSIONS.width}" height="${DIMENSIONS.height}" 
+           style="background: #f8f9fa; border-radius: 8px;">
+        ${svgElements}
+      </svg>
+    `;
+  };
+
+  const svgContent = createPureSVG();
+
+  return React.createElement('div', {
+    style: {
+      padding: '24px',
+      backgroundColor: '#ffffff',
+      borderRadius: '12px',
+      fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+      maxWidth: '1200px',
+      margin: '0 auto',
+      boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)'
+    }
+  }, [
+    React.createElement('h1', {
+      key: 'title',
+      style: {
+        fontSize: '28px',
+        fontWeight: '700',
+        color: '#2c3e50',
+        marginBottom: '16px',
+        textAlign: 'center',
+        borderBottom: '3px solid #3498db',
+        paddingBottom: '16px'
+      }
+    }, '📊 Contributors Folder Activity Flow'),
+    
+    React.createElement('p', {
+      key: 'subtitle',
+      style: {
+        textAlign: 'center',
+        color: '#6c757d',
+        marginBottom: '24px',
+        fontSize: '16px'
+      }
+    }, 'D3-powered visualization of contributors moving between folders across releases'),
+    
+    React.createElement('div', {
+      key: 'chart',
+      dangerouslySetInnerHTML: { __html: svgContent }
+    }),
+    
+    React.createElement('div', {
+      key: 'legend',
+      style: {
+        marginTop: '20px',
+        padding: '16px',
+        backgroundColor: '#f8f9fa',
+        borderRadius: '8px',
+        border: '1px solid #e9ecef'
+      }
+    }, [
+      React.createElement('h3', {
+        key: 'legend-title',
+        style: { fontSize: '16px', marginBottom: '12px', color: '#2c3e50' }
+      }, '📊 Chart Legend'),
+      React.createElement('div', {
+        key: 'legend-content',
+        style: { fontSize: '14px', color: '#6c757d', lineHeight: '1.6' }
+      }, [
+        React.createElement('div', { key: 'legend-1' }, '• Circle size represents activity volume (changes)'),
+        React.createElement('div', { key: 'legend-2' }, '• Colors represent different contributors'),
+        React.createElement('div', { key: 'legend-3' }, '• Curved lines show contributor movement between releases'),
+        React.createElement('div', { key: 'legend-4' }, '• Horizontal lanes represent folder paths'),
+        React.createElement('div', { key: 'legend-5' }, '• X-axis shows release timeline')
+      ])
+    ])
+  ]);
+};
+
+export default ServerSideFolderActivityFlow;
+
+
+

--- a/packages/mcp/src/component/FolderActivityFlow/index.ts
+++ b/packages/mcp/src/component/FolderActivityFlow/index.ts
@@ -1,0 +1,1 @@
+export { default as FolderActivityFlow } from "./FolderActivityFlow";

--- a/packages/mcp/src/dataProcessors/storylineProcessor.ts
+++ b/packages/mcp/src/dataProcessors/storylineProcessor.ts
@@ -1,0 +1,418 @@
+import type { CommitRaw, CommitNode, CSMNode, CSMDictionary } from '@githru-vscode-ext/analysis-engine/dist/types';
+
+export type CSMData = CSMDictionary;
+
+export interface NodeBase {
+  nodeTypeName: string;
+}
+
+export type ClusterNode = NodeBase & {
+  commitNodeList: CommitNode[];
+};
+
+export interface CommitData {
+  id: string;
+  authorDate: string;
+  commitDate: string;
+  author: {
+    id: string;
+    names: string[];
+    emails: string[];
+  };
+  diffStatistics: {
+    insertions: number;
+    deletions: number;
+    files: {
+      [filePath: string]: {
+        insertions: number;
+        deletions: number;
+      };
+    };
+  };
+  releaseTags: string[];
+}
+
+export interface ReleaseGroup {
+  releaseTag: string;
+  commitCount: number;
+  dateRange: {
+    start: Date;
+    end: Date;
+  };
+  commits: CommitData[];
+}
+
+export interface ReleaseFolderActivity {
+  folderPath: string;
+  releaseTag: string;
+  totalChanges: number;
+  insertions: number;
+  deletions: number;
+  commitCount: number;
+  contributors: string[];
+}
+
+export interface ReleaseContributorActivity {
+  contributorName: string;
+  folderPath: string;
+  releaseTag: string;
+  releaseIndex: number;
+  changes: number;
+  insertions: number;
+  deletions: number;
+  date: Date;
+}
+
+export interface ReleaseFlowLineData {
+  startReleaseIndex: number;
+  startFolder: string;
+  endReleaseIndex: number;
+  endFolder: string;
+  contributorName: string;
+}
+
+/**
+ * 폴더 경로에서 지정된 깊이의 폴더를 추출
+ */
+export function extractFolderFromPath(filePath: string, depth = 1): string {
+  const parts = filePath.split("/");
+  if (parts.length === 1) return "."; // 루트 레벨 파일
+
+  const folderParts = parts.slice(0, Math.min(depth, parts.length - 1));
+  return folderParts.length > 0 ? folderParts.join("/") : ".";
+}
+
+/**
+ * 커밋들을 releaseTags 기준으로 그룹화
+ * releaseTags가 없는 커밋은 이전 releaseTags와 합침
+ */
+export function groupCommitsByReleaseTags(clusterNodeList: CommitData[]): ReleaseGroup[] {
+  // 모든 커밋을 시간순으로 정렬
+  const allCommits = [...clusterNodeList];
+  allCommits.sort((a, b) => new Date(a.commitDate).getTime() - new Date(b.commitDate).getTime());
+
+  const releaseGroups: ReleaseGroup[] = [];
+  let currentGroup: ReleaseGroup | null = null;
+
+  allCommits.forEach((commit) => {
+    if (commit.releaseTags && commit.releaseTags.length > 0) {
+      // 새로운 릴리즈 태그가 있는 경우, 새 그룹 시작
+      commit.releaseTags.forEach((releaseTag) => {
+        currentGroup = {
+          releaseTag,
+          commitCount: 1,
+          dateRange: {
+            start: new Date(commit.commitDate),
+            end: new Date(commit.commitDate),
+          },
+          commits: [commit],
+        };
+        releaseGroups.push(currentGroup);
+      });
+    } else if (currentGroup) {
+      // 기존 그룹에 추가
+      currentGroup.commits.push(commit);
+      currentGroup.commitCount += 1;
+      currentGroup.dateRange.end = new Date(commit.commitDate);
+    } else {
+      // 첫 번째 릴리즈 태그 이전의 커밋들을 위한 그룹 생성
+      currentGroup = {
+        releaseTag: "Pre-release",
+        commitCount: 1,
+        dateRange: {
+          start: new Date(commit.commitDate),
+          end: new Date(commit.commitDate),
+        },
+        commits: [commit],
+      };
+      releaseGroups.unshift(currentGroup); // 맨 앞에 추가
+    }
+  });
+
+  return releaseGroups;
+}
+
+/**
+ * 릴리즈 그룹별 폴더 활동 분석
+ */
+export function analyzeReleaseFolderActivity(releaseGroups: ReleaseGroup[], folderDepth = 1): ReleaseFolderActivity[] {
+  const activities: ReleaseFolderActivity[] = [];
+
+  releaseGroups.forEach((group) => {
+    const folderStats = new Map<
+      string,
+      {
+        totalChanges: number;
+        insertions: number;
+        deletions: number;
+        commitCount: number;
+        contributors: Set<string>;
+      }
+    >();
+
+    // 각 커밋의 파일 변경사항 분석
+    group.commits.forEach((commit) => {
+      const authorName = commit.author.names[0] || "Unknown";
+
+      Object.entries(commit.diffStatistics.files).forEach(([filePath, stats]) => {
+        const folderPath = extractFolderFromPath(filePath, folderDepth);
+
+        if (!folderStats.has(folderPath)) {
+          folderStats.set(folderPath, {
+            totalChanges: 0,
+            insertions: 0,
+            deletions: 0,
+            commitCount: 0,
+            contributors: new Set(),
+          });
+        }
+
+        const folderActivity = folderStats.get(folderPath);
+        if (!folderActivity) return;
+        folderActivity.insertions += stats.insertions;
+        folderActivity.deletions += stats.deletions;
+        folderActivity.totalChanges += stats.insertions + stats.deletions;
+        folderActivity.contributors.add(authorName);
+      });
+    });
+
+    // 폴더별 고유 커밋 수 계산
+    group.commits.forEach((commit) => {
+      const foldersInCommit = new Set<string>();
+      Object.keys(commit.diffStatistics.files).forEach((filePath) => {
+        const folderPath = extractFolderFromPath(filePath, folderDepth);
+        foldersInCommit.add(folderPath);
+      });
+
+      foldersInCommit.forEach((folderPath) => {
+        const stats = folderStats.get(folderPath);
+        if (stats) {
+          stats.commitCount += 1;
+        }
+      });
+    });
+
+    // ReleaseFolderActivity 객체로 변환
+    folderStats.forEach((stats, folderPath) => {
+      activities.push({
+        folderPath,
+        releaseTag: group.releaseTag,
+        totalChanges: stats.totalChanges,
+        insertions: stats.insertions,
+        deletions: stats.deletions,
+        commitCount: stats.commitCount,
+        contributors: Array.from(stats.contributors),
+      });
+    });
+  });
+
+  return activities;
+}
+
+/**
+ * 릴리즈별 상위 폴더 추출
+ */
+export function getTopFoldersByRelease(
+  clusterNodeList: CommitData[],
+  count = 8,
+  folderDepth = 1
+): {
+  releaseGroups: ReleaseGroup[];
+  folderActivities: ReleaseFolderActivity[];
+  topFolders: string[];
+} {
+  const releaseGroups = groupCommitsByReleaseTags(clusterNodeList);
+  const folderActivities = analyzeReleaseFolderActivity(releaseGroups, folderDepth);
+
+  // 전체 기간 동안 가장 활발한 폴더들 추출
+  const globalFolderStats = new Map<string, number>();
+  folderActivities.forEach((activity) => {
+    const current = globalFolderStats.get(activity.folderPath) || 0;
+    globalFolderStats.set(activity.folderPath, current + activity.totalChanges);
+  });
+
+  const topFolders = Array.from(globalFolderStats.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, count)
+    .map(([folderPath]) => folderPath);
+
+  return {
+    releaseGroups,
+    folderActivities: folderActivities.filter((activity) => topFolders.includes(activity.folderPath)),
+    topFolders,
+  };
+}
+
+/**
+ * 특정 릴리즈 그룹의 기여자 활동 추출
+ */
+export function extractReleaseContributorActivities(
+  releaseGroups: ReleaseGroup[],
+  topFolders: string[],
+  folderDepth = 1
+): ReleaseContributorActivity[] {
+  const activities: ReleaseContributorActivity[] = [];
+
+  releaseGroups.forEach((group, releaseIndex) => {
+    const contributorFolderStats = new Map<
+      string,
+      Map<
+        string,
+        {
+          changes: number;
+          insertions: number;
+          deletions: number;
+          lastDate: Date;
+        }
+      >
+    >();
+
+    group.commits.forEach((commit) => {
+      const authorName = commit.author.names[0] || "Unknown";
+      const commitDate = new Date(commit.commitDate);
+
+      if (!contributorFolderStats.has(authorName)) {
+        contributorFolderStats.set(authorName, new Map());
+      }
+
+      const contributorStats = contributorFolderStats.get(authorName);
+      if (!contributorStats) return;
+
+      Object.entries(commit.diffStatistics.files).forEach(([filePath, stats]) => {
+        const folderPath = extractFolderFromPath(filePath, folderDepth);
+
+        if (!topFolders.includes(folderPath)) return;
+
+        if (!contributorStats.has(folderPath)) {
+          contributorStats.set(folderPath, {
+            changes: 0,
+            insertions: 0,
+            deletions: 0,
+            lastDate: commitDate,
+          });
+        }
+
+        const folderStats = contributorStats.get(folderPath);
+        if (!folderStats) return;
+        folderStats.changes += stats.insertions + stats.deletions;
+        folderStats.insertions += stats.insertions;
+        folderStats.deletions += stats.deletions;
+        folderStats.lastDate = commitDate;
+      });
+    });
+
+    // 활동 데이터로 변환
+    contributorFolderStats.forEach((folderStatsMap, contributorName) => {
+      folderStatsMap.forEach((stats, folderPath) => {
+        activities.push({
+          contributorName,
+          folderPath,
+          releaseTag: group.releaseTag,
+          releaseIndex,
+          changes: stats.changes,
+          insertions: stats.insertions,
+          deletions: stats.deletions,
+          date: stats.lastDate,
+        });
+      });
+    });
+  });
+
+  return activities;
+}
+
+/**
+ * 릴리즈 기반 상위 폴더 분석
+ */
+export function analyzeReleaseBasedFolders(
+  totalData: CommitData[],
+  count = 8,
+  folderDepth = 1
+): {
+  releaseGroups: ReleaseGroup[];
+  topFolders: ReleaseFolderActivity[];
+  topFolderPaths: string[];
+} {
+  const result = getTopFoldersByRelease(totalData, count, folderDepth);
+
+  return {
+    releaseGroups: result.releaseGroups,
+    topFolders: result.folderActivities,
+    topFolderPaths: result.topFolders,
+  };
+}
+
+/**
+ * 릴리즈 기반 기여자 활동 추출
+ */
+export function extractReleaseBasedContributorActivities(
+  totalData: CommitData[],
+  topFolderPaths: string[],
+  folderDepth = 1
+): ReleaseContributorActivity[] {
+  const result = getTopFoldersByRelease(totalData, topFolderPaths.length, folderDepth);
+  return extractReleaseContributorActivities(result.releaseGroups, topFolderPaths, folderDepth);
+}
+
+/**
+ * 릴리즈 기반 플로우 라인 데이터 생성
+ */
+export function generateReleaseFlowLineData(
+  contributorActivities: ReleaseContributorActivity[]
+): ReleaseFlowLineData[] {
+  const activitiesByContributor = new Map<string, ReleaseContributorActivity[]>();
+  contributorActivities.forEach((activity) => {
+    if (!activitiesByContributor.has(activity.contributorName)) {
+      activitiesByContributor.set(activity.contributorName, []);
+    }
+    activitiesByContributor.get(activity.contributorName)?.push(activity);
+  });
+
+  const flowLineData: ReleaseFlowLineData[] = [];
+
+  activitiesByContributor.forEach((contributorActivitiesList) => {
+    contributorActivitiesList.sort((a, b) => a.releaseIndex - b.releaseIndex || a.date.getTime() - b.date.getTime());
+
+    for (let i = 0; i < contributorActivitiesList.length - 1; i += 1) {
+      const current = contributorActivitiesList[i];
+      const next = contributorActivitiesList[i + 1];
+
+      if (current.releaseIndex !== next.releaseIndex) {
+        flowLineData.push({
+          startReleaseIndex: current.releaseIndex,
+          startFolder: current.folderPath,
+          endReleaseIndex: next.releaseIndex,
+          endFolder: next.folderPath,
+          contributorName: current.contributorName,
+        });
+      }
+    }
+  });
+
+  return flowLineData;
+}
+
+/**
+ * 릴리즈 기반 첫 번째 기여자 노드 찾기
+ */
+export function findFirstReleaseContributorNodes(
+  contributorActivities: ReleaseContributorActivity[]
+): Map<string, ReleaseContributorActivity> {
+  const firstNodesByContributor = new Map<string, ReleaseContributorActivity>();
+  const sortedActivities = [...contributorActivities].sort(
+    (a, b) => a.releaseIndex - b.releaseIndex || a.date.getTime() - b.date.getTime()
+  );
+
+  sortedActivities.forEach((activity) => {
+    const key = activity.contributorName;
+    if (!firstNodesByContributor.has(key)) {
+      firstNodesByContributor.set(key, activity);
+    }
+  });
+
+  return firstNodesByContributor;
+}
+
+
+
+

--- a/packages/mcp/src/tool/contributorRecommender.ts
+++ b/packages/mcp/src/tool/contributorRecommender.ts
@@ -53,7 +53,7 @@ export class ContributorRecommender {
   private async analyzePRContributors(): Promise<ContributorCandidate[]> {
     if (!this.pr) return [];
 
-    const prNumber = CommonUtils.safeParseInt(this.pr!);
+    const prNumber = parseInt(String(this.pr!));
     
     try {
       const prFiles = await this.octokit.paginate(

--- a/packages/mcp/src/tool/storylineRenderer.ts
+++ b/packages/mcp/src/tool/storylineRenderer.ts
@@ -1,0 +1,186 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import { generateNewViz } from '../tool/generateNewViz.js';
+import ServerSideFolderActivityFlow from '../component/FolderActivityFlow/ServerSideFolderActivityFlow.js';
+import { analyzeReleaseBasedFolders, extractReleaseBasedContributorActivities, generateReleaseFlowLineData, findFirstReleaseContributorNodes } from '../component/FolderActivityFlow/FolderActivityFlow.util.js';
+// @ts-ignore
+import sharp from 'sharp';
+
+interface StorylineInputs {
+  repo: string;
+  githubToken: string;
+  baseBranchName?: string;
+  locale?: string;
+  debug?: boolean;
+}
+
+export async function renderStorylineUI(inputs: StorylineInputs): Promise<{ type: 'image'; data: string; mimeType: string; annotations?: any } | { type: 'text'; data: string }> {
+  try {
+
+    const totalData = await generateNewViz({
+      repo: inputs.repo,
+      githubToken: inputs.githubToken,
+      baseBranchName: inputs.baseBranchName,
+      debug: inputs.debug || false
+    });
+
+
+    if (!totalData || Object.keys(totalData).length === 0) {
+      return {
+        type: 'text',
+        data: '<div style="padding:20px;border:1px solid #orange;border-radius:8px">No data available for storyline visualization</div>'
+      };
+    }
+
+    const commitDataList: any[] = [];
+
+    if (totalData && typeof totalData === 'object' && !Array.isArray(totalData)) {
+      Object.values(totalData).forEach((csmNodes: any) => {
+        if (Array.isArray(csmNodes)) {
+          csmNodes.forEach((csmNode: any) => {
+            if (csmNode && csmNode.base && csmNode.base.commit) {
+              const commitRaw = csmNode.base.commit;
+              commitDataList.push({
+                id: commitRaw.id,
+                authorDate: commitRaw.authorDate.toISOString(),
+                commitDate: commitRaw.committerDate.toISOString(),
+                author: {
+                  id: commitRaw.author.name,
+                  names: [commitRaw.author.name],
+                  emails: [commitRaw.author.email],
+                },
+                committer: {
+                  id: commitRaw.committer.name,
+                  names: [commitRaw.committer.name],
+                  emails: [commitRaw.committer.email],
+                },
+                message: commitRaw.message,
+                releaseTags: commitRaw.tags || [],
+                tags: commitRaw.tags || [],
+                diffStatistics: {
+                  changedFileCount: Object.keys(commitRaw.differenceStatistic.fileDictionary).length,
+                  insertions: commitRaw.differenceStatistic.totalInsertionCount,
+                  deletions: commitRaw.differenceStatistic.totalDeletionCount,
+                  files: commitRaw.differenceStatistic.fileDictionary,
+                },
+              });
+            }
+            if (csmNode && csmNode.source && Array.isArray(csmNode.source)) {
+              csmNode.source.forEach((sourceNode: any) => {
+                if (sourceNode && sourceNode.commit) {
+                  const commitRaw = sourceNode.commit;
+                  commitDataList.push({
+                    id: commitRaw.id,
+                    authorDate: commitRaw.authorDate.toISOString(),
+                    commitDate: commitRaw.committerDate.toISOString(),
+                    author: {
+                      id: commitRaw.author.name,
+                      names: [commitRaw.author.name],
+                      emails: [commitRaw.author.email],
+                    },
+                    committer: {
+                      id: commitRaw.committer.name,
+                      names: [commitRaw.committer.name],
+                      emails: [commitRaw.committer.email],
+                    },
+                    message: commitRaw.message,
+                    releaseTags: commitRaw.tags || [],
+                    tags: commitRaw.tags || [],
+                    diffStatistics: {
+                      changedFileCount: Object.keys(commitRaw.differenceStatistic.fileDictionary).length,
+                      insertions: commitRaw.differenceStatistic.totalInsertionCount,
+                      deletions: commitRaw.differenceStatistic.totalDeletionCount,
+                      files: commitRaw.differenceStatistic.fileDictionary,
+                    },
+                  });
+                }
+              });
+            }
+          });
+        }
+      });
+    } else if (Array.isArray(totalData)) {
+      commitDataList.push(...totalData);
+    } else {
+      throw new Error('Invalid data format: expected CSMDictionary or array');
+    }
+
+    const clusterNodes = commitDataList.map((commitData, index) => ({
+      nodeTypeName: 'CLUSTER' as any,
+      commitNodeList: [{
+        nodeTypeName: 'COMMIT' as any,
+        commit: {
+          sequence: index,
+          id: commitData.id,
+          parents: [],
+          branches: [],
+          tags: commitData.tags || [],
+          author: {
+            name: commitData.author.names[0] || commitData.author.id,
+            email: commitData.author.emails[0] || ''
+          },
+          authorDate: new Date(commitData.authorDate),
+          committer: {
+            name: commitData.committer.names[0] || commitData.committer.id,
+            email: commitData.committer.emails[0] || ''
+          },
+          committerDate: new Date(commitData.commitDate),
+          message: commitData.message,
+          differenceStatistic: {
+            totalInsertionCount: commitData.diffStatistics.insertions,
+            totalDeletionCount: commitData.diffStatistics.deletions,
+            fileDictionary: commitData.diffStatistics.files
+          },
+          commitMessageType: ''
+        },
+        seq: index,
+        clusterId: index
+      }]
+    }));
+
+    const releaseResult = analyzeReleaseBasedFolders(clusterNodes, 8, 1);
+    const { releaseGroups, topFolderPaths: releaseTopFolderPaths } = releaseResult;
+    
+    const releaseContributorActivities = extractReleaseBasedContributorActivities(clusterNodes, releaseTopFolderPaths, 1);
+    const flowLineData = generateReleaseFlowLineData(releaseContributorActivities);
+    const firstNodesByContributor = findFirstReleaseContributorNodes(releaseContributorActivities);
+
+    const htmlString = ReactDOMServer.renderToString(
+      React.createElement(ServerSideFolderActivityFlow, {
+        releaseGroups,
+        releaseTopFolderPaths: releaseTopFolderPaths,
+        releaseContributorActivities,
+        flowLineData,
+        firstNodesByContributor,
+      })
+    );
+
+    const svgMatch = htmlString.match(/<svg[^>]*>[\s\S]*<\/svg>/);
+    if (!svgMatch) {
+      throw new Error('SVG not found in rendered HTML');
+    }
+
+        const svgString = svgMatch[0];
+        
+    const pngBuffer = await sharp(Buffer.from(svgString))
+      .png()
+      .toBuffer();
+        
+    return {
+      type: 'image',
+      data: pngBuffer.toString('base64'),
+      mimeType: 'image/png',
+      annotations: {
+        audience: ['user'],
+        priority: 0.9
+      }
+    };
+
+  } catch (error: any) {
+    console.error('Error in renderStorylineUI:', error);
+    return {
+      type: 'text',
+      data: `<div style="padding:20px;border:1px solid #red;border-radius:8px;background-color:#ffe6e6"><h3>Error in Storyline UI</h3><p>Error: ${error.message}</p><details><summary>Show technical details</summary><pre>${error.stack}</pre></details></div>`
+    };
+  }
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -7,7 +7,13 @@
         "outDir": "dist",
         "strict": true,
         "esModuleInterop": true,
-        "skipLibCheck": true
+        "skipLibCheck": true,
+        "jsx": "react-jsx",
+        "allowSyntheticDefaultImports": true,
+        "baseUrl": "src",
+        "paths": {
+            "types": ["../analysis-engine/dist/types"]
+        }
     },
     "include": ["src"]
 }


### PR DESCRIPTION
## Related issue
#957 
- MCP 서버와 Githru 패키지 간의 연동.

## Result
- engine과 new-viz 팀과의 연동.
- NewViz 팀의 결과물인 Storyline UI를 MCP 서버에 연동

<img width="797" height="620" alt="image" src="https://github.com/user-attachments/assets/6b1b1eb5-b9ac-4438-b3f2-01b9b2864c6d" />

## Work list
- analysis-engine에 필요한 CSMDict 생성
- new Viz 팀의 Component를 통해 작업을 연동.
- D3는 서버사이드 렌더링 방식이므로 SVG로 작업 후 sharp를 통해 png로 변환
  - 현재 MCP 서버(또는 클로드..)는 png 방식밖에 읽지 못하는 이슈


## Discussion
