### PR TITLE
[new feature](view): StoryLine chart 타이틀/서브타이틀 구현

### DIFF
--- a/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.scss
+++ b/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.scss
@@ -89,6 +89,7 @@
       font-size: $font-size-body;
       font-weight: $font-weight-regular;
       text-decoration: none;
+      cursor: pointer;
 
       &:hover {
         color: $color-white;

--- a/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.tsx
+++ b/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.tsx
@@ -173,7 +173,6 @@ const FolderActivityFlow = () => {
                 underline="none"
                 component="button"
                 onClick={() => navigateToBreadcrumb(index, breadcrumbs.length)}
-                sx={{ cursor: "pointer" }}
               >
                 {crumb}
               </Link>


### PR DESCRIPTION
## Related issue
#959 

## Result
<img width="1182" height="228" alt="image" src="https://github.com/user-attachments/assets/91017c4f-cacb-4b45-8e23-ed7ccfd6d491" />
<img width="1260" height="288" alt="image" src="https://github.com/user-attachments/assets/fdd69c04-9a8d-4b68-aa0a-6786a69ddc1f" />


## Work list
- [ ] 브레드크럼 정렬 수정
- [ ] 타이틀 Top contributor 구하기 위한  contributorClocs 로직 구현
- [ ] 서브타이틀 firstReleaseLabel, lastReleaseLabel 추출 로직 구현
- [ ] 타이틀&서브타이틀 구현

## Discussion
