### PR TITLE
fix: generateCSMDict 경로 속 파일 이름 대소문자 불일치 문제 개선

### DIFF
--- a/packages/mcp/src/tools/react/register.ts
+++ b/packages/mcp/src/tools/react/register.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { registerGenerateCsmDictTool } from "./generateCsmDict.js";
+import { registerGenerateCsmDictTool } from "./generateCSMDict.js";
 import { registerReactComponentTestTool } from "./reactComponentTest.js";
 import { registerDataDrivenComponentTestTool } from "./dataDrivienTest.js";
 


### PR DESCRIPTION
generateCsmDict -> generateCSMDict
파일 이름이 잘못되어 있어 수정했습니다.
