### PR TITLE
feat(view): 스토리라인 차트 모달 개선

### DIFF
--- a/packages/view/src/App.scss
+++ b/packages/view/src/App.scss
@@ -46,36 +46,3 @@ body {
     margin: 2.5rem 0 0 0;
   }
 }
-
-.folder-activity-flow-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 1000;
-}
-
-.folder-activity-flow-modal-content {
-  background-color: white;
-  padding: 1.25rem;
-  border-radius: 0.5rem;
-  width: 90%;
-  height: 80%;
-  overflow: auto;
-  position: relative;
-}
-
-.folder-activity-flow-modal-close {
-  position: absolute;
-  top: 0.625rem;
-  right: 0.625rem;
-  background: none;
-  border: none;
-  font-size: 1.25rem;
-  cursor: pointer;
-}

--- a/packages/view/src/App.tsx
+++ b/packages/view/src/App.tsx
@@ -21,6 +21,14 @@ import { useBranchStore, useDataStore, useGithubInfo, useLoadingStore, useThemeS
 import { THEME_INFO } from "components/ThemeSelector/ThemeSelector.const";
 import { NetworkGraph } from "components/NetworkGraph";
 import { InsightsButton } from "components/InsightsButton";
+import { Dialog, dialogClasses } from "@mui/material";
+import Divider from "@mui/material/Divider";
+import AppBar from "@mui/material/AppBar";
+import Toolbar from "@mui/material/Toolbar";
+import IconButton from "@mui/material/IconButton";
+import Typography from "@mui/material/Typography";
+import CloseIcon from "@mui/icons-material/Close";
+import { pxToRem } from "utils";
 
 const App = () => {
   const initRef = useRef<boolean>(false);
@@ -28,7 +36,7 @@ const App = () => {
   const { handleChangeAnalyzedData } = useAnalayzedData();
   const filteredData = useDataStore((state) => state.filteredData);
   const { handleChangeBranchList } = useBranchStore();
-  const { handleGithubInfo } = useGithubInfo();
+  const { handleGithubInfo, repo } = useGithubInfo();
   const { loading, setLoading } = useLoadingStore();
   const { theme } = useThemeStore();
   const ideAdapter = container.resolve<IDEPort>("IDEAdapter");
@@ -111,34 +119,43 @@ const App = () => {
 
       {/* Folder Activity Flow Modal */}
       {showFolderActivityFlowModal && (
-        <div
-          className="folder-activity-flow-modal"
-          onClick={handleCloseFolderActivityFlowModal}
-          onKeyDown={(e) => {
-            if (e.key === "Escape") {
-              handleCloseFolderActivityFlowModal();
-            }
+        <Dialog
+          fullScreen
+          open={showFolderActivityFlowModal}
+          onClose={handleCloseFolderActivityFlowModal}
+          sx={{
+            [`& .${dialogClasses.paper}`]: {
+              backgroundColor: "#222324",
+            },
           }}
-          role="button"
-          tabIndex={0}
         >
-          <div
-            className="folder-activity-flow-modal-content"
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => e.stopPropagation()}
-            role="dialog"
-            tabIndex={-1}
-          >
-            <button
-              type="button"
-              className="folder-activity-flow-modal-close"
-              onClick={handleCloseFolderActivityFlowModal}
-            >
-              ×
-            </button>
-            <FolderActivityFlow />
-          </div>
-        </div>
+          <AppBar sx={{ position: "relative", backgroundColor: "#222324", paddingY: pxToRem(20) }}>
+            <Toolbar>
+              <Typography
+                sx={{ pl: pxToRem(25), flex: 1 }}
+                variant="h4"
+                component="div"
+              >
+                {`Storyline of ${repo}`}
+              </Typography>
+              <IconButton
+                edge="end"
+                color="inherit"
+                onClick={handleCloseFolderActivityFlowModal}
+                size="large"
+                aria-label="close"
+              >
+                <CloseIcon />
+              </IconButton>
+            </Toolbar>
+          </AppBar>
+          <Divider
+            sx={{
+              backgroundColor: "#F7F7F780",
+            }}
+          />
+          <FolderActivityFlow />
+        </Dialog>
       )}
     </>
   );

--- a/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.scss
+++ b/packages/view/src/components/FolderActivityFlow/FolderActivityFlow.scss
@@ -21,8 +21,6 @@
 
   padding: 1rem;
   background: $color-background;
-  border-radius: 8px;
-
 
   &__head {
     margin-top: 40px;


### PR DESCRIPTION
## Related issue

closes #952 

## Result

| 전 | 후 |
|--------|--------|
| <img width="2318" height="1874" alt="image" src="https://github.com/user-attachments/assets/1c4a81d8-34aa-4a52-8315-8452f66df3f5" /> | <img width="2362" height="1554" alt="image" src="https://github.com/user-attachments/assets/8d5bccdc-8f82-4289-b6d7-66ad8b944551" /> |

## Work list

- 풀스크린 모달로 변경
- 모달 타이틀 추가

## Discussion

전체적인 디자인은 [피그마 시안](https://www.figma.com/design/sPPWdw79GremoGcH5vxyx3/newviz?node-id=0-1&p=f&t=ra0BZONOp2UdI1WR-0)을 참고했습니다. 다만 시안과 완전히 일치시키려면 MUI 컴포넌트 스타일을 일일이 override해야 하는 복잡함이 있어, 기본 MUI 스타일을 따르되 필요한 부분만 커스터마이징했습니다. 

과거 디자인 시스템 관련 논의 (#607)를 참고했을 때, 장기적으로는 개별 컴포넌트를 매번 커스터마이징하기보다 [Theming](https://mui.com/material-ui/customization/theming/) 하여 디자인 시스템을 체계적으로 활용하는 방향이 더 효율적일 것으로 판단됩니다.

별도로 차트 내부 요소(activity-dot, folder-label 등)의 크기 조정도 필요해 보입니다. 현재는 차트 영역을 확대해도 내부 요소 크기가 고정되어 있어 실질적인 가시성 개선이 이루어지지 않은 상태입니다.