### PR TITLE
fix(view): 무한 스크롤을 위한 FakeIDEAdapter 개선

### DIFF
--- a/packages/view/src/index.tsx
+++ b/packages/view/src/index.tsx
@@ -7,6 +7,6 @@ import { DI_IDENTIFIERS } from "container/identifiers";
 
 import { initRender } from "./index.common";
 
-diContainer.bind<IDEPort>(DI_IDENTIFIERS.IDEAdapter).to(FakeIDEAdapter);
+diContainer.bind<IDEPort>(DI_IDENTIFIERS.IDEAdapter).to(FakeIDEAdapter).inSingletonScope();
 
 initRender();


### PR DESCRIPTION
## 🎯 목적
- Issue #1007 해결을 위해 `FakeIDEAdapter`의 데이터 페이로드 구조를 실제 `VSCodeIDEAdapter`와 일치시킵니다.
- 개발 환경에서 무한 스크롤 기능 테스트가 가능하도록 `FakeIDEAdapter`에 페이지네이션 기능을 구현합니다.

## 📋 주요 변경사항
- **페이로드 구조 동기화**: `FakeIDEAdapter`가 반환하는 데이터에 `isLastPage`, `nextCommitId`, `isLoadMore` 필드를 추가하여 실제 어댑터와 구조를 일치시켰습니다.
- **페이지네이션 구현**: `FakeIDEAdapter`에 페이지 상태를 관리하는 로직을 추가하여, 실제 API처럼 데이터를 나누어 제공하도록 수정했습니다.
- **상태 유지**: `FakeIDEAdapter`를 싱글톤으로 등록하여 페이지 상태가 요청 간에 유지되도록 보장합니다.

## 📊 영향 범위
- `packages/view/src/ide/FakeIDEAdapter.ts`
- `packages/view/src/index.tsx`

## ✅ 체크리스트
- [x] 테스트 통과
- [x] 기존 기능 영향도 확인

## 🔗 관련 이슈
- Closes #1007
